### PR TITLE
Fix PBOs in Android

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.h
+++ b/src/BufferCopy/ColorBufferToRDRAM.h
@@ -2,6 +2,7 @@
 #define ColorBufferToRDRAM_H
 
 #include <OpenGL.h>
+#include <array>
 
 struct CachedTexture;
 struct FrameBuffer;
@@ -27,6 +28,8 @@ protected:
 private:
 	virtual void _init() = 0;
 	virtual void _destroy() = 0;
+	virtual void _initBuffers(void) = 0;
+	virtual void _destroyBuffers(void) = 0;
 	virtual GLubyte* _getPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync) = 0;
 	virtual void _cleanUpPixels(GLubyte* pixelData) = 0;
 
@@ -37,9 +40,15 @@ private:
 		u32 raw;
 	};
 
+	void _initFBTexture(void);
+
+	void _destroyFBTexure(void);
+
 	bool _prepareCopy(u32 _startAddress);
 
 	void _copy(u32 _startAddress, u32 _endAddress, bool _sync);
+
+	u32 _getRealWidth(u32 _viWidth);
 
 	// Convert pixel from video memory to N64 buffer format.
 	static u8 _RGBAtoR8(u8 _c);
@@ -50,6 +59,11 @@ private:
 	FrameBuffer * m_pCurFrameBuffer;
 	u32 m_frameCount;
 	u32 m_startAddress;
+
+	u32 m_lastVIWidth;
+	u32 m_lastVIHeight;
+
+	std::array<u32, 3> m_allowedRealWidths;
 };
 
 void copyWhiteToRDRAM(FrameBuffer * _pBuffer);

--- a/src/BufferCopy/ColorBufferToRDRAMDesktop.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAMDesktop.cpp
@@ -13,8 +13,10 @@ private:
 	void _destroy() override;
 	GLubyte* _getPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync)  override;
 	void _cleanUpPixels(GLubyte* pixelData)  override;
-
-	GLuint m_PBO[3];
+	void _initBuffers(void) override;
+	void _destroyBuffers(void) override;
+	static const int _numPBO = 3;
+	GLuint m_PBO[_numPBO];
 	u32 m_curIndex;
 };
 
@@ -28,25 +30,42 @@ ColorBufferToRDRAMDesktop::ColorBufferToRDRAMDesktop()
 	: ColorBufferToRDRAM()
 	, m_curIndex(-1)
 {
-	m_PBO[0] = m_PBO[1] = m_PBO[2] = 0;
+	for(int index = 0; index < _numPBO; ++index)
+	{
+		m_PBO[index] = 0;
+	}
 }
 
 void ColorBufferToRDRAMDesktop::_init()
 {
-	// Generate and initialize Pixel Buffer Objects
-	glGenBuffers(3, m_PBO);
-	for (u32 i = 0; i < 3; ++i) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[i]);
-		glBufferData(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, NULL, GL_DYNAMIC_READ);
-	}
-	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+	// Generate Pixel Buffer Objects
+	glGenBuffers(_numPBO, m_PBO);
 	m_curIndex = 0;
 }
 
 void ColorBufferToRDRAMDesktop::_destroy()
 {
-	glDeleteBuffers(3, m_PBO);
-	m_PBO[0] = m_PBO[1] = m_PBO[2] = 0;
+	glDeleteBuffers(_numPBO, m_PBO);
+
+	for(int index = 0; index < _numPBO; ++index)
+	{
+		m_PBO[index] = 0;
+	}
+}
+
+void ColorBufferToRDRAMDesktop::_initBuffers(void)
+{
+	// Initialize Pixel Buffer Objects
+	for (u32 i = 0; i < _numPBO; ++i) {
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[i]);
+		glBufferData(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, NULL, GL_DYNAMIC_READ);
+	}
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+}
+
+void ColorBufferToRDRAMDesktop::_destroyBuffers(void)
+{
+
 }
 
 GLubyte* ColorBufferToRDRAMDesktop::_getPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync)
@@ -68,22 +87,30 @@ GLubyte* ColorBufferToRDRAMDesktop::_getPixels(GLint _x0, GLint _y0, GLsizei _wi
 		m_curIndex ^= 1;
 		const u32 nextIndex = m_curIndex ^ 1;
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[m_curIndex]);
-		glReadPixels(_x0, _y0, _width, _height, colorFormat, colorType, 0);
+		glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[nextIndex]);
 	} else {
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[2]);
-		glReadPixels(_x0, _y0, _width, _height, colorFormat, colorType, 0);
+		glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
 	}
 
-	GLubyte* pixelData = (GLubyte*)glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, _width * _height * colorFormatBytes, GL_MAP_READ_BIT);
+	GLubyte* pixelData = (GLubyte*)glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, m_pTexture->realWidth * _height * colorFormatBytes, GL_MAP_READ_BIT);
 	if (pixelData == NULL)
 		return NULL;
 
-	return pixelData;
+	int widthBytes = _width*colorFormatBytes;
+	int strideBytes = m_pTexture->realWidth * colorFormatBytes;
+	GLubyte* pixelDataAlloc = (GLubyte*)malloc(_width * _height * colorFormatBytes);
+	for (unsigned int lnIndex = 0; lnIndex < _height; ++lnIndex) {
+		memcpy(pixelDataAlloc + lnIndex*widthBytes, pixelData + (lnIndex*strideBytes), widthBytes);
+	}
+	return pixelDataAlloc;
 }
 
 void ColorBufferToRDRAMDesktop::_cleanUpPixels(GLubyte* pixelData)
 {
 	glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
 	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+	free(pixelData);
 }


### PR DESCRIPTION
I was finally able to get PBOs working in android. The issue is, at least with Adreno, that ```glReadPixels``` with PBOs doesn't like reading parts of the texture. The whole texture must be read, otherwise ```glReadPixels``` will end up converting the data.

Also, this doesn't mean that we should get rid of ColorBufferToRDRAMAndroid.cpp. This is because PBOs don't work with GLES 2.0 but EGLImageKHR will work with GLES 2.0 even in non-Android devices. That method will be useful when copy color to RDRAM is ported to GLES 2.0.