### PR TITLE
Remove glEnable(GL_TEXTURE_2D)

### DIFF
--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -116,9 +116,7 @@ void InitShaderCombiner()
 	}
 
 	glActiveTexture(GL_TEXTURE0);
-	glEnable(GL_TEXTURE_2D);
 	glActiveTexture(GL_TEXTURE1);
-	glEnable(GL_TEXTURE_2D);
 
 	g_vertex_shader_object = _createShader(GL_VERTEX_SHADER, vertex_shader);
 	g_vertex_shader_object_notex = _createShader(GL_VERTEX_SHADER, vertex_shader_notex);


### PR DESCRIPTION
glEnable(GL_TEXTURE_2D) is not valid for Open GL ES 2 (probably not valid for 3+ either, but it doesn't throw an error in those versions)

Fixes https://github.com/gonetz/GLideN64/issues/999

See:
https://www.khronos.org/opengles/sdk/docs/man/xhtml/glEnable.xml