### PR TITLE
Fix Texture Cache on Raspberry Pi

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -522,6 +522,16 @@ void TextureCache::destroy()
 
 void TextureCache::_checkCacheSize()
 {
+#ifdef VC
+	if (m_textures.size() > 15000) {
+		CachedTexture& piTex = m_textures.back();
+		m_cachedBytes -= piTex.textureBytes;
+		glDeleteTextures(1, &piTex.glName);
+		m_lruTextureLocations.erase(piTex.crc);
+		m_textures.pop_back();
+	}
+#endif
+
 	if (m_cachedBytes <= m_maxBytes)
 		return;
 


### PR DESCRIPTION
The Raspberry Pi only supports 32768 GPU memory allocations
see https://github.com/raspberrypi/firmware/issues/611

Each texture takes 2 allocs, so the max is around 16000, I've set it to 15000 to be safe

Fixes https://github.com/gonetz/GLideN64/issues/1015

It still seems odd that games are allocating so many textures, they must be duplicates. If there is a better way to solve this problem I am open to it. I can't notice any performance difference once it goes over the 15000 limit (tested GoldenEye and Worms Armageddon)