### PR TITLE
remove unneeded detectCFB settings

### DIFF
--- a/GLideN64.custom.ini
+++ b/GLideN64.custom.ini
@@ -265,10 +265,6 @@ Good_Name=Morita Shougi 64 (J)
 Good_Name=Ms. Pac-Man - Maze Madness (U)
 frameBufferEmulation\detectCFB=1
 
-[NAMCOMUSEUM64]
-Good_Name=Namco Museum 64 (U)
-frameBufferEmulation\detectCFB=1
-
 [14B30473]
 Good_Name=Nushi Duri 64 (J)
 


### PR DESCRIPTION
testing complete
with Project64 some settings are not needed because the emulator can notify the plugin. But I left the settings there because with other emulators notification may not work.