### PR TITLE
implement framebuffer to RDRAM

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -49,6 +49,7 @@ void Config::resetToDefaults()
 #endif
 	frameBufferEmulation.copyDepthToRDRAM = ctDisable;
 	frameBufferEmulation.copyFromRDRAM = 0;
+	frameBufferEmulation.copyAuxiliary = 0;
 	frameBufferEmulation.copyToRDRAM = ctAsync;
 	frameBufferEmulation.detectCFB = 0;
 	frameBufferEmulation.N64DepthCompare = 0;

--- a/src/Config.h
+++ b/src/Config.h
@@ -71,6 +71,7 @@ struct Config
 
 	struct {
 		u32 enable;
+		u32 copyAuxiliary;
 		u32 copyToRDRAM;
 		u32 copyDepthToRDRAM;
 		u32 copyFromRDRAM;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -191,8 +191,14 @@ void FrameBuffer::init(u32 _address, u32 _endAddress, u16 _format, u16 _size, u1
 	m_width = _width;
 	m_height = _height;
 	m_size = _size;
-	m_scaleX = ogl.getScaleX();
-	m_scaleY = ogl.getScaleY();
+	if (m_width != VI.width && config.frameBufferEmulation.copyAuxiliary == 1) {
+		m_scaleX = 1;
+		m_scaleY = 1;
+	}
+	else {
+		m_scaleX = ogl.getScaleX();
+		m_scaleY = ogl.getScaleY();
+	}
 	m_fillcolor = 0;
 	m_cfb = _cfb;
 	m_needHeightCorrection = _width != VI.width && _width != *REG.VI_WIDTH;
@@ -1013,11 +1019,22 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, u32 readPBO, u32 writePBO)
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_FBO);
 	glScissor(0, 0, pBuffer->m_pTexture->realWidth, pBuffer->m_pTexture->realHeight);
-	glBlitFramebuffer(
-		0, 0, pBuffer->m_width * pBuffer->m_scaleX, pBuffer->m_height * pBuffer->m_scaleY,
-		0, 0, pBuffer->m_width, pBuffer->m_height,
-		GL_COLOR_BUFFER_BIT, GL_NEAREST
-	);
+
+	if (pBuffer->m_scaleX == 1) {
+		glBlitFramebuffer(
+			0, 0, pBuffer->m_width, pBuffer->m_height,
+			0, 0, pBuffer->m_width, pBuffer->m_height,
+			GL_COLOR_BUFFER_BIT, GL_NEAREST
+			);
+	}
+	else {
+		glBlitFramebuffer(
+			0, 0, video().getWidth(), video().getHeight(),
+			0, 0, VI.width, VI.height,
+			GL_COLOR_BUFFER_BIT, GL_NEAREST
+			);
+	}
+
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, frameBufferList().getCurrent()->m_FBO);
 
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, m_FBO);

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -451,6 +451,13 @@ FrameBuffer * FrameBufferList::findTmpBuffer(u32 _address)
 
 void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _width, u16 _height, bool _cfb)
 {
+	if (m_pCurrent != NULL && config.frameBufferEmulation.copyAuxiliary != 0) {
+		if (m_pCurrent->m_width != VI.width) {
+			FrameBuffer_CopyToRDRAM(m_pCurrent->m_startAddress, 3, 3);
+			removeBuffer(m_pCurrent->m_startAddress);
+		}
+	}
+
 	if (VI.width == 0 || _height == 0) {
 		m_pCurrent = NULL;
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -531,12 +531,25 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 	m_pCurrent->m_postProcessed = false;
 }
 
-void FrameBufferList::toRDRAM()
+void FrameBufferList::copyAux()
 {
 	for (FrameBuffers::iterator iter = m_list.begin(); iter != m_list.end(); ++iter) {
-		if (iter->m_width != VI.width && iter->m_height != VI.height) {
+		if (iter->m_width != VI.width && iter->m_height != VI.height)
 			FrameBuffer_CopyToRDRAM(iter->m_startAddress, 3, 3);
-			m_list.erase(iter);
+	}
+}
+
+void FrameBufferList::removeAux()
+{
+	for (FrameBuffers::iterator iter = m_list.begin(); iter != m_list.end(); ++iter) {
+		while (iter->m_width != VI.width && iter->m_height != VI.height) {
+			if (&(*iter) == m_pCurrent) {
+				m_pCurrent = NULL;
+				glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+			}
+			iter = m_list.erase(iter);
+			if (iter == m_list.end())
+				return;
 		}
 	}
 }

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -981,14 +981,18 @@ void FrameBufferToRDRAM::Destroy() {
 
 void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, u32 readPBO, u32 writePBO)
 {
-	const u32 numPixels = VI.width * VI.height;
-	if (numPixels == 0 || frameBufferList().getCurrent() == NULL) // Incorrect buffer size or no current buffer. Don't copy
+	if (VI.width == 0 || frameBufferList().getCurrent() == NULL)
 		return;
+
 	FrameBuffer *pBuffer = frameBufferList().findBuffer(_address);
 	if (pBuffer == NULL || pBuffer->m_isOBScreen)
 		return;
 
-	if ((config.generalEmulation.hacks & hack_subscreen) != 0) {
+	const u32 numPixels = pBuffer->m_width * pBuffer->m_height;
+	if (numPixels == 0)
+		return;
+
+	if ((config.generalEmulation.hacks & hack_subscreen) != 0 && pBuffer->m_width == VI.width && pBuffer->m_height == VI.height) {
 		copyWhiteToRDRAM(pBuffer);
 		return;
 	}
@@ -1003,8 +1007,8 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, u32 readPBO, u32 writePBO)
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_FBO);
 	glScissor(0, 0, pBuffer->m_pTexture->realWidth, pBuffer->m_pTexture->realHeight);
 	glBlitFramebuffer(
-		0, 0, video().getWidth(), video().getHeight(),
-		0, 0, VI.width, VI.height,
+		0, 0, pBuffer->m_width * pBuffer->m_scaleX, pBuffer->m_height * pBuffer->m_scaleY,
+		0, 0, pBuffer->m_width, pBuffer->m_height,
 		GL_COLOR_BUFFER_BIT, GL_NEAREST
 	);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, frameBufferList().getCurrent()->m_FBO);

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -268,7 +268,7 @@ void FrameBuffer::copyRdram()
 	const u32 dataSize = stride * height;
 
 	// Auxiliary frame buffer
-	if (m_width != VI.width && !config.frameBufferEmulation.copyAuxiliary) {
+	if (m_width != VI.width && config.frameBufferEmulation.copyAuxiliary == 0) {
 		// Write small amount of data to the start of the buffer.
 		// This is necessary for auxilary buffers: game can restore content of RDRAM when buffer is not needed anymore
 		// Thus content of RDRAM on moment of buffer creation will be the same as when buffer becomes obsolete.

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1044,7 +1044,8 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, u32 readPBO, u32 writePBO)
 		for (u32 y = 0; y < height; ++y) {
 			for (u32 x = 0; x < pBuffer->m_width; ++x) {
 				c.raw = ptr_src[x + (height - y - 1)*pBuffer->m_width];
-				ptr_dst[(x + y*pBuffer->m_width) ^ 1] = ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | (c.a == 0 ? 0 : 1);
+				if (c.a)
+					ptr_dst[(x + y*pBuffer->m_width) ^ 1] = ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | 1;
 			}
 		}
 	}

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -533,6 +533,16 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 	m_pCurrent->m_postProcessed = false;
 }
 
+void FrameBufferList::toRDRAM()
+{
+	for (FrameBuffers::iterator iter = m_list.begin(); iter != m_list.end(); ++iter) {
+		if (iter->m_width != VI.width && iter->m_height != VI.height) {
+			FrameBuffer_CopyToRDRAM(iter->m_startAddress);
+			m_list.erase(iter);
+		}
+	}
+}
+
 void FrameBufferList::removeBuffer(u32 _address )
 {
 	for (FrameBuffers::iterator iter = m_list.begin(); iter != m_list.end(); ++iter)
@@ -962,7 +972,7 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address)
 	if (numPixels == 0 || frameBufferList().getCurrent() == NULL) // Incorrect buffer size or no current buffer. Don't copy
 		return;
 	FrameBuffer *pBuffer = frameBufferList().findBuffer(_address);
-	if (pBuffer == NULL || pBuffer->m_width < VI.width || pBuffer->m_isOBScreen)
+	if (pBuffer == NULL || pBuffer->m_isOBScreen)
 		return;
 
 	if ((config.generalEmulation.hacks & hack_subscreen) != 0) {
@@ -991,11 +1001,11 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address)
 #ifndef GLES2
 	// If Sync, read pixels from the buffer, copy them to RDRAM.
 	// If not Sync, read pixels from the buffer, copy pixels from the previous buffer to RDRAM.
-	m_curIndex ^= 1;
-	const u32 nextIndex = m_bSync ? m_curIndex : m_curIndex^1;
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, m_aPBO[m_curIndex]);
-	glReadPixels(0, 0, VI.width, VI.height, GL_RGBA, GL_UNSIGNED_BYTE, 0);
-	PBOBinder binder(GL_PIXEL_PACK_BUFFER, m_aPBO[nextIndex]);
+	//m_curIndex ^= 1;
+	//const u32 nextIndex = m_bSync ? m_curIndex : m_curIndex^1;
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, m_aPBO[0]);
+	glReadPixels(0, 0, pBuffer->m_width, pBuffer->m_height, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+	PBOBinder binder(GL_PIXEL_PACK_BUFFER, m_aPBO[0]);
 	GLubyte* pixelData = (GLubyte*)glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, numPixels * 4, GL_MAP_READ_BIT);
 	if(pixelData == NULL)
 		return;
@@ -1007,15 +1017,15 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address)
 #endif // GLES2
 
 	const u32 stride = pBuffer->m_width << pBuffer->m_size >> 1;
-	const u32 height = _cutHeight(_address, VI.height, stride);
+	const u32 height = _cutHeight(_address, pBuffer->m_height, stride);
 
 	if (pBuffer->m_size == G_IM_SIZ_32b) {
 		u32 *ptr_dst = (u32*)(RDRAM + _address);
 		u32 *ptr_src = (u32*)pixelData;
 
 		for (u32 y = 0; y < height; ++y) {
-			for (u32 x = 0; x < VI.width; ++x)
-				ptr_dst[x + y*VI.width] = ptr_src[x + (height - y - 1)*VI.width];
+			for (u32 x = 0; x < pBuffer->m_width; ++x)
+				ptr_dst[x + y*pBuffer->m_width] = ptr_src[x + (height - y - 1)*pBuffer->m_width];
 		}
 	} else {
 		u16 *ptr_dst = (u16*)(RDRAM + _address);
@@ -1023,9 +1033,9 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address)
 		RGBA c;
 
 		for (u32 y = 0; y < height; ++y) {
-			for (u32 x = 0; x < VI.width; ++x) {
-				c.raw = ptr_src[x + (height - y - 1)*VI.width];
-				ptr_dst[(x + y*VI.width)^1] = ((c.r>>3)<<11) | ((c.g>>3)<<6) | ((c.b>>3)<<1) | (c.a == 0 ? 0 : 1);
+			for (u32 x = 0; x < pBuffer->m_width; ++x) {
+				c.raw = ptr_src[x + (height - y - 1)*pBuffer->m_width];
+				ptr_dst[(x + y*pBuffer->m_width) ^ 1] = ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | (c.a == 0 ? 0 : 1);
 			}
 		}
 	}

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1047,7 +1047,8 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, u32 readPBO, u32 writePBO)
 			for (u32 x = 0; x < pBuffer->m_width; ++x)
 				ptr_dst[x + y*pBuffer->m_width] = ptr_src[x + (height - y - 1)*pBuffer->m_width];
 		}
-	} else {
+	}
+	else if (pBuffer->m_size == G_IM_SIZ_16b){
 		u16 *ptr_dst = (u16*)(RDRAM + _address);
 		u32 * ptr_src = (u32*)pixelData;
 		RGBA c;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -261,7 +261,7 @@ void FrameBuffer::copyRdram()
 	const u32 dataSize = stride * height;
 
 	// Auxiliary frame buffer
-	if (m_width != VI.width) {
+	if (m_width != VI.width && !config.frameBufferEmulation.copyAuxiliary) {
 		// Write small amount of data to the start of the buffer.
 		// This is necessary for auxilary buffers: game can restore content of RDRAM when buffer is not needed anymore
 		// Thus content of RDRAM on moment of buffer creation will be the same as when buffer becomes obsolete.

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -114,7 +114,7 @@ FrameBufferList & frameBufferList()
 
 void FrameBuffer_Init();
 void FrameBuffer_Destroy();
-void FrameBuffer_CopyToRDRAM( u32 _address );
+void FrameBuffer_CopyToRDRAM( u32 _address, u32 readPBO, u32 writePBO );
 void FrameBuffer_CopyFromRDRAM( u32 address, bool bUseAlpha );
 bool FrameBuffer_CopyDepthBuffer( u32 address );
 void FrameBuffer_ActivateBufferTexture(s16 t, FrameBuffer *pBuffer);

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -115,7 +115,7 @@ FrameBufferList & frameBufferList()
 
 void FrameBuffer_Init();
 void FrameBuffer_Destroy();
-void FrameBuffer_CopyToRDRAM( u32 _address, u32 readPBO, u32 writePBO );
+void FrameBuffer_CopyToRDRAM( u32 _address, bool async);
 void FrameBuffer_CopyFromRDRAM( u32 address, bool bUseAlpha );
 bool FrameBuffer_CopyDepthBuffer( u32 address );
 void FrameBuffer_ActivateBufferTexture(s16 t, FrameBuffer *pBuffer);

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -60,6 +60,7 @@ public:
 	void init();
 	void destroy();
 	void saveBuffer(u32 _address, u16 _format, u16 _size, u16 _width, u16 _height, bool _cfb);
+	void toRDRAM();
 	void removeBuffer(u32 _address);
 	void removeBuffers(u32 _width);
 	void attachDepthBuffer();

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -60,7 +60,8 @@ public:
 	void init();
 	void destroy();
 	void saveBuffer(u32 _address, u16 _format, u16 _size, u16 _width, u16 _height, bool _cfb);
-	void toRDRAM();
+	void removeAux();
+	void copyAux();
 	void removeBuffer(u32 _address);
 	void removeBuffers(u32 _width);
 	void attachDepthBuffer();

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -209,8 +209,6 @@ void RSP_ProcessDList()
 		}
 	}
 
-	if (config.frameBufferEmulation.copyToRDRAM != Config::ctDisable)
-		FrameBuffer_CopyToRDRAM(gDP.colorImage.address);
 	if (config.frameBufferEmulation.copyDepthToRDRAM != Config::ctDisable)
 		FrameBuffer_CopyDepthBuffer(gDP.colorImage.address);
 

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -882,7 +882,8 @@ void gDPTextureRectangleFlip( f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, f32 
 
 void gDPFullSync()
 {
-	frameBufferList().toRDRAM();
+	if (config.frameBufferEmulation.copyAuxiliary)
+		frameBufferList().toRDRAM();
 
 	// If Sync, read pixels from the buffer, copy them to RDRAM.
 	// If not Sync, read pixels from the buffer, copy pixels from the previous buffer to RDRAM.

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -887,12 +887,9 @@ void gDPFullSync()
 		frameBufferList().removeAux();
 	}
 
-	// If Sync, read pixels from the buffer, copy them to RDRAM.
-	// If not Sync, read pixels from the buffer, copy pixels from the previous buffer to RDRAM.
-	gDP.colorImage.curIndex ^= 1;
-	const u32 nextIndex = gDP.colorImage.sync ? gDP.colorImage.curIndex : gDP.colorImage.curIndex ^ 1;
+	u32 sync = config.frameBufferEmulation.copyToRDRAM == Config::ctSync;
 	if (config.frameBufferEmulation.copyToRDRAM != Config::ctDisable)
-		FrameBuffer_CopyToRDRAM(gDP.colorImage.address, gDP.colorImage.curIndex, nextIndex);
+		FrameBuffer_CopyToRDRAM(gDP.colorImage.address, !sync);
 
 	if (RSP.bLLE) {
 		if (config.frameBufferEmulation.copyDepthToRDRAM != Config::ctDisable)

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -882,7 +882,7 @@ void gDPTextureRectangleFlip( f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, f32 
 
 void gDPFullSync()
 {
-	if (config.frameBufferEmulation.copyAuxiliary) {
+	if (config.frameBufferEmulation.copyAuxiliary != 0) {
 		frameBufferList().copyAux();
 		frameBufferList().removeAux();
 	}

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -882,6 +882,7 @@ void gDPTextureRectangleFlip( f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, f32 
 
 void gDPFullSync()
 {
+	frameBufferList().toRDRAM();
 	if (RSP.bLLE) {
 		if (config.frameBufferEmulation.copyToRDRAM != Config::ctDisable)
 			FrameBuffer_CopyToRDRAM(gDP.colorImage.address);

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -883,9 +883,15 @@ void gDPTextureRectangleFlip( f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, f32 
 void gDPFullSync()
 {
 	frameBufferList().toRDRAM();
+
+	// If Sync, read pixels from the buffer, copy them to RDRAM.
+	// If not Sync, read pixels from the buffer, copy pixels from the previous buffer to RDRAM.
+	gDP.colorImage.curIndex ^= 1;
+	const u32 nextIndex = gDP.colorImage.sync ? gDP.colorImage.curIndex : gDP.colorImage.curIndex ^ 1;
+	if (config.frameBufferEmulation.copyToRDRAM != Config::ctDisable)
+		FrameBuffer_CopyToRDRAM(gDP.colorImage.address, gDP.colorImage.curIndex, nextIndex);
+
 	if (RSP.bLLE) {
-		if (config.frameBufferEmulation.copyToRDRAM != Config::ctDisable)
-			FrameBuffer_CopyToRDRAM(gDP.colorImage.address);
 		if (config.frameBufferEmulation.copyDepthToRDRAM != Config::ctDisable)
 			FrameBuffer_CopyDepthBuffer(gDP.colorImage.address);
 	}

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -882,8 +882,10 @@ void gDPTextureRectangleFlip( f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, f32 
 
 void gDPFullSync()
 {
-	if (config.frameBufferEmulation.copyAuxiliary)
-		frameBufferList().toRDRAM();
+	if (config.frameBufferEmulation.copyAuxiliary) {
+		frameBufferList().copyAux();
+		frameBufferList().removeAux();
+	}
 
 	// If Sync, read pixels from the buffer, copy them to RDRAM.
 	// If not Sync, read pixels from the buffer, copy pixels from the previous buffer to RDRAM.

--- a/src/gDP.h
+++ b/src/gDP.h
@@ -210,6 +210,7 @@ struct gDPInfo
 
 	struct
 	{
+		u32 curIndex, sync;
 		u32 format, size, width, height, bpl;
 		u32 address, changed;
 		u32 depthImage;

--- a/src/gDP.h
+++ b/src/gDP.h
@@ -210,7 +210,6 @@ struct gDPInfo
 
 	struct
 	{
-		u32 curIndex, sync;
 		u32 format, size, width, height, bpl;
 		u32 address, changed;
 		u32 depthImage;

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -79,6 +79,8 @@ bool Config_SetDefault()
 	//#Frame Buffer Settings:"
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableFBEmulation", config.frameBufferEmulation.enable, "Enable frame and|or depth buffer emulation.");
 	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableCopyAuxiliaryToRDRAM", config.frameBufferEmulation.copyAuxiliary, "Copy auxiliary buffers to RDRAM");
+	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultInt(g_configVideoGliden64, "EnableCopyColorToRDRAM", config.frameBufferEmulation.copyToRDRAM, "Enable color buffer copy to RDRAM (0=do not copy, 1=copy in sync mode, 2=copy in async mode)");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableCopyDepthToRDRAM", config.frameBufferEmulation.copyDepthToRDRAM, "Enable depth buffer copy to RDRAM.");
@@ -189,6 +191,7 @@ void Config_LoadConfig()
 #endif
 	//#Frame Buffer Settings:"
 	config.frameBufferEmulation.enable = ConfigGetParamBool(g_configVideoGliden64, "EnableFBEmulation");
+	config.frameBufferEmulation.copyAuxiliary = ConfigGetParamBool(g_configVideoGliden64, "EnableCopyAuxiliaryToRDRAM");
 	config.frameBufferEmulation.copyToRDRAM = ConfigGetParamInt(g_configVideoGliden64, "EnableCopyColorToRDRAM");
 	config.frameBufferEmulation.copyDepthToRDRAM = ConfigGetParamBool(g_configVideoGliden64, "EnableCopyDepthToRDRAM");
 	config.frameBufferEmulation.copyFromRDRAM = ConfigGetParamBool(g_configVideoGliden64, "EnableCopyColorFromRDRAM");


### PR DESCRIPTION
At the moment for auxiliary buffers only. async is disabled for now. This needs a config option.
My idea is to write all auxiliary buffers at fullsync and then remove them. Works very good in a number of games. Copying main framebuffers still needs to be implemented. 

Current state: 
Pokemon Stadium games: #415 is back. Some bugs are fixed like #725 #723 #699
Mario Tennis: works at the beginning but crashes after a while (?)
Pokemon Snap: camera detection works
Zelda OOT: works but the subscreen delay fix must be disabled
Yoshi's Story: Water effects are correct
Conker/Jet Force Gemini: Crash when shadows are used
Body Harvest: just freezes

screenshots:
![gliden64_mariotennis_001](https://cloud.githubusercontent.com/assets/7283660/10684438/5f3fdf24-794d-11e5-9c97-5f69bf4d620e.jpg)
![gliden64_the_legend_of_zelda_004](https://cloud.githubusercontent.com/assets/7283660/10684439/5f410886-794d-11e5-80a3-f8d3fcfa061a.jpg)
![gliden64_pokemon_stadium_2_009](https://cloud.githubusercontent.com/assets/7283660/10684437/5f3c44c2-794d-11e5-8ba9-602c3700598f.jpg)
![gliden64_pokemon_snap_000](https://cloud.githubusercontent.com/assets/7283660/10684440/5f4172da-794d-11e5-8134-3994fb5caf9d.jpg)

