### PR TITLE
change fillcolor to something more original

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -187,7 +187,7 @@ void FrameBuffer::init(u32 _address, u32 _endAddress, u16 _format, u16 _size, u1
 	m_size = _size;
 	m_scaleX = ogl.getScaleX();
 	m_scaleY = ogl.getScaleY();
-	m_fillcolor = 0;
+	m_fillcolor = 0xd456;
 	m_cfb = _cfb;
 	m_needHeightCorrection = _width != VI.width && _width != *REG.VI_WIDTH;
 	m_cleared = false;


### PR DESCRIPTION
together with #619 this fixes remaining problems with validity checking in Pokemon Stadium 2, #416 is fixed, but causes regressions in Mario Tennis. I dislike these lines, looks like a bug.
![gliden64_mariotennis_003](https://cloud.githubusercontent.com/assets/7283660/8768760/43bc6900-2e8b-11e5-8bc8-a7297ec428e2.jpg)

![gliden64_mariotennis_002](https://cloud.githubusercontent.com/assets/7283660/8768743/0f7324a4-2e8b-11e5-8997-21229063dddf.jpg)
