### PR TITLE
Reduced Main Menu button translation size

### DIFF
--- a/translations/gliden64_es.ts
+++ b/translations/gliden64_es.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="AboutDialog.ui" line="35"/>
         <source>About GLideN64</source>
-        <translation>Acerca de GlideN64</translation>
+        <translation>Sobre GlideN64</translation>
     </message>
     <message>
         <location filename="AboutDialog.ui" line="66"/>


### PR DESCRIPTION
Changed "Acerca de" to "Sobre" since their translations are equivalent and it makes for a smaller menu button.