### PR TITLE
UniformCollection: Add missing virtual destructor

### DIFF
--- a/src/UniformCollection.h
+++ b/src/UniformCollection.h
@@ -35,6 +35,8 @@ public:
 		luTotal
 	};
 
+	virtual ~UniformCollection() {}
+
 	virtual void bindWithShaderCombiner(ShaderCombiner * _pCombiner) = 0;
 	virtual void setColorData(ColorUniforms _index, u32 _dataSize, const void * _data) = 0;
 	virtual void updateTextureParameters() = 0;


### PR DESCRIPTION
Short and simple PR. Ensures the derived destructors are called when necessary.