### PR TITLE
correct cfb mode if screeen update on color buffer change is selected

### DIFF
--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -127,7 +127,7 @@ void VI_UpdateScreen()
 			bNeedSwap = bCFB ? true : (*REG.VI_ORIGIN != VI.lastOrigin);
 			break;
 		case Config::bsOnColorImageChange:
-			bNeedSwap = gDP.colorImage.changed != 0;
+			bNeedSwap = bCFB ? true : (gDP.colorImage.changed != 0);
 			break;
 		}
 


### PR DESCRIPTION
In cfb mode the screen always needs to be updated