### PR TITLE
Adds noisy warning if we can't find Texture Image support

### DIFF
--- a/src/Log.h
+++ b/src/Log.h
@@ -8,7 +8,7 @@
 #define LOG_VERBOSE 4
 #define LOG_APIFUNC 5
 
-#define LOG_LEVEL LOG_ERROR
+#define LOG_LEVEL LOG_WARNING
 
 #if LOG_LEVEL>0
 #ifdef ANDROID

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -1351,6 +1351,10 @@ void OGLRender::_initExtensions()
 	m_bImageTexture = false;
 #endif
 	LOG(LOG_VERBOSE, "ImageTexture support: %s\n", m_bImageTexture ? "yes" : "no");
+	if (m_bImageTexture == false)
+	{
+		LOG(LOG_WARNING, "N64 depth compare and depth based fog will not work without Image Textures support provided in OpenGL >= 4.3 or GLES >= 3.1");
+	}
 
 	if (config.texture.maxAnisotropy != 0 && OGLVideo::isExtensionSupported("GL_EXT_texture_filter_anisotropic")) {
 		glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &config.texture.maxAnisotropyF);


### PR DESCRIPTION
This is a better version of the last one. Sorry I forgot about the last one.

This was confusing me for a while as it would simply fail to find the
proper support and I was confronted with a blank screen in certain areas.
This warning (and the associated change of default. I'd like users to see
warnings as well) will help others figure out why there is a blank screen.

My driver supports the necessary extensions (but not 4.3), so if I force it to
advertise 4.3 support (and glsl 420 support) it will properly render.
I tried to create a patch that only looks for the proper extension, and
it works for me, but I feel as though it would depend on behaviour that
most GL implementations would not implement the same way so I've put
it in a separate branch and probably won't request to merge it.
Mesa should get 4.3 support soon enough anyway, so it shouldn't
be an issue for much longer.