### PR TITLE
Adding check that there is at least one binary format for shader cach…

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -97,7 +97,11 @@ void CombinerInfo::init()
 {
 	m_pCurrent = NULL;
 	m_pUniformCollection = createUniformCollection();
-	m_bShaderCacheSupported = config.generalEmulation.enableShadersStorage != 0 && OGLVideo::isExtensionSupported(GET_PROGRAM_BINARY_EXTENSION);
+	int numBinaryFormats;
+	glGetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &numBinaryFormats);
+	m_bShaderCacheSupported = config.generalEmulation.enableShadersStorage != 0 &&
+								OGLVideo::isExtensionSupported(GET_PROGRAM_BINARY_EXTENSION) &&
+								numBinaryFormats > 0;
 
 	m_shadersLoaded = 0;
 	if (m_bShaderCacheSupported && !_loadShadersStorage()) {


### PR DESCRIPTION
…e support

There is one implementation that supports the get_program_binary
extension, but doesn't provide any actual formats. (it's Mesa)
In any case this is probably a good check to have.

Without this, with the default options, the program fails on Mesa.