### PR TITLE
Changing the texture cache to be a proper LRU cache

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -524,15 +524,15 @@ void TextureCache::_checkCacheSize()
 	if (m_cachedBytes <= m_maxBytes)
 		return;
 
-	Textures::const_iterator iter = m_textures.cend();
+	Textures::iterator iter = m_textures.end();
 	do {
 		--iter;
-		const CachedTexture& tex = *iter;
+		CachedTexture& tex = *iter;
 		m_cachedBytes -= tex.textureBytes;
 		glDeleteTextures(1, &tex.glName);
 		m_lruTextureLocations.erase(tex.crc);
 	} while (m_cachedBytes > m_maxBytes && iter != m_textures.cbegin());
-	m_textures.erase(iter, m_textures.cend());
+	m_textures.erase(iter, m_textures.end());
 }
 
 CachedTexture * TextureCache::_addTexture(u32 _crc32)

--- a/src/Textures.h
+++ b/src/Textures.h
@@ -2,6 +2,7 @@
 #define TEXTURES_H
 
 #include <map>
+#include <deque>
 
 #include "CRC.h"
 #include "convert.h"
@@ -82,9 +83,12 @@ private:
 	void _initDummyTexture(CachedTexture * _pDummy);
 	void _getTextureDestData(CachedTexture& tmptex, u32* pDest, GLuint glInternalFormat, GetTexelFunc GetTexel, u16* pLine);
 
-	typedef std::map<u32, CachedTexture> Textures;
+	typedef std::list<CachedTexture> Textures;
+	typedef std::map<u32, Textures::iterator> Texture_Locations;
+	typedef std::map<u32, CachedTexture> FBTextures;
 	Textures m_textures;
-	Textures m_fbTextures;
+	Texture_Locations m_lruTextureLocations;
+	FBTextures m_fbTextures;
 	CachedTexture * m_pDummy;
 	CachedTexture * m_pMSDummy;
 	u32 m_hits, m_misses;

--- a/src/Textures.h
+++ b/src/Textures.h
@@ -2,7 +2,6 @@
 #define TEXTURES_H
 
 #include <map>
-#include <deque>
 
 #include "CRC.h"
 #include "convert.h"


### PR DESCRIPTION
I change the currently used 'map' of textures to a queue (implemented as a list),
and then remove from the end of the queue when textures need removing from
the cache, and adding to the beginning of the queue.
The other operation that is needed is moving the texture to the
front of the list whenever it is used, so that frequently used
textures are not deleted.
In order to make that last operation effecient, I created
a map of the locations of these textures, and keep that
properly updated. This makes the accessing of a texture still O(1).
Then, in order to have the iterators remain valid through insertions
and deletions, I needed to implement the queue as a list.

The map and queue implementation is a standard way to implement
an LRU cache, just FYI. Not something I thought of all on my own.

Fixes issue #744 

I'm hoping that this also fixes issue #534 

Finally, I may have broken framebuffer textures (I'm not sure how those work). What is a game that uses those so that I can make sure?

I know this doesn't clean up the texture code any, but I don't quite understand it all do a nice cleanup yet. Maybe later :P