### PR TITLE
Add depth to RDRAM for games that need it.

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -32,6 +32,17 @@ Good_Name=Bakushou Jinsei 64 - Mezase! Resort Ou (J)
 [BANJO-KAZOOIE]
 Good_Name=Banjo-Kazooie (E)(U) / Banjo To Kazooie No Daibouken (J)
 frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
+
+[BANJO%20KAZOOIE%202]
+Good_Name=Banjo to Kazooie no Daibouken 2 (J)
+frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
+
+[BANJO%20TOOIE]
+Good_Name=Banjo-Tooie (E)(U)
+frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [BEETLE%20ADVENTURE%20RAC]
 Good_Name=Beetle Adventure Racing (E)(U)
@@ -83,6 +94,10 @@ frameBufferEmulation\copyDepthToRDRAM=1
 [362D06B6]
 Good_Name=Densha de Go! 64 (J)
 
+[Diddy%20Kong%20Racing]
+Good_Name=Diddy Kong Racing (E)(U)(J)
+frameBufferEmulation\copyDepthToRDRAM=1
+
 [DONALD%20DUCK%20GOIN%27%20QU]
 Good_Name=Donald Duck - Goin' Quackers (U)
 frameBufferEmulation\copyToRDRAM=1
@@ -99,11 +114,13 @@ frameBufferEmulation\copyDepthToRDRAM=1
 Good_Name=Donkey Kong 64 (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\detectCFB=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [D%20K%20DISPLAY]
 Good_Name=Donkey Kong 64 Kiosk Demo (U)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\detectCFB=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [72390C86]
 Good_Name=Doraemon - Nobita To 3tsu No Seireiseki (J)
@@ -246,10 +263,12 @@ frameBufferEmulation\copyToRDRAM=1
 [MICKEY%20USA%20PAL]
 Good_Name=Mickey's Speedway USA (E)
 frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [MICKEY%20USA]
 Good_Name=Mickey's Speedway USA (U) / Mickey No Racing Challenge USA (J)
 frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [293D0695]
 Good_Name=Morita Shougi 64 (J)

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -87,6 +87,9 @@ frameBufferEmulation\copyDepthToRDRAM=1
 Good_Name=Dr. Mario 64 (U)
 frameBufferEmulation\copyFromRDRAM=1
 
+[EXCITEBIKE64]
+frameBufferEmulation\copyDepthToRDRAM=1
+
 [EXTREME_G]
 Good_Name=Extreme-G (E)
 frameBufferEmulation\N64DepthCompare=1

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -44,10 +44,12 @@ frameBufferEmulation\copyToRDRAM=1
 [BEETLE%20ADVENTURE%20RAC]
 Good_Name=Beetle Adventure Racing (E)(U)
 frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [BEETLE%20ADVENTURE%20JP]
 Good_Name=Beetle Adventure Racing (J)
 frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [BIOFREAKS]
 Good_Name=Bio F.R.E.A.K.S. (E)(U)
@@ -60,6 +62,8 @@ frameBufferEmulation\detectCFB=1
 
 [52150A67]
 Good_Name=Bokujou Monogatari 2 (J)
+frameBufferEmulation\copyDepthToRDRAM=1
+frameBufferEmulation\N64DepthCompare=1
 
 [476C09C1]
 Good_Name=Bomberman Hero - Mirian Oujo Wo Sukue! (J)

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -11,24 +11,6 @@ Good_Name=1080 Snowboarding (E)(JU)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
 
-[6D120CBF]
-Good_Name=64 De Hakken!! Tamagotchi - Minna De Tamagotchi World (J)
-
-[68DD0BB5]
-Good_Name=64 Hanafuda - Tenshi No Yakusoku (J)
-
-[1F580575]
-Good_Name=64 Oozumou 2 (J)
-
-[1333047D]
-Good_Name=AI Shougi 3 (J)
-
-[30080737]
-Good_Name=Air Boarder 64 (J)
-
-[44BB08DC]
-Good_Name=Bakushou Jinsei 64 - Mezase! Resort Ou (J)
-
 [BANJO-KAZOOIE]
 Good_Name=Banjo-Kazooie (E)(U) / Banjo To Kazooie No Daibouken (J)
 frameBufferEmulation\copyToRDRAM=1
@@ -64,12 +46,6 @@ frameBufferEmulation\detectCFB=1
 Good_Name=Bokujou Monogatari 2 (J)
 frameBufferEmulation\N64DepthCompare=1
 
-[476C09C1]
-Good_Name=Bomberman Hero - Mirian Oujo Wo Sukue! (J)
-
-[13E50365]
-Good_Name=Choro Q 64 2 - Hacha Mecha Grand Prix Race (J)
-
 [CASTLEVANIA]
 Good_Name=Castlevania (E)(U)
 frameBufferEmulation\copyToRDRAM=1
@@ -78,22 +54,10 @@ frameBufferEmulation\copyToRDRAM=1
 Good_Name=Castlevania - Legacy Of Darkness (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 
-[3D9F08DB]
-Good_Name=Chou Kuukan Nighter Pro Yakyuu King 2 (J)
-
-[31DC0863]
-Good_Name=Chou Snobow Kids (J)
-
 [CONKER%20BFD]
 Good_Name=Conker's Bad Fur Day (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
-
-[362D06B6]
-Good_Name=Densha de Go! 64 (J)
-
-[Diddy%20Kong%20Racing]
-Good_Name=Diddy Kong Racing (E)(U)(J)
 
 [DONALD%20DUCK%20GOIN%27%20QU]
 Good_Name=Donald Duck - Goin' Quackers (U)
@@ -119,21 +83,9 @@ frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\detectCFB=1
 frameBufferEmulation\copyDepthToRDRAM=1
 
-[72390C86]
-Good_Name=Doraemon - Nobita To 3tsu No Seireiseki (J)
-
-[6E3D0C76]
-Good_Name=Doraemon 2 - Nobita To Hikari No Shinden (J)
-
-[84CE0BDF]
-Good_Name=Doraemon 3 - Nobita No Machi SOS! (J)
-
 [DR.MARIO%2064]
 Good_Name=Dr. Mario 64 (U)
 frameBufferEmulation\copyFromRDRAM=1
-
-[67000C2B]
-Good_Name=Eikou No Saint Andrews (J)
 
 [EXTREME_G]
 Good_Name=Extreme-G (E)
@@ -147,9 +99,6 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Extreme-G (U)
 frameBufferEmulation\N64DepthCompare=1
 
-[208E05CD]
-Good_Name=Extreme-G XG2 (J)
-
 [F1%20POLE%20POSITION%2064]
 Good_Name=F-1 Pole Position 64 (E)(U)
 frameBufferEmulation\copyToRDRAM=1
@@ -158,52 +107,19 @@ frameBufferEmulation\copyToRDRAM=1
 Good_Name=F-Zero X (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 
-[18000458]
-Good_Name=Famista 64 (J)
-
-[2997071D]
-Good_Name=Fushigi No Dungeon - Fuurai No Shiren 2 - Oni Shuurai! Shiren Jou! (J)
-
-[3BE3091D]
-Good_Name=Ganbare Goemon - Neo Momoyama Bakufu No Odori (J)
-
-[53900B10]
-Good_Name=Goemon - Mononoke Sugoroku (J)
-
-[457A0908]
-Good_Name=Hamster Monogatari 64 (J)
-
 [HARVESTMOON64]
 Good_Name=Harvest Moon 64 (U)
 frameBufferEmulation\N64DepthCompare=1
-
-[5CFA0A2E]
-Good_Name=Heiwa Pachinko World 64 (J)
 
 [HEXEN]
 Good_Name=Hexen (E)(F)(G)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\detectCFB=1
 
-[30AB07E1]
-Good_Name=Hiryuu No Ken Twin (J)
-
 [HSV%20ADVENTURE%20RACING]
 Good_Name=HSV Adventure Racing (A)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
-
-[83CA0DCA]
-Good_Name=Ide Yousuke No Mahjong Juku (J)
-
-[43CC08A2]
-Good_Name=J.League Dynamite Soccer 64 (J)
-
-[7EA50BA0]
-Good_Name=J.League Eleven Beat 1997 (J)
-
-[31E0076F]
-Good_Name=Jangou Simulation Mahjong Dou 64 (J)
 
 [JET%20FORCE%20GEMINI]
 Good_Name=Jet Force Gemini (E)(U)
@@ -217,9 +133,6 @@ frameBufferEmulation\copyToRDRAM=0
 Good_Name=Jet Force Gemini Kiosk Demo (U)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
-
-[713F0C09]
-Good_Name=Kiratto Kaiketsu! 64 Tanteidan (J)
 
 [LEGORACERS]
 Good_Name=Lego Racers (E)(U)
@@ -242,9 +155,6 @@ frameBufferEmulation\copyDepthToRDRAM=1
 Good_Name=Mario Kart 64 (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 
-[2B6D07C8]
-Good_Name=Mario No Photopi (J)
-
 [MARIO%20STORY]
 Good_Name=Mario Story (J)
 frameBufferEmulation\copyToRDRAM=1
@@ -264,19 +174,11 @@ frameBufferEmulation\copyToRDRAM=1
 [MICKEY%20USA]
 Good_Name=Mickey's Speedway USA (U) / Mickey No Racing Challenge USA (J)
 frameBufferEmulation\copyToRDRAM=1
-
-[293D0695]
-Good_Name=Morita Shougi 64 (J)
+frameBufferEmulation\copyDepthToRDRAM=1
 
 [MS.%20PAC-MAN%20MM]
 Good_Name=Ms. Pac-Man - Maze Madness (U)
 frameBufferEmulation\detectCFB=1
-
-[14B30473]
-Good_Name=Nushi Duri 64 (J)
-
-[5E5A0B37]
-Good_Name=Nushi Duri 64 - Shiokaze Ni Notte (J)
 
 [PAPER%20MARIO]
 Good_Name=Paper Mario (E)(U)
@@ -312,15 +214,9 @@ frameBufferEmulation\detectCFB=1
 Good_Name=Resident Evil 2 (E)(U)
 frameBufferEmulation\detectCFB=1
 
-[437009B9]
-Good_Name=Saikyou Habu Shougi (J)
-
 [RUSH%202049]
 Good_Name=San Francisco Rush 2049 (E)(U)
 frameBufferEmulation\copyToRDRAM=0
-
-[1C500641]
-Good_Name=Snobow Kids (J)
 
 [SPACE%20INVADERS]
 Good_Name=Space Invaders (U)
@@ -343,12 +239,6 @@ frameBufferEmulation\copyToRDRAM=0
 [STAR%20WARS%20EP1%20RACER]
 Good_Name=Star Wars Episode I - Racer (E)(U)(J)
 frameBufferEmulation\copyDepthToRDRAM=1
-
-[67ED0B45]
-Good_Name=Super Robot Taisen 64 (J)
-
-[622D0C12]
-Good_Name=Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (J)
 
 [ZELDA%20MAJORA%27S%20MASK]
 Good_Name=The Legend Of Zelda - Majora's Mask (E)(U) / Zelda No Densetsu - Mujura No Karmen (J)
@@ -378,21 +268,9 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Tonic Trouble (E)(U)
 frameBufferEmulation\detectCFB=1
 
-[48460A35]
-Good_Name=Ucchan Nanchan No Hono No Challenger - Denryuu Ira Ira Bou (J)
-
 [VIGILANTE%208]
 Good_Name=Vigilante 8 (E)(F)(G)(U)
 frameBufferEmulation\copyDepthToRDRAM=1
-
-[4C2E093B]
-Good_Name=Virtual Pro Wrestling 2 - Oudou Keishou (J)
-
-[8B6F0CBE]
-Good_Name=Virtual Pro Wrestling 64 (J)
-
-[34060655]
-Good_Name=WWF Wrestlemania 2000 (J)
 
 [THE%20MASK%20OF%20MUJURA]
 Good_Name=Zelda No Densetsu - Mujura No Karmen (J)

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -32,27 +32,22 @@ Good_Name=Bakushou Jinsei 64 - Mezase! Resort Ou (J)
 [BANJO-KAZOOIE]
 Good_Name=Banjo-Kazooie (E)(U) / Banjo To Kazooie No Daibouken (J)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BANJO%20KAZOOIE%202]
 Good_Name=Banjo to Kazooie no Daibouken 2 (J)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BANJO%20TOOIE]
 Good_Name=Banjo-Tooie (E)(U)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BEETLE%20ADVENTURE%20RAC]
 Good_Name=Beetle Adventure Racing (E)(U)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BEETLE%20ADVENTURE%20JP]
 Good_Name=Beetle Adventure Racing (J)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BIOFREAKS]
 Good_Name=Bio F.R.E.A.K.S. (E)(U)
@@ -96,7 +91,6 @@ Good_Name=Densha de Go! 64 (J)
 
 [Diddy%20Kong%20Racing]
 Good_Name=Diddy Kong Racing (E)(U)(J)
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [DONALD%20DUCK%20GOIN%27%20QU]
 Good_Name=Donald Duck - Goin' Quackers (U)
@@ -140,14 +134,17 @@ Good_Name=Eikou No Saint Andrews (J)
 
 [EXTREME_G]
 Good_Name=Extreme-G (E)
+frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [EXTREME-G]
 Good_Name=Extreme-G (J)
+frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [EXTREMEG]
 Good_Name=Extreme-G (U)
+frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [208E05CD]
@@ -178,6 +175,7 @@ Good_Name=Hamster Monogatari 64 (J)
 
 [HARVESTMOON64]
 Good_Name=Harvest Moon 64 (U)
+frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [5CFA0A2E]
@@ -234,6 +232,7 @@ Good_Name=Mahjong Hourouki Classic (J)
 
 [301E07CC]
 Good_Name=Mahjong Master (J)
+frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [MARIOGOLF64]
@@ -263,12 +262,10 @@ frameBufferEmulation\copyToRDRAM=1
 [MICKEY%20USA%20PAL]
 Good_Name=Mickey's Speedway USA (E)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [MICKEY%20USA]
 Good_Name=Mickey's Speedway USA (U) / Mickey No Racing Challenge USA (J)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [293D0695]
 Good_Name=Morita Shougi 64 (J)
@@ -377,6 +374,7 @@ frameBufferEmulation\copyDepthToRDRAM=1
 
 [TIGGER%27S%20HONEY%20HUNT]
 Good_Name=Tigger's Honey Hunt (E)(U)
+frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [TONIC%20TROUBLE]

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -62,7 +62,6 @@ frameBufferEmulation\detectCFB=1
 
 [52150A67]
 Good_Name=Bokujou Monogatari 2 (J)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [476C09C1]
@@ -138,17 +137,14 @@ Good_Name=Eikou No Saint Andrews (J)
 
 [EXTREME_G]
 Good_Name=Extreme-G (E)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [EXTREME-G]
 Good_Name=Extreme-G (J)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [EXTREMEG]
 Good_Name=Extreme-G (U)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [208E05CD]
@@ -179,7 +175,6 @@ Good_Name=Hamster Monogatari 64 (J)
 
 [HARVESTMOON64]
 Good_Name=Harvest Moon 64 (U)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [5CFA0A2E]
@@ -236,7 +231,6 @@ Good_Name=Mahjong Hourouki Classic (J)
 
 [301E07CC]
 Good_Name=Mahjong Master (J)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [MARIOGOLF64]
@@ -378,7 +372,6 @@ frameBufferEmulation\copyDepthToRDRAM=1
 
 [TIGGER%27S%20HONEY%20HUNT]
 Good_Name=Tigger's Honey Hunt (E)(U)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\N64DepthCompare=1
 
 [TONIC%20TROUBLE]

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -243,6 +243,9 @@ frameBufferEmulation\copyToRDRAM=0
 Good_Name=Star Wars Episode I - Racer (E)(U)(J)
 frameBufferEmulation\copyDepthToRDRAM=1
 
+[TWISTED%20EDGE]
+frameBufferEmulation\copyDepthToRDRAM=1
+
 [ZELDA%20MAJORA%27S%20MASK]
 Good_Name=The Legend Of Zelda - Majora's Mask (E)(U) / Zelda No Densetsu - Mujura No Karmen (J)
 frameBufferEmulation\copyToRDRAM=1

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -11,6 +11,24 @@ Good_Name=1080 Snowboarding (E)(JU)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
 
+[6D120CBF]
+Good_Name=64 De Hakken!! Tamagotchi - Minna De Tamagotchi World (J)
+
+[68DD0BB5]
+Good_Name=64 Hanafuda - Tenshi No Yakusoku (J)
+
+[1F580575]
+Good_Name=64 Oozumou 2 (J)
+
+[1333047D]
+Good_Name=AI Shougi 3 (J)
+
+[30080737]
+Good_Name=Air Boarder 64 (J)
+
+[44BB08DC]
+Good_Name=Bakushou Jinsei 64 - Mezase! Resort Ou (J)
+
 [BANJO-KAZOOIE]
 Good_Name=Banjo-Kazooie (E)(U) / Banjo To Kazooie No Daibouken (J)
 frameBufferEmulation\copyToRDRAM=1
@@ -46,6 +64,12 @@ frameBufferEmulation\detectCFB=1
 Good_Name=Bokujou Monogatari 2 (J)
 frameBufferEmulation\N64DepthCompare=1
 
+[476C09C1]
+Good_Name=Bomberman Hero - Mirian Oujo Wo Sukue! (J)
+
+[13E50365]
+Good_Name=Choro Q 64 2 - Hacha Mecha Grand Prix Race (J)
+
 [CASTLEVANIA]
 Good_Name=Castlevania (E)(U)
 frameBufferEmulation\copyToRDRAM=1
@@ -54,10 +78,19 @@ frameBufferEmulation\copyToRDRAM=1
 Good_Name=Castlevania - Legacy Of Darkness (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 
+[3D9F08DB]
+Good_Name=Chou Kuukan Nighter Pro Yakyuu King 2 (J)
+
+[31DC0863]
+Good_Name=Chou Snobow Kids (J)
+
 [CONKER%20BFD]
 Good_Name=Conker's Bad Fur Day (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
+
+[362D06B6]
+Good_Name=Densha de Go! 64 (J)
 
 [DONALD%20DUCK%20GOIN%27%20QU]
 Good_Name=Donald Duck - Goin' Quackers (U)
@@ -83,9 +116,21 @@ frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\detectCFB=1
 frameBufferEmulation\copyDepthToRDRAM=1
 
+[72390C86]
+Good_Name=Doraemon - Nobita To 3tsu No Seireiseki (J)
+
+[6E3D0C76]
+Good_Name=Doraemon 2 - Nobita To Hikari No Shinden (J)
+
+[84CE0BDF]
+Good_Name=Doraemon 3 - Nobita No Machi SOS! (J)
+
 [DR.MARIO%2064]
 Good_Name=Dr. Mario 64 (U)
 frameBufferEmulation\copyFromRDRAM=1
+
+[67000C2B]
+Good_Name=Eikou No Saint Andrews (J)
 
 [EXCITEBIKE64]
 frameBufferEmulation\copyDepthToRDRAM=1
@@ -102,6 +147,9 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Extreme-G (U)
 frameBufferEmulation\N64DepthCompare=1
 
+[208E05CD]
+Good_Name=Extreme-G XG2 (J)
+
 [F1%20POLE%20POSITION%2064]
 Good_Name=F-1 Pole Position 64 (E)(U)
 frameBufferEmulation\copyToRDRAM=1
@@ -110,19 +158,52 @@ frameBufferEmulation\copyToRDRAM=1
 Good_Name=F-Zero X (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 
+[18000458]
+Good_Name=Famista 64 (J)
+
+[2997071D]
+Good_Name=Fushigi No Dungeon - Fuurai No Shiren 2 - Oni Shuurai! Shiren Jou! (J)
+
+[3BE3091D]
+Good_Name=Ganbare Goemon - Neo Momoyama Bakufu No Odori (J)
+
+[53900B10]
+Good_Name=Goemon - Mononoke Sugoroku (J)
+
+[457A0908]
+Good_Name=Hamster Monogatari 64 (J)
+
 [HARVESTMOON64]
 Good_Name=Harvest Moon 64 (U)
 frameBufferEmulation\N64DepthCompare=1
+
+[5CFA0A2E]
+Good_Name=Heiwa Pachinko World 64 (J)
 
 [HEXEN]
 Good_Name=Hexen (E)(F)(G)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\detectCFB=1
 
+[30AB07E1]
+Good_Name=Hiryuu No Ken Twin (J)
+
 [HSV%20ADVENTURE%20RACING]
 Good_Name=HSV Adventure Racing (A)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
+
+[83CA0DCA]
+Good_Name=Ide Yousuke No Mahjong Juku (J)
+
+[43CC08A2]
+Good_Name=J.League Dynamite Soccer 64 (J)
+
+[7EA50BA0]
+Good_Name=J.League Eleven Beat 1997 (J)
+
+[31E0076F]
+Good_Name=Jangou Simulation Mahjong Dou 64 (J)
 
 [JET%20FORCE%20GEMINI]
 Good_Name=Jet Force Gemini (E)(U)
@@ -136,6 +217,9 @@ frameBufferEmulation\copyToRDRAM=0
 Good_Name=Jet Force Gemini Kiosk Demo (U)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
+
+[713F0C09]
+Good_Name=Kiratto Kaiketsu! 64 Tanteidan (J)
 
 [LEGORACERS]
 Good_Name=Lego Racers (E)(U)
@@ -158,6 +242,9 @@ frameBufferEmulation\copyDepthToRDRAM=1
 Good_Name=Mario Kart 64 (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 
+[2B6D07C8]
+Good_Name=Mario No Photopi (J)
+
 [MARIO%20STORY]
 Good_Name=Mario Story (J)
 frameBufferEmulation\copyToRDRAM=1
@@ -179,9 +266,18 @@ Good_Name=Mickey's Speedway USA (U) / Mickey No Racing Challenge USA (J)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyDepthToRDRAM=1
 
+[293D0695]
+Good_Name=Morita Shougi 64 (J)
+
 [MS.%20PAC-MAN%20MM]
 Good_Name=Ms. Pac-Man - Maze Madness (U)
 frameBufferEmulation\detectCFB=1
+
+[14B30473]
+Good_Name=Nushi Duri 64 (J)
+
+[5E5A0B37]
+Good_Name=Nushi Duri 64 - Shiokaze Ni Notte (J)
 
 [PAPER%20MARIO]
 Good_Name=Paper Mario (E)(U)
@@ -217,9 +313,15 @@ frameBufferEmulation\detectCFB=1
 Good_Name=Resident Evil 2 (E)(U)
 frameBufferEmulation\detectCFB=1
 
+[437009B9]
+Good_Name=Saikyou Habu Shougi (J)
+
 [RUSH%202049]
 Good_Name=San Francisco Rush 2049 (E)(U)
 frameBufferEmulation\copyToRDRAM=0
+
+[1C500641]
+Good_Name=Snobow Kids (J)
 
 [SPACE%20INVADERS]
 Good_Name=Space Invaders (U)
@@ -242,6 +344,12 @@ frameBufferEmulation\copyToRDRAM=0
 [STAR%20WARS%20EP1%20RACER]
 Good_Name=Star Wars Episode I - Racer (E)(U)(J)
 frameBufferEmulation\copyDepthToRDRAM=1
+
+[67ED0B45]
+Good_Name=Super Robot Taisen 64 (J)
+
+[622D0C12]
+Good_Name=Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (J)
 
 [TWISTED%20EDGE]
 frameBufferEmulation\copyDepthToRDRAM=1
@@ -274,9 +382,21 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Tonic Trouble (E)(U)
 frameBufferEmulation\detectCFB=1
 
+[48460A35]
+Good_Name=Ucchan Nanchan No Hono No Challenger - Denryuu Ira Ira Bou (J)
+
 [VIGILANTE%208]
 Good_Name=Vigilante 8 (E)(F)(G)(U)
 frameBufferEmulation\copyDepthToRDRAM=1
+
+[4C2E093B]
+Good_Name=Virtual Pro Wrestling 2 - Oudou Keishou (J)
+
+[8B6F0CBE]
+Good_Name=Virtual Pro Wrestling 64 (J)
+
+[34060655]
+Good_Name=WWF Wrestlemania 2000 (J)
 
 [THE%20MASK%20OF%20MUJURA]
 Good_Name=Zelda No Densetsu - Mujura No Karmen (J)


### PR DESCRIPTION
Knowing which games want depth buffer to RDRAM is really hard. For now, I think it should be enabled for the notorious suspects -- Rareware racing and platforming games.