### PR TITLE
Fixes flickering textures in Adreno devices.

### DIFF
--- a/src/OGL3X/UniformBlock.cpp
+++ b/src/OGL3X/UniformBlock.cpp
@@ -148,7 +148,17 @@ void UniformBlock::setColorData(ColorUniforms _index, u32 _dataSize, const void 
 		m_currentBuffer = m_colorsBlock.m_buffer;
 		glBindBuffer(GL_UNIFORM_BUFFER, m_colorsBlock.m_buffer);
 	}
-	glBufferSubData(GL_UNIFORM_BUFFER, m_colorsBlock.m_offsets[_index], _dataSize, _data);
+
+	OGLVideo & ogl = video();
+	OGLRender & render = ogl.getRender();
+	if (render.getRenderer() == OGLRender::glrAdreno)
+	{
+	        glBufferData(GL_UNIFORM_BUFFER, m_colorsBlockData.size(), m_colorsBlockData.data(), GL_STATIC_COPY);
+	}
+	else
+	{
+	        glBufferSubData(GL_UNIFORM_BUFFER, m_colorsBlock.m_offsets[_index], _dataSize, _data);
+	}
 }
 
 void UniformBlock::updateTextureParameters()
@@ -219,7 +229,18 @@ void UniformBlock::updateTextureParameters()
 		m_currentBuffer = m_textureBlock.m_buffer;
 		glBindBuffer(GL_UNIFORM_BUFFER, m_textureBlock.m_buffer);
 	}
-	glBufferSubData(GL_UNIFORM_BUFFER, m_textureBlock.m_offsets[tuTexScale], m_textureBlockData.size(), pData);
+
+
+        OGLVideo & ogl = video();
+        OGLRender & render = ogl.getRender();
+        if (render.getRenderer() == OGLRender::glrAdreno)
+        {
+                glBufferData(GL_UNIFORM_BUFFER, m_textureBlockData.size(), m_textureBlockData.data(), GL_STATIC_COPY);
+        }
+        else
+        {
+                glBufferSubData(GL_UNIFORM_BUFFER, m_textureBlock.m_offsets[tuTexScale], m_textureBlockData.size(), pData);
+        }
 }
 
 void UniformBlock::updateLightParameters()
@@ -237,7 +258,17 @@ void UniformBlock::updateLightParameters()
 		m_currentBuffer = m_lightBlock.m_buffer;
 		glBindBuffer(GL_UNIFORM_BUFFER, m_lightBlock.m_buffer);
 	}
-	glBufferSubData(GL_UNIFORM_BUFFER, m_lightBlock.m_offsets[luLightDirection], m_lightBlockData.size(), pData);
+
+        OGLVideo & ogl = video();
+        OGLRender & render = ogl.getRender();
+        if (render.getRenderer() == OGLRender::glrAdreno)
+        {
+                glBufferData(GL_UNIFORM_BUFFER, m_lightBlockData.size(), m_lightBlockData.data(), GL_STATIC_COPY);
+        }
+        else
+        {
+                glBufferSubData(GL_UNIFORM_BUFFER, m_lightBlock.m_offsets[luLightDirection], m_lightBlockData.size(), pData);
+        }
 }
 
 UniformCollection * createUniformCollection()


### PR DESCRIPTION
Through sheer luck, I think I found the issue. After applying this fix, flickering textures in Adreno devices are gone. This fixes this issue: https://github.com/gonetz/GLideN64/issues/714

You don't have to take this pull request as is since I'm dumb when it comes to OpenGL. 

Please see my comments.