### PR TITLE
Fix some assertions on GLES2

### DIFF
--- a/src/GLES2/Shaders_gles2.h
+++ b/src/GLES2/Shaders_gles2.h
@@ -478,7 +478,7 @@ SHADER_VERSION
 const char * strTexrectDrawerFragmentShaderTex =
 "uniform sampler2D uTex0;																						\n"
 "uniform lowp int uEnableAlphaTest;																				\n"
-"uniform lowp vec4 uTestColor = vec4(4.0/255.0, 2.0/255.0, 1.0/255.0, 0.0);										\n"
+"lowp vec4 uTestColor = vec4(4.0/255.0, 2.0/255.0, 1.0/255.0, 0.0);										\n"
 "IN mediump vec2 vTexCoord0;																					\n"
 "OUT lowp vec4 fragColor;																						\n"
 "void main()																									\n"
@@ -492,7 +492,7 @@ const char * strTexrectDrawerFragmentShaderTex =
 
 const char * strTexrectDrawerFragmentShaderClean =
 SHADER_VERSION
-"uniform lowp vec4 uTestColor = vec4(4.0/255.0, 2.0/255.0, 1.0/255.0, 0.0);	\n"
+"lowp vec4 uTestColor = vec4(4.0/255.0, 2.0/255.0, 1.0/255.0, 0.0);	\n"
 "void main()																\n"
 "{																			\n"
 "  gl_FragColor = uTestColor;												\n"

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -399,8 +399,10 @@ void OGLRender::TexrectDrawer::init()
 	assert(m_textureBoundsLoc >= 0);
 	m_enableAlphaTestLoc = glGetUniformLocation(m_programTex, "uEnableAlphaTest");
 	assert(m_enableAlphaTestLoc >= 0);
+#ifndef GLES2
 	m_depthScaleLoc = glGetUniformLocation(m_programTex, "uDepthScale");
 	assert(m_depthScaleLoc >= 0);
+#endif
 	glUseProgram(0);
 
 	m_vecRectCoords.reserve(256);


### PR DESCRIPTION
GLSL ES 1.00 doesn't like when you initialize a uniform, and uDepthScale is never used in GLES2, and it was giving me an assertion error