### PR TITLE
improve cfb detection

### DIFF
--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -113,7 +113,8 @@ void VI_UpdateScreen()
 			gDP.changed |= CHANGED_CPU_FB_WRITE;
 		else if (!pBuffer->isValid()) {
 			gDP.changed |= CHANGED_CPU_FB_WRITE;
-			frameBufferList().removeBuffer(pBuffer->m_startAddress);
+			if (config.frameBufferEmulation.copyToRDRAM == 0)
+				pBuffer->copyRdram();
 		}
 
 		const bool bCFB = (gDP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE;


### PR DESCRIPTION
This fixes flickering in Conker's BFD it's war cutscene. I did this some time ago. But it seems like this was not merged.