### PR TITLE
always reinit buffers during height correction

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -391,10 +391,7 @@ void FrameBufferList::correctHeight()
 		return;
 	}
 	if (m_pCurrent->m_needHeightCorrection && m_pCurrent->m_width == gDP.scissor.lrx) {
-		if (m_pCurrent->m_height < (u32)gDP.scissor.lry)
-			m_pCurrent->reinit((u32)gDP.scissor.lry);
-		else
-			m_pCurrent->m_height = (u32)gDP.scissor.lry;
+		m_pCurrent->reinit((u32)gDP.scissor.lry);
 
 		if (m_pCurrent->_isMarioTennisScoreboard())
 			g_RDRAMtoFB.CopyFromRDRAM(m_pCurrent->m_startAddress + 4, false);


### PR DESCRIPTION
In the library in Pokemon Stadium 2 one image is always missing. Here's the fix
![gliden64_pokemon_stadium_2_000](https://cloud.githubusercontent.com/assets/7283660/9660196/ae74683c-5254-11e5-844d-3e1a9141871e.jpg)
