### PR TITLE
Changing the getRevision script to place the header differently

### DIFF
--- a/src/getRevision.sh
+++ b/src/getRevision.sh
@@ -1,3 +1,4 @@
+SCRIPT_DIRECTORY=`dirname $0`
 rev=\"`git rev-parse --short HEAD`\"
 echo current revision $rev
-echo "#define PLUGIN_REVISION $rev" > Revision.h
+echo "#define PLUGIN_REVISION $rev" > $SCRIPT_DIRECTORY/Revision.h


### PR DESCRIPTION
I called getRevision.sh from a directory other than src and I ended
up with an unexpected Revision.h in my current directory without
placing one in src. This modifies the script to place the header
file in the same directory as the script.