### PR TITLE
Fix ISS64 player shadows

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -197,6 +197,10 @@ frameBufferEmulation\copyDepthToRDRAM=1
 [83CA0DCA]
 Good_Name=Ide Yousuke No Mahjong Juku (J)
 
+[I%20S%20S%2064]
+Good_Name=International Superstar Soccer 64 (E) (U)
+frameBufferEmulation\N64DepthCompare=1
+
 [43CC08A2]
 Good_Name=J.League Dynamite Soccer 64 (J)
 
@@ -218,6 +222,10 @@ frameBufferEmulation\copyToRDRAM=0
 Good_Name=Jet Force Gemini Kiosk Demo (U)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
+
+[PERFECT%20STRIKER]
+Good_Name=Jikkyou J.League Perfect Striker (J)
+frameBufferEmulation\N64DepthCompare=1
 
 [713F0C09]
 Good_Name=Kiratto Kaiketsu! 64 Tanteidan (J)


### PR DESCRIPTION
Enable N64DepthCompare for ISS64 and his japanese version

For japanese version, the shadows have a transparency issue but it's better than big black square...

Fix #103 