### PR TITLE
remove condition from FrameBufferList::saveBuffer

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -299,13 +299,11 @@ frameBufferEmulation\detectCFB=1
 Good_Name=Pokemon Stadium 2 (E)(F)(G)(I)(J)(S)(U)
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
-frameBufferEmulation\validityCheckMethod=1
 
 [POKEMON%20STADIUM%20G&S]
 Good_Name=Pokemon Stadium Kin Gin (J)
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
-frameBufferEmulation\validityCheckMethod=1
 
 [RAYMAN%202]
 Good_Name=Rayman 2 - The Great Escape (E)(U)

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -265,6 +265,9 @@ void FrameBuffer::copyRdram()
 			// Thus content of RDRAM on moment of buffer creation will be the same as when buffer becomes obsolete.
 			// Validity check will see that the RDRAM is the same and thus the buffer is valid, which is false.
 			// It can be enough to write data just little more than treshold level, but more safe to write twice as much in case that some values in buffer match our fingerprint.
+			FrameBuffer * pCurrentBuffer = frameBufferList().getCurrent();
+			if (pCurrentBuffer != NULL)
+				pCurrentBuffer->m_cleared = false;
 			const u32 twoPercent = dataSize / 200;
 			u32 start = m_startAddress >> 2;
 			u32 * pData = (u32*)RDRAM;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -446,8 +446,9 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 			if (m_pCurrent->m_width == VI.width)
 				gDP.colorImage.height = min(gDP.colorImage.height, VI.height);
 			m_pCurrent->m_endAddress = min(RDRAMSize, m_pCurrent->m_startAddress + (((m_pCurrent->m_width * gDP.colorImage.height) << m_pCurrent->m_size >> 1) - 1));
-			if (!config.frameBufferEmulation.copyFromRDRAM && !m_pCurrent->_isMarioTennisScoreboard() && !m_pCurrent->m_isDepthBuffer && !m_pCurrent->m_copiedToRdram && !m_pCurrent->m_cfb && !m_pCurrent->m_cleared && m_pCurrent->m_RdramCopy.empty() && gDP.colorImage.height > 1) {
-				m_pCurrent->copyRdram();
+		//	if (!config.frameBufferEmulation.copyFromRDRAM && !m_pCurrent->_isMarioTennisScoreboard() && !m_pCurrent->m_isDepthBuffer && !m_pCurrent->m_copiedToRdram && !m_pCurrent->m_cfb && !m_pCurrent->m_cleared && m_pCurrent->m_RdramCopy.empty() && gDP.colorImage.height > 1) {
+			{
+			m_pCurrent->copyRdram();
 			}
 		}
 		m_pCurrent = _findBuffer(m_pCurrent->m_startAddress, m_pCurrent->m_endAddress, m_pCurrent->m_width);

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -446,9 +446,8 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 			if (m_pCurrent->m_width == VI.width)
 				gDP.colorImage.height = min(gDP.colorImage.height, VI.height);
 			m_pCurrent->m_endAddress = min(RDRAMSize, m_pCurrent->m_startAddress + (((m_pCurrent->m_width * gDP.colorImage.height) << m_pCurrent->m_size >> 1) - 1));
-		//	if (!config.frameBufferEmulation.copyFromRDRAM && !m_pCurrent->_isMarioTennisScoreboard() && !m_pCurrent->m_isDepthBuffer && !m_pCurrent->m_copiedToRdram && !m_pCurrent->m_cfb && !m_pCurrent->m_cleared && m_pCurrent->m_RdramCopy.empty() && gDP.colorImage.height > 1) {
-			{
-			m_pCurrent->copyRdram();
+			if (!m_pCurrent->_isMarioTennisScoreboard() && !m_pCurrent->m_isDepthBuffer && !m_pCurrent->m_copiedToRdram && !m_pCurrent->m_cfb && m_pCurrent->m_RdramCopy.empty() && gDP.colorImage.height > 1) {
+				m_pCurrent->copyRdram();
 			}
 		}
 		m_pCurrent = _findBuffer(m_pCurrent->m_startAddress, m_pCurrent->m_endAddress, m_pCurrent->m_width);

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -449,8 +449,8 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 			if (m_pCurrent->m_width == VI.width)
 				gDP.colorImage.height = min(gDP.colorImage.height, VI.height);
 			m_pCurrent->m_endAddress = min(RDRAMSize, m_pCurrent->m_startAddress + (((m_pCurrent->m_width * gDP.colorImage.height) << m_pCurrent->m_size >> 1) - 1));
-			if (!m_pCurrent->_isMarioTennisScoreboard() && !m_pCurrent->m_isDepthBuffer && !m_pCurrent->m_copiedToRdram && !m_pCurrent->m_cfb && m_pCurrent->m_RdramCopy.empty() && gDP.colorImage.height > 1) {
-				m_pCurrent->copyRdram();
+			if (!m_pCurrent->_isMarioTennisScoreboard() && !m_pCurrent->m_isDepthBuffer && !m_pCurrent->m_copiedToRdram && !m_pCurrent->m_cfb && gDP.colorImage.height > 1) {
+			m_pCurrent->copyRdram();
 			}
 		}
 		m_pCurrent = _findBuffer(m_pCurrent->m_startAddress, m_pCurrent->m_endAddress, m_pCurrent->m_width);


### PR DESCRIPTION
With this condition some auxiliary buffers are not filled with a test value, this causes problems with validity checking in Pokemon Stadium 2 #416 and possibly also in other games. I konw some games may need this condition, so this pull request is more meant for discussion, not for merging.