### PR TITLE
Revert "Don't discard frame buffers creation when _height == 0"

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -441,7 +441,7 @@ FrameBuffer * FrameBufferList::findTmpBuffer(u32 _address)
 
 void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _width, u16 _height, bool _cfb)
 {
-	if (VI.width == 0)
+	if (VI.width == 0 || _height == 0)
 		return;
 
 	OGLVideo & ogl = video();


### PR DESCRIPTION
I think I just obscured the bug rather than fixing it. _height should not be 0
This opens #415 again