### PR TITLE
Make Qt optional

### DIFF
--- a/projects/msvc12/GLideN64.sln
+++ b/projects/msvc12/GLideN64.sln
@@ -20,6 +20,7 @@ Global
 		MinSizeRel|Win32 = MinSizeRel|Win32
 		Release_dll|Win32 = Release_dll|Win32
 		Release_mupenplus|Win32 = Release_mupenplus|Win32
+		Release_noUI|Win32 = Release_noUI|Win32
 		Release|Win32 = Release|Win32
 		RelWithDebInfo|Win32 = RelWithDebInfo|Win32
 	EndGlobalSection
@@ -34,6 +35,8 @@ Global
 		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release_dll|Win32.Build.0 = Release|Win32
 		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release_mupenplus|Win32.ActiveCfg = Release_mupenplus|Win32
 		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release_mupenplus|Win32.Build.0 = Release_mupenplus|Win32
+		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release_noUI|Win32.ActiveCfg = Release_noUI|Win32
+		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release_noUI|Win32.Build.0 = Release_noUI|Win32
 		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release|Win32.ActiveCfg = Release|Win32
 		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.Release|Win32.Build.0 = Release|Win32
 		{37D31D7F-C4E7-45B0-AEF6-D6824A243CF7}.RelWithDebInfo|Win32.ActiveCfg = Release|Win32
@@ -48,6 +51,8 @@ Global
 		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release_dll|Win32.Build.0 = Release_dll|Win32
 		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release_mupenplus|Win32.ActiveCfg = Release|Win32
 		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release_mupenplus|Win32.Build.0 = Release|Win32
+		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release_noUI|Win32.ActiveCfg = Release|Win32
+		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release_noUI|Win32.Build.0 = Release|Win32
 		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release|Win32.ActiveCfg = Release|Win32
 		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.Release|Win32.Build.0 = Release|Win32
 		{DA965BCF-2219-47AF-ACE7-EAF76D5D4756}.RelWithDebInfo|Win32.ActiveCfg = RelWithDebInfo|Win32
@@ -62,6 +67,8 @@ Global
 		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release_dll|Win32.Build.0 = Release|Win32
 		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release_mupenplus|Win32.ActiveCfg = Release|Win32
 		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release_mupenplus|Win32.Build.0 = Release|Win32
+		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release_noUI|Win32.ActiveCfg = Release|Win32
+		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release_noUI|Win32.Build.0 = Release|Win32
 		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release|Win32.ActiveCfg = Release|Win32
 		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.Release|Win32.Build.0 = Release|Win32
 		{7BF6F100-31DB-44AE-A2A5-5DDEED9A909C}.RelWithDebInfo|Win32.ActiveCfg = Release|Win32

--- a/projects/msvc12/GLideN64.vcxproj
+++ b/projects/msvc12/GLideN64.vcxproj
@@ -13,6 +13,10 @@
       <Configuration>Release_mupenplus</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_noUI|Win32">
+      <Configuration>Release_noUI</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -25,6 +29,11 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v120</PlatformToolset>
@@ -51,6 +60,10 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
@@ -73,10 +86,13 @@
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug_mupenplus|Win32'">true</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Release\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">Release\</OutDir>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'">Release\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Release\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">Release\</IntDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'">Release\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">false</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'">false</LinkIncremental>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug_mupenplus|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
@@ -85,10 +101,13 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug_mupenplus|Win32'" />
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'" />
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'" />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_mupenplus|Win32'">
@@ -182,6 +201,37 @@
       <AdditionalLibraryDirectories>../../../freetype/lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <PreprocessorDefinitions>NDEBUG;NO_UI;UNICODE;TXFILTER_LIB;WIN32_ASM;OS_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>../../src/inc;../../src/osal;../../../freetype/include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>freetype253MT.lib;osal\Release\osal.lib;GLideNHQ\Release\libGLideNHQ.lib;opengl32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>c:\Games\N64\Plugin\GLideN64.dll</OutputFile>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <ImportLibrary>$(OutDir)New glNintendo64().lib</ImportLibrary>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalLibraryDirectories>../../../freetype/lib</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_mupenplus|Win32'">
     <ClCompile>
       <Optimization>Full</Optimization>
@@ -233,22 +283,27 @@
     <ClCompile Include="..\..\src\MupenPlusPluginAPI.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\mupenplus\CommonAPIImpl_mupenplus.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\mupenplus\Config_mupenplus.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\mupenplus\MupenPlusAPIImpl.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\mupenplus\OpenGL_mupenplus.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\N64.cpp" />
     <ClCompile Include="..\..\src\OGL3X\GLSLCombiner_ogl3x.cpp" />
@@ -323,6 +378,7 @@
     <ClInclude Include="..\..\src\mupenplus\GLideN64_mupenplus.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_noUI|Win32'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="..\..\src\N64.h" />
     <ClInclude Include="..\..\src\OGL3X\Shaders_ogl3x.h" />

--- a/src/Config.h
+++ b/src/Config.h
@@ -133,9 +133,11 @@ struct Config
 
 extern Config config;
 
+#ifndef NO_UI
 void Config_LoadConfig();
 #ifndef MUPENPLUSAPI
 void Config_DoConfig(/*HWND hParent*/);
 #endif
+#endif //NO_UI
 
 #endif // CONFIG_H

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -168,10 +168,12 @@ void OGLVideo::setCaptureScreen(const char * const _strDirectory)
 
 void OGLVideo::saveScreenshot()
 {
+#ifndef NO_UI
 	if (!m_bCaptureScreen)
 		return;
 	_saveScreenshot();
 	m_bCaptureScreen = false;
+#endif
 }
 
 bool OGLVideo::changeWindow()

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -235,7 +235,9 @@ private:
 	virtual bool _start() = 0;
 	virtual void _stop() = 0;
 	virtual void _swapBuffers() = 0;
+#ifndef NO_UI
 	virtual void _saveScreenshot() = 0;
+#endif
 	virtual void _changeWindow() = 0;
 	virtual bool _resizeWindow() = 0;
 };

--- a/src/common/CommonAPIImpl_common.cpp
+++ b/src/common/CommonAPIImpl_common.cpp
@@ -29,7 +29,11 @@ void RSP_ThreadProc(std::mutex * _pRspThreadMtx, std::mutex * _pPluginThreadMtx,
 	_pRspThreadMtx->lock();
 	RSP_Init();
 	GBI.init();
+#ifndef NO_UI
 	Config_LoadConfig();
+#else
+	config.resetToDefaults();
+#endif
 	video().start();
 	assert(!isGLError());
 

--- a/src/windows/Config_windows.cpp
+++ b/src/windows/Config_windows.cpp
@@ -8,6 +8,7 @@
 
 Config config;
 
+#ifndef NO_UI
 void Config_DoConfig(/*HWND hParent*/)
 {
 	wchar_t strIniFolderPath[PLUGIN_PATH_SIZE];
@@ -30,3 +31,4 @@ void Config_LoadConfig()
 	if (config.generalEmulation.enableCustomSettings != 0)
 		LoadCustomRomSettings(strIniFolderPath, RSP.romname);
 }
+#endif

--- a/src/windows/OpenGL_windows.cpp
+++ b/src/windows/OpenGL_windows.cpp
@@ -15,7 +15,9 @@ private:
 	virtual bool _start();
 	virtual void _stop();
 	virtual void _swapBuffers();
+#ifndef NO_UI
 	virtual void _saveScreenshot();
+#endif
 	virtual bool _resizeWindow();
 	virtual void _changeWindow();
 
@@ -112,6 +114,7 @@ void OGLVideoWindows::_swapBuffers()
 		SwapBuffers( hDC );
 }
 
+#ifndef NO_UI
 void OGLVideoWindows::_saveScreenshot()
 {
 	unsigned char *pixelData = (unsigned char*)malloc(m_screenWidth * m_screenHeight * 3);
@@ -124,6 +127,7 @@ void OGLVideoWindows::_saveScreenshot()
 	SaveScreenshot(m_strScreenDirectory, RSP.romname, m_screenWidth, m_screenHeight, pixelData);
 	free( pixelData );
 }
+#endif
 
 void OGLVideoWindows::_changeWindow()
 {

--- a/src/windows/ZilmarAPIImpl_windows.cpp
+++ b/src/windows/ZilmarAPIImpl_windows.cpp
@@ -8,10 +8,12 @@
 
 void PluginAPI::DllAbout(/*HWND _hParent*/)
 {
+#ifndef NO_UI
 	Config_LoadConfig();
 	wchar_t strIniFolderPath[PLUGIN_PATH_SIZE];
 	api().FindPluginPath(strIniFolderPath);
 	RunAbout(strIniFolderPath);
+#endif
 }
 
 void PluginAPI::CaptureScreen(char * _Directory)
@@ -21,7 +23,9 @@ void PluginAPI::CaptureScreen(char * _Directory)
 
 void PluginAPI::DllConfig(HWND _hParent)
 {
+#ifndef NO_UI
 	Config_DoConfig(/*_hParent*/);
+#endif
 }
 
 void PluginAPI::GetDllInfo(PLUGIN_INFO * PluginInfo)


### PR DESCRIPTION
Release_noUI configuration now builds the plugin without UI
I think it's a good thing to seperate the essential parts of the plugin and the optional parts. Unfortunately Qt currently reads the ini files and writes the screenshots so this functionality will be missing. Only the default settings can be used