### PR TITLE
Fix Android build for x86_64

### DIFF
--- a/src/GLideNHQ/TxDbg.cpp
+++ b/src/GLideNHQ/TxDbg.cpp
@@ -28,6 +28,8 @@
 #include <stdio.h>
 
 #ifdef ANDROID
+
+#include <stdlib.h>
 #include <android/log.h>
 
 TxDbg::TxDbg()

--- a/src/GLideNHQ/txWidestringWrapper.cpp
+++ b/src/GLideNHQ/txWidestringWrapper.cpp
@@ -1,6 +1,7 @@
 #ifdef ANDROID
 
 #include <stdarg.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include "txWidestringWrapper.h"
 


### PR DESCRIPTION
This adds the stdlib.h include to support the wcstombs function.