### PR TITLE
Fixing multisampling

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -481,24 +481,26 @@ void TextureCache::init()
 	current[0] = current[1] = NULL;
 
 #ifdef GL_MULTISAMPLING_SUPPORT
-	m_pMSDummy = addFrameBufferTexture(); // we don't want to remove dummy texture
-	_initDummyTexture(m_pMSDummy);
+	if (config.video.multisampling != 0) {
+		m_pMSDummy = addFrameBufferTexture(); // we don't want to remove dummy texture
+		_initDummyTexture(m_pMSDummy);
 
-	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, m_pMSDummy->glName);
+		glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, m_pMSDummy->glName);
 
 #if defined(GLES3_1)
-	glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling,
-				GL_RGBA8, m_pMSDummy->realWidth, m_pMSDummy->realHeight, false);
+		glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling,
+					GL_RGBA8, m_pMSDummy->realWidth, m_pMSDummy->realHeight, false);
 #else
-	glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling,
-				GL_RGBA8, m_pMSDummy->realWidth, m_pMSDummy->realHeight, false);
+		glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling,
+					GL_RGBA8, m_pMSDummy->realWidth, m_pMSDummy->realHeight, false);
 #endif
 
-	activateMSDummy(0);
-	activateMSDummy(1);
-#else
-	m_pMSDummy = NULL;
+		activateMSDummy(0);
+		activateMSDummy(1);
+	} else
 #endif
+	m_pMSDummy = NULL;
+	assert(!isGLError());
 }
 
 void TextureCache::destroy()


### PR DESCRIPTION
We were calling glTexStorage2DMultisample with a 'samples' parameter of 0.
Reading the GL 4.4 spec, this is specifically forbidden, but the
documentation pages from Chronos were incorrectly stating that it was
allowed, so many implementations probably accept it. Mesa, the graphics
driver for many Linux cards has recently been corrected so that it emits
a warning and fails when glTexStorage2DMultisample is called with
samples=0. The current release works, but the next one will fail when
multisampling is turned off in this plugin (with multisampling turned
on, it will work the same as before).

The documentation pages from Kronos have since been updated to reflect
the GL spec (I put in a bug to them). You can see the proper
changes at this address
(https://www.opengl.org/wiki/GLAPI/glTexStorage2DMultisample).

This fixes issue #695 