### PR TITLE
copy only modified pixels to RDRAM

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1066,7 +1066,8 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, bool _sync)
 		for (u32 y = 0; y < height; ++y) {
 			for (u32 x = 0; x < pBuffer->m_width; ++x) {
 				c.raw = ptr_src[x + (height - y - 1)*pBuffer->m_width];
-				ptr_dst[(x + y*pBuffer->m_width)] = (c.r << 24) | (c.g << 16) | (c.b << 8) | c.a;
+				if (c.raw)
+					ptr_dst[(x + y*pBuffer->m_width)] = (c.r << 24) | (c.g << 16) | (c.b << 8) | c.a;
 			}
 		}
 	} else if (pBuffer->m_size == G_IM_SIZ_16b) {
@@ -1077,7 +1078,8 @@ void FrameBufferToRDRAM::CopyToRDRAM(u32 _address, bool _sync)
 		for (u32 y = 0; y < height; ++y) {
 			for (u32 x = 0; x < pBuffer->m_width; ++x) {
 				c.raw = ptr_src[x + (height - y - 1)*pBuffer->m_width];
-				ptr_dst[(x + y*pBuffer->m_width) ^ 1] = ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | (c.a == 0 ? 0 : 1);
+				if (c.raw)
+					ptr_dst[(x + y*pBuffer->m_width) ^ 1] = ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | (c.a == 0 ? 0 : 1);
 			}
 		}
 	}


### PR DESCRIPTION
I know this solution is not perfect. But without this change copying to RDRAM can cause crashes. And that's something which should never happen. I noticed this fixes Donkey Kong 64 (E)!