### PR TITLE
Fix PostProcessor crash

### DIFF
--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -24,6 +24,10 @@
 #define FRAGMENT_SHADER_END "\n"
 #endif
 
+#ifdef ANDROID
+PostProcessor PostProcessor::processor;
+#endif
+
 static const char * vertexShader =
 SHADER_VERSION
 "#if (__VERSION__ > 120)						\n"
@@ -469,7 +473,9 @@ void PostProcessor::destroy()
 
 PostProcessor & PostProcessor::get()
 {
+#ifndef ANDROID
 	static PostProcessor processor;
+#endif
 	return processor;
 }
 

--- a/src/PostProcessor.h
+++ b/src/PostProcessor.h
@@ -18,6 +18,7 @@ public:
 private:
 	PostProcessor();
 	PostProcessor(const PostProcessor & _other);
+
 	void _initCommon();
 	void _destroyCommon();
 	void _initGammaCorrection();
@@ -43,6 +44,10 @@ private:
 	CachedTexture * m_pTextureOriginal;
 	CachedTexture * m_pTextureGlowMap;
 	CachedTexture * m_pTextureBlur;
+
+#ifdef ANDROID
+	static PostProcessor processor;
+#endif
 };
 
 #endif // POST_PROCESSOR_H


### PR DESCRIPTION
See this issue:

https://github.com/gonetz/GLideN64/issues/968

Somehow the local static variable is being re-constructed. I added some logging to the constructor to verify and it's indeed getting called multiple times. I have no idea how this is happening since I thought the language would guarantee that it would only be called once. All I can think is compiler bug, let me know if you have any better ideas.

By the way, the change I did in this pull request fixes it even though I can't understand why the original code doesn't work.