### PR TITLE
Allowing building GLideNHQ using GLES2

### DIFF
--- a/src/GLideNHQ/CMakeLists.txt
+++ b/src/GLideNHQ/CMakeLists.txt
@@ -27,6 +27,12 @@ else(PANDORA OR BCMHOST)
 endif(PANDORA OR BCMHOST)
 LINK_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/lib )
 
+if(GLES2)
+  add_definitions(
+    -DGLES2
+   )
+endif(GLES2)
+
 if(UNIX)
   add_definitions(
     -DNDEBUG

--- a/src/GLideNHQ/TxInternal.h
+++ b/src/GLideNHQ/TxInternal.h
@@ -40,6 +40,9 @@
 #elif defined(GLES2)
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#ifndef GL_RGBA8
+#define GL_RGBA8 0x8058
+#endif
 #define GL_COLOR_INDEX8_EXT  0x80E5
 #elif defined(GLES3)
 #include <GLES3/gl3.h>


### PR DESCRIPTION
Currently, the GLideNHQ CMake setup doesn't check for GLES2, so GLES2 devices need gl.h in order to build. This fixes that.