### PR TITLE
Fix build error for target GLES2

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -97,12 +97,16 @@ void CombinerInfo::init()
 {
 	m_pCurrent = NULL;
 	m_pUniformCollection = createUniformCollection();
+#if defined(GLES2)
+	m_bShaderCacheSupported = config.generalEmulation.enableShadersStorage != 0 &&
+								OGLVideo::isExtensionSupported(GET_PROGRAM_BINARY_EXTENSION);
+#else
 	int numBinaryFormats;
 	glGetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &numBinaryFormats);
 	m_bShaderCacheSupported = config.generalEmulation.enableShadersStorage != 0 &&
 								OGLVideo::isExtensionSupported(GET_PROGRAM_BINARY_EXTENSION) &&
 								numBinaryFormats > 0;
-
+#endif
 	m_shadersLoaded = 0;
 	if (m_bShaderCacheSupported && !_loadShadersStorage()) {
 		for (Combiners::iterator cur = m_combiners.begin(); cur != m_combiners.end(); ++cur)


### PR DESCRIPTION
On a GLES2 target build error output tells "GL_NUM_PROGRAM_BINARY_FORMATS was not declared in this scope". GL_NUM_PROGRAM_BINARY_FORMATS is not declared in gl2.h. Regression was introduced here: https://github.com/gonetz/GLideN64/commit/e126a51f6f8c6a4f47155a8d8e564b823d8d3bb9