### PR TITLE
rename RSP.DList

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -287,7 +287,7 @@ void FrameBuffer::copyRdram()
 
 bool FrameBuffer::isValid() const
 {
-	if (m_validityChecked == RSP.buffer_count)
+	if (m_validityChecked == video().getBuffersSwapCount())
 		return true; // Already checked
 
 	const u32 * const pData = (const u32*)RDRAM;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -287,7 +287,7 @@ void FrameBuffer::copyRdram()
 
 bool FrameBuffer::isValid() const
 {
-	if (m_validityChecked == RSP.DList)
+	if (m_validityChecked == RSP.buffer_count)
 		return true; // Already checked
 
 	const u32 * const pData = (const u32*)RDRAM;

--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -78,7 +78,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == RSP.buffer_count || config.generalEmulation.enableNoise == 0)
+	if (m_DList == video().getBuffersSwapCount() || config.generalEmulation.enableNoise == 0)
 		return;
 
 	if (VI.width*VI.height == 0)
@@ -92,7 +92,7 @@ void NoiseTexture::update()
 	glActiveTexture(GL_TEXTURE0 + g_noiseTexIndex);
 	glBindTexture(GL_TEXTURE_2D, m_pTexture->glName);
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, VI.width, VI.height, GL_LUMINANCE, GL_UNSIGNED_BYTE, m_pData.get());
-	m_DList = RSP.buffer_count;
+	m_DList = video().getBuffersSwapCount();
 }
 
 static

--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -78,7 +78,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == RSP.DList || config.generalEmulation.enableNoise == 0)
+	if (m_DList == RSP.buffer_count || config.generalEmulation.enableNoise == 0)
 		return;
 
 	if (VI.width*VI.height == 0)
@@ -92,7 +92,7 @@ void NoiseTexture::update()
 	glActiveTexture(GL_TEXTURE0 + g_noiseTexIndex);
 	glBindTexture(GL_TEXTURE_2D, m_pTexture->glName);
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, VI.width, VI.height, GL_LUMINANCE, GL_UNSIGNED_BYTE, m_pData.get());
-	m_DList = RSP.DList;
+	m_DList = RSP.buffer_count;
 }
 
 static

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -93,7 +93,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == RSP.DList || config.generalEmulation.enableNoise == 0)
+	if (m_DList == RSP.buffer_count || config.generalEmulation.enableNoise == 0)
 		return;
 	const u32 dataSize = VI.width*VI.height;
 	if (dataSize == 0)
@@ -111,7 +111,7 @@ void NoiseTexture::update()
 	glActiveTexture(GL_TEXTURE0 + g_noiseTexIndex);
 	glBindTexture(GL_TEXTURE_2D, m_pTexture->glName);
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, VI.width, VI.height, GL_RED, GL_UNSIGNED_BYTE, 0);
-	m_DList = RSP.DList;
+	m_DList = RSP.buffer_count;
 }
 
 

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -93,7 +93,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == RSP.buffer_count || config.generalEmulation.enableNoise == 0)
+	if (m_DList == video().getBuffersSwapCount() || config.generalEmulation.enableNoise == 0)
 		return;
 	const u32 dataSize = VI.width*VI.height;
 	if (dataSize == 0)
@@ -111,7 +111,7 @@ void NoiseTexture::update()
 	glActiveTexture(GL_TEXTURE0 + g_noiseTexIndex);
 	glBindTexture(GL_TEXTURE_2D, m_pTexture->glName);
 	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, VI.width, VI.height, GL_RED, GL_UNSIGNED_BYTE, 0);
-	m_DList = RSP.buffer_count;
+	m_DList = video().getBuffersSwapCount();
 }
 
 

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -156,7 +156,7 @@ void OGLVideo::swapBuffers()
 	_swapBuffers();
 	gDP.otherMode.l = 0;
 	gDPSetTextureLUT(G_TT_NONE);
-	++RSP.DList;
+	++RSP.buffer_count;
 }
 
 void OGLVideo::setCaptureScreen(const char * const _strDirectory)
@@ -934,8 +934,8 @@ bool texturedRectDepthBufferCopy(const OGLRender::TexturedRectParams & _params)
 		if (pBuffer == NULL)
 			return true;
 		pBuffer->m_cleared = true;
-		if (lastDList != RSP.DList) {
-			lastDList = RSP.DList;
+		if (lastDList != RSP.buffer_count) {
+			lastDList = RSP.buffer_count;
 			if (!FrameBuffer_CopyDepthBuffer(gDP.colorImage.address))
 				return true;
 		}

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -138,6 +138,7 @@ void OGLVideo::start()
 	_start(); // TODO: process initialization error
 	initGLFunctions();
 	m_render._initData();
+	m_buffersSwapCount = 0;
 }
 
 void OGLVideo::stop()
@@ -156,7 +157,7 @@ void OGLVideo::swapBuffers()
 	_swapBuffers();
 	gDP.otherMode.l = 0;
 	gDPSetTextureLUT(G_TT_NONE);
-	++RSP.buffer_count;
+	++m_buffersSwapCount;
 }
 
 void OGLVideo::setCaptureScreen(const char * const _strDirectory)
@@ -934,8 +935,8 @@ bool texturedRectDepthBufferCopy(const OGLRender::TexturedRectParams & _params)
 		if (pBuffer == NULL)
 			return true;
 		pBuffer->m_cleared = true;
-		if (lastDList != RSP.buffer_count) {
-			lastDList = RSP.buffer_count;
+		if (lastDList != video().getBuffersSwapCount()) {
+			lastDList = video().getBuffersSwapCount();
 			if (!FrameBuffer_CopyDepthBuffer(gDP.colorImage.address))
 				return true;
 		}

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -189,6 +189,7 @@ public:
 	f32 getScaleX() const {return m_scaleX;}
 	f32 getScaleY() const {return m_scaleY;}
 	f32 getAdjustScale() const {return m_adjustScale;}
+	u32 getBuffersSwapCount() const {return m_buffersSwapCount;}
 	u32 getWidth() const { return m_width; }
 	u32 getHeight() const {return m_height;}
 	u32 getScreenWidth() const {return m_screenWidth;}
@@ -219,6 +220,7 @@ protected:
 	bool m_bFullscreen;
 	bool m_bAdjustScreen;
 
+	u32 m_buffersSwapCount;
 	u32 m_width, m_height, m_heightOffset;
 	u32 m_screenWidth, m_screenHeight;
 	u32 m_resizeWidth, m_resizeHeight;

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -288,7 +288,6 @@ void RSP_Init()
 	RDRAMSize = 1024 * 1024 * 8 - 1;
 #endif // OS_WINDOWS
 
-	RSP.buffer_count = 0;
 	RSP.uc_start = RSP.uc_dstart = 0;
 	RSP.bLLE = false;
 

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -288,7 +288,7 @@ void RSP_Init()
 	RDRAMSize = 1024 * 1024 * 8 - 1;
 #endif // OS_WINDOWS
 
-	RSP.DList = 0;
+	RSP.buffer_count = 0;
 	RSP.uc_start = RSP.uc_dstart = 0;
 	RSP.bLLE = false;
 

--- a/src/RSP.h
+++ b/src/RSP.h
@@ -5,7 +5,7 @@
 
 typedef struct
 {
-	u32 PC[18], PCi, busy, halt, close, DList, uc_start, uc_dstart, cmd, nextCmd;
+	u32 PC[18], PCi, busy, halt, close, buffer_count, uc_start, uc_dstart, cmd, nextCmd;
 	s32 count;
 	bool bLLE;
 	char romname[21];

--- a/src/RSP.h
+++ b/src/RSP.h
@@ -5,7 +5,7 @@
 
 typedef struct
 {
-	u32 PC[18], PCi, busy, halt, close, buffer_count, uc_start, uc_dstart, cmd, nextCmd;
+	u32 PC[18], PCi, busy, halt, close, uc_start, uc_dstart, cmd, nextCmd;
 	s32 count;
 	bool bLLE;
 	char romname[21];

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1224,7 +1224,7 @@ void TextureCache::activateTexture(u32 _t, CachedTexture *_pTexture)
 	if (video().getRender().getRenderState() == OGLRender::rsTriangle && config.texture.maxAnisotropyF > 0.0f)
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, config.texture.maxAnisotropyF);
 
-	_pTexture->lastDList = RSP.DList;
+	_pTexture->lastDList = RSP.buffer_count;
 
 	current[_t] = _pTexture;
 }
@@ -1312,7 +1312,7 @@ void TextureCache::_updateBackground()
 	pCurrent->clampT = 0;
 	pCurrent->line = 0;
 	pCurrent->tMem = 0;
-	pCurrent->lastDList = RSP.DList;
+	pCurrent->lastDList = RSP.buffer_count;
 	pCurrent->frameBufferTexture = CachedTexture::fbNone;
 
 	pCurrent->realWidth = gSP.bgImage.width;
@@ -1481,7 +1481,7 @@ void TextureCache::update(u32 _t)
 	pCurrent->clampT = gSP.textureTile[_t]->clampt;
 	pCurrent->line = gSP.textureTile[_t]->line;
 	pCurrent->tMem = gSP.textureTile[_t]->tmem;
-	pCurrent->lastDList = RSP.DList;
+	pCurrent->lastDList = RSP.buffer_count;
 	pCurrent->frameBufferTexture = CachedTexture::fbNone;
 
 	pCurrent->realWidth = sizes.realWidth;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1224,7 +1224,7 @@ void TextureCache::activateTexture(u32 _t, CachedTexture *_pTexture)
 	if (video().getRender().getRenderState() == OGLRender::rsTriangle && config.texture.maxAnisotropyF > 0.0f)
 		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, config.texture.maxAnisotropyF);
 
-	_pTexture->lastDList = RSP.buffer_count;
+	_pTexture->lastDList = video().getBuffersSwapCount();
 
 	current[_t] = _pTexture;
 }
@@ -1312,7 +1312,7 @@ void TextureCache::_updateBackground()
 	pCurrent->clampT = 0;
 	pCurrent->line = 0;
 	pCurrent->tMem = 0;
-	pCurrent->lastDList = RSP.buffer_count;
+	pCurrent->lastDList = video().getBuffersSwapCount();
 	pCurrent->frameBufferTexture = CachedTexture::fbNone;
 
 	pCurrent->realWidth = gSP.bgImage.width;
@@ -1481,7 +1481,7 @@ void TextureCache::update(u32 _t)
 	pCurrent->clampT = gSP.textureTile[_t]->clampt;
 	pCurrent->line = gSP.textureTile[_t]->line;
 	pCurrent->tMem = gSP.textureTile[_t]->tmem;
-	pCurrent->lastDList = RSP.buffer_count;
+	pCurrent->lastDList = video().getBuffersSwapCount();
 	pCurrent->frameBufferTexture = CachedTexture::fbNone;
 
 	pCurrent->realWidth = sizes.realWidth;

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -413,7 +413,7 @@ bool CheckForFrameBufferTexture(u32 _address, u32 _bytes)
 		if (bRes) {
 			bRes = pBuffer->isValid();
 			if (bRes)
-				pBuffer->m_validityChecked = RSP.DList;
+				pBuffer->m_validityChecked = RSP.buffer_count;
 			else
 				fbList.removeBuffer(pBuffer->m_startAddress);
 		}

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -413,7 +413,7 @@ bool CheckForFrameBufferTexture(u32 _address, u32 _bytes)
 		if (bRes) {
 			bRes = pBuffer->isValid();
 			if (bRes)
-				pBuffer->m_validityChecked = RSP.buffer_count;
+				pBuffer->m_validityChecked = video().getBuffersSwapCount();
 			else
 				fbList.removeBuffer(pBuffer->m_startAddress);
 		}


### PR DESCRIPTION
I think it's confusing RSP.DList does not actually count the dlists. The amount of dlists and buffer swaps can be the same but it's not necessarily the case. Maybe this should be changed further and get moved away from RSP