### PR TITLE
always show cfb until first dlist

### DIFF
--- a/src/RDP.cpp
+++ b/src/RDP.cpp
@@ -561,6 +561,7 @@ void RDP_ProcessRDPList()
 	if (dp_end <= dp_current) return;
 
 	RSP.bLLE = true;
+	RSP.bfirstDlist = true;
 
 	// load command data
 	for (u32 i = 0; i < length; i += 4) {

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -148,6 +148,7 @@ void RSP_ProcessDList()
 
 	RSP.halt = FALSE;
 	RSP.busy = TRUE;
+	RSP.firstDlist = true;
 
 	gSP.matrix.stackSize = min( 32U, *(u32*)&DMEM[0x0FE4] >> 6 );
 	if (gSP.matrix.stackSize == 0)
@@ -284,6 +285,7 @@ void RSP_Init()
 	RDRAMSize = 1024 * 1024 * 8 - 1;
 #endif // OS_WINDOWS
 
+	RSP.firstDlist = false;
 	RSP.DList = 0;
 	RSP.uc_start = RSP.uc_dstart = 0;
 	RSP.bLLE = false;

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -148,7 +148,7 @@ void RSP_ProcessDList()
 
 	RSP.halt = FALSE;
 	RSP.busy = TRUE;
-	RSP.firstDlist = true;
+	RSP.bfirstDlist = true;
 
 	gSP.matrix.stackSize = min( 32U, *(u32*)&DMEM[0x0FE4] >> 6 );
 	if (gSP.matrix.stackSize == 0)
@@ -285,10 +285,10 @@ void RSP_Init()
 	RDRAMSize = 1024 * 1024 * 8 - 1;
 #endif // OS_WINDOWS
 
-	RSP.firstDlist = false;
 	RSP.DList = 0;
 	RSP.uc_start = RSP.uc_dstart = 0;
 	RSP.bLLE = false;
+	RSP.bfirstDlist = false;
 
 	// get the name of the ROM
 	char romname[21];

--- a/src/RSP.h
+++ b/src/RSP.h
@@ -7,7 +7,7 @@ typedef struct
 {
 	u32 PC[18], PCi, busy, halt, close, DList, uc_start, uc_dstart, cmd, nextCmd;
 	s32 count;
-	bool bLLE;
+	bool bLLE, firstDlist;
 	char romname[21];
 	wchar_t pluginpath[PLUGIN_PATH_SIZE];
 } RSPInfo;

--- a/src/RSP.h
+++ b/src/RSP.h
@@ -7,7 +7,7 @@ typedef struct
 {
 	u32 PC[18], PCi, busy, halt, close, DList, uc_start, uc_dstart, cmd, nextCmd;
 	s32 count;
-	bool bLLE, firstDlist;
+	bool bLLE, bfirstDlist;
 	char romname[21];
 	wchar_t pluginpath[PLUGIN_PATH_SIZE];
 } RSPInfo;

--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -109,7 +109,7 @@ void VI_UpdateScreen()
 	}
 
 	if (config.frameBufferEmulation.enable) {
-		const bool bCFB = config.frameBufferEmulation.detectCFB != 0 && (gSP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE;
+		const bool bCFB = ((config.frameBufferEmulation.detectCFB != 0 || RSP.firstDlist == false) && (gSP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE);
 		const bool bNeedUpdate = gDP.colorImage.changed != 0 || (bCFB ? true : (*REG.VI_ORIGIN != VI.lastOrigin));
 
 		if (bNeedUpdate) {

--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -109,7 +109,7 @@ void VI_UpdateScreen()
 	}
 
 	if (config.frameBufferEmulation.enable) {
-		const bool bCFB = ((config.frameBufferEmulation.detectCFB != 0 || RSP.firstDlist == false) && (gSP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE);
+		const bool bCFB = ((config.frameBufferEmulation.detectCFB != 0 || RSP.bfirstDlist == false) && (gSP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE);
 		const bool bNeedUpdate = gDP.colorImage.changed != 0 || (bCFB ? true : (*REG.VI_ORIGIN != VI.lastOrigin));
 
 		if (bNeedUpdate) {


### PR DESCRIPTION
many pd roms and demos use cpu rendering only
now they are supported with default settings
also detectCFB=1 now isn't needed anymore for some games