### PR TITLE
Fix framebuffer texture rectangle coordinate in GLES2

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -760,6 +760,7 @@ void FrameBufferList::renderBuffer(u32 _address)
 	pBuffer->m_pTexture->offsetT = (float)height;
 	textureCache().activateTexture(0, pBuffer->m_pTexture);
 	gSP.textureTile[0]->fuls = gSP.textureTile[0]->fult = 0.0f;
+	gSP.textureTile[0]->shifts = gSP.textureTile[0]->shiftt = 0;
 	currentCombiner()->updateTextureInfo(true);
 	CombinerInfo::get().updateParameters(OGLRender::rsTexRect);
 


### PR DESCRIPTION
Here's a screenshot of the issue:
![capture](https://cloud.githubusercontent.com/assets/2852068/8451405/610c5cf6-1fe3-11e5-8f36-cc3b5d900fef.PNG)

And here's a screenshot of the normal behaviour:
![capture2](https://cloud.githubusercontent.com/assets/2852068/8451435/9fb54f76-1fe3-11e5-9ef7-a2e7fea59b2a.PNG)
