### PR TITLE
Removed some useless header files + forced multisampling option to 0 when not supported

### DIFF
--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -3,12 +3,6 @@
 #include <math.h>
 #include <time.h>       /* time_t, struct tm, difftime, time, mktime */
 
-//// paulscode, added for SDL linkage:
-#if defined(GLESX)
-#include "ae_bridge.h"
-#endif // GLESX
-////
-
 #include "Types.h"
 #include "GLideN64.h"
 #include "OpenGL.h"

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -11,7 +11,6 @@
 
 #ifdef GLES2
 #include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
 #define GL_DRAW_FRAMEBUFFER GL_FRAMEBUFFER
 #define GL_READ_FRAMEBUFFER GL_FRAMEBUFFER
 #define GLESX
@@ -20,12 +19,10 @@ typedef char GLchar;
 #endif
 #elif defined(GLES3)
 #include <GLES3/gl3.h>
-#include <GLES3/gl3ext.h>
 #define GLESX
 #define GL_UNIFORMBLOCK_SUPPORT
 #elif defined(GLES3_1)
 #include <GLES3/gl31.h>
-#include <GLES3/gl3ext.h>
 #define GLESX
 #define GL_IMAGE_TEXTURES_SUPPORT
 #define GL_MULTISAMPLING_SUPPORT

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -6,6 +6,7 @@
 
 #include "../Config.h"
 #include "../GLideN64.h"
+#include "../OpenGL.h"
 #include "../GBI.h"
 #include "../RSP.h"
 #include "../Log.h"
@@ -156,7 +157,11 @@ void Config_LoadConfig()
 	config.video.windowedHeight = ConfigGetParamInt(g_configVideoGeneral, "ScreenHeight");
 	config.video.verticalSync = ConfigGetParamBool(g_configVideoGeneral, "VerticalSync");
 
+#ifdef GL_MULTISAMPLING_SUPPORT
 	config.video.multisampling = ConfigGetParamInt(g_configVideoGliden64, "MultiSampling");
+#else
+	config.video.multisampling = 0;
+#endif
 	config.frameBufferEmulation.aspect = ConfigGetParamInt(g_configVideoGliden64, "AspectRatio");
 
 	//#Texture Settings


### PR DESCRIPTION
I accidently launched the GLES3 version with multisampling set to 2 which of course didn't end up very well, so I just forced multisampling to 0 when not supported to avoid such a case in the future ;-)