### PR TITLE
Fix Linux compilation

### DIFF
--- a/src/GLideNHQ/TextureFilters_xbrz.cpp
+++ b/src/GLideNHQ/TextureFilters_xbrz.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <algorithm>
 #include <vector>
+#include <cmath>
 
 namespace
 {

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <algorithm>
+#include <cmath>
 #include "GLideN64.h"
 #include "N64.h"
 #include "GBI.h"


### PR DESCRIPTION
std::sqrt and fabsf need cmath include to build on Linux.