### PR TITLE
Fix core dump with PowerVR GPUs in android

### DIFF
--- a/src/OGL3X/Shaders_ogl3x.h
+++ b/src/OGL3X/Shaders_ogl3x.h
@@ -150,12 +150,14 @@ MAIN_SHADER_VERSION
 
 static const char* fragment_shader_header_common_variables =
 MAIN_SHADER_VERSION
+#ifndef GLESX
 "#ifdef GL_NV_fragdepth			\n"
 "    #extension GL_NV_fragdepth : enable \n"
 "#endif										\n"
 "#ifdef GL_OES_standard_derivatives			\n"
 "    #extension GL_OES_standard_derivatives : enable \n"
 "#endif										\n"
+#endif
 "uniform sampler2D uTex0;		\n"
 "uniform sampler2D uTex1;		\n"
 #ifdef GL_MULTISAMPLING_SUPPORT
@@ -200,12 +202,14 @@ MAIN_SHADER_VERSION
 
 static const char* fragment_shader_header_common_variables_notex =
 MAIN_SHADER_VERSION
+#ifndef GLESX
 "#ifdef GL_NV_fragdepth			\n"
 "    #extension GL_NV_fragdepth : enable \n"
 "#endif										\n"
 "#ifdef GL_OES_standard_derivatives			\n"
 "    #extension GL_OES_standard_derivatives : enable \n"
 "#endif										\n"
+#endif
 "layout (std140) uniform ColorsBlock {\n"
 "  lowp vec4 uFogColor;			\n"
 "  lowp vec4 uCenterColor;		\n"


### PR DESCRIPTION
Fixed core dump with PowerVR GPUs in android. This solution has been
tested with other android devices with no negative impacts.

This is against this issue:

https://github.com/gonetz/GLideN64/issues/630
