### PR TITLE
don't update NoiseTexture if noise is disabled 

### DIFF
--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -74,7 +74,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == RSP.DList)
+	if (m_DList == RSP.DList || config.generalEmulation.enableNoise == 0)
 		return;
 	const u32 dataSize = VI.width*VI.height;
 	if (dataSize == 0)

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -89,7 +89,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == RSP.DList)
+	if (m_DList == RSP.DList || config.generalEmulation.enableNoise == 0)
 		return;
 	const u32 dataSize = VI.width*VI.height;
 	if (dataSize == 0)


### PR DESCRIPTION
With this change I get 210 VI/s in Star Wars Episode I - Racer (track select screen). With noise emulation enabled I get 95 VI/s. With noise emulation + copy color + copy depth I get 45 VI/s.