### PR TITLE
Apply Quake II hack to Quake 64.

### DIFF
--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -325,7 +325,9 @@ void RSP_Init()
 		config.generalEmulation.hacks |= hack_blastCorps;
 	else if (strstr(RSP.romname, (const char *)"SPACE INVADERS") != NULL)
 		config.generalEmulation.hacks |= hack_ignoreVIHeightChange;
-	else if (strstr(RSP.romname, (const char *)"QUAKE II") != NULL)
+	else if (strstr(RSP.romname, (const char *)"QUAKE II") != NULL) ||
+		strstr(RSP.romname, (const char *)"Quake") != NULL)
+		)
 		config.generalEmulation.hacks |= hack_VIUpdateOnCIChange;
 
 	api().FindPluginPath(RSP.pluginpath);


### PR DESCRIPTION
I have no idea whether I got the syntax right thanks to not being able to build GLideN64. Assuming this works, this should fix underwater rendering in Quake 64.