### PR TITLE
Jet Force Gemini: Crosshair fix

### DIFF
--- a/GLideN64.custom.ini
+++ b/GLideN64.custom.ini
@@ -193,14 +193,17 @@ Good_Name=J.League Eleven Beat 1997 (J)
 Good_Name=Jangou Simulation Mahjong Dou 64 (J)
 
 [JET%20FORCE%20GEMINI]
-Good_Name=Jet Force Gemini (E)(U)  / Enable the option below for rain effect
-frameBufferEmulation\copyFromRDRAM=0
-frameBufferEmulation\copyToRDRAM=1
+Good_Name=Jet Force Gemini (E)(U)
+; Show all crosshair reticules and miscellaneous graphics
+frameBufferEmulation\copyFromRDRAM=1
+; Required for character select monitor and possibly other effects, but disabled due to #378
+frameBufferEmulation\copyToRDRAM=0
 
 [J%20F%20G%20DISPLAY]
-Good_Name=Jet Force Gemini Kiosk Demo (U) / Enable the option below for rain effect
-frameBufferEmulation\copyFromRDRAM=0
-frameBufferEmulation\copyToRDRAM=1
+; See Jet Force Gemini for notes
+Good_Name=Jet Force Gemini Kiosk Demo (U)
+frameBufferEmulation\copyFromRDRAM=1
+frameBufferEmulation\copyToRDRAM=0
 
 [713F0C09]
 Good_Name=Kiratto Kaiketsu! 64 Tanteidan (J)
@@ -361,9 +364,10 @@ Good_Name=Star Craft 64 (U)
 frameBufferEmulation\detectCFB=1
 
 [STAR%20TWINS]
-Good_Name=Star Twins (J) / Enable the option below for rain effect
-frameBufferEmulation\copyFromRDRAM=0
-frameBufferEmulation\copyToRDRAM=1
+; See Jet Force Gemini for notes
+Good_Name=Star Twins (J)
+frameBufferEmulation\copyFromRDRAM=1
+frameBufferEmulation\copyToRDRAM=0
 
 [67ED0B45]
 Good_Name=Super Robot Taisen 64 (J)


### PR DESCRIPTION
Custom configuration change for Jet Force Gemini to display all parts of the manual targeting reticule instead of effects rendered to RDRAM. Also some comment tweaks.

I have no idea whether this is the correct way to share my changes. I tried to sync directly to the custom_ini branch but Github for Windows said I didn't have permissions. Please tell me the right way to do it because I don't know!