### PR TITLE
Fix framebuffer emulation issues in Raspberry pi and PowerVR devices

### DIFF
--- a/src/OGL3X/UniformBlock.cpp
+++ b/src/OGL3X/UniformBlock.cpp
@@ -148,7 +148,9 @@ void UniformBlock::setColorData(ColorUniforms _index, u32 _dataSize, const void 
 		glBindBuffer(GL_UNIFORM_BUFFER, m_colorsBlock.m_buffer);
 	}
 
-	if (m_renderer != OGLRender::glrAdreno)
+	if (m_renderer != OGLRender::glrAdreno &&
+		m_renderer != OGLRender::glrPowerVR &&
+		m_renderer != OGLRender::glrMali)
 		glBufferSubData(GL_UNIFORM_BUFFER, m_colorsBlock.m_offsets[_index], _dataSize, _data);
 	else
 		glBufferData(GL_UNIFORM_BUFFER, m_colorsBlockData.size(), m_colorsBlockData.data(), GL_STATIC_DRAW);
@@ -159,7 +161,8 @@ void UniformBlock::updateTextureParameters()
 	if (m_textureBlock.m_buffer == 0)
 		return;
 
-	GLbyte * pData = m_textureBlockData.data();
+	std::vector<GLbyte> temp(m_textureBlockData.size(), 0);
+	GLbyte * pData = temp.data();
 	f32 texScale[4] = { gSP.texture.scales, gSP.texture.scalet, 0, 0 };
 	memcpy(pData + m_textureBlock.m_offsets[tuTexScale], texScale, m_textureBlock.m_offsets[tuTexOffset] - m_textureBlock.m_offsets[tuTexScale]);
 
@@ -231,10 +234,17 @@ void UniformBlock::updateTextureParameters()
 		glBindBuffer(GL_UNIFORM_BUFFER, m_textureBlock.m_buffer);
 	}
 
-	if (m_renderer != OGLRender::glrAdreno)
-		glBufferSubData(GL_UNIFORM_BUFFER, m_textureBlock.m_offsets[tuTexScale], m_textureBlockData.size(), pData);
-	else
-		glBufferData(GL_UNIFORM_BUFFER, m_textureBlockData.size(), m_textureBlockData.data(), GL_STATIC_DRAW);
+	
+	if(temp != m_textureBlockData)
+	{
+		m_textureBlockData = temp;
+		if (m_renderer != OGLRender::glrAdreno &&
+			m_renderer != OGLRender::glrPowerVR &&
+			m_renderer != OGLRender::glrMali)
+			glBufferSubData(GL_UNIFORM_BUFFER, m_textureBlock.m_offsets[tuTexScale], m_textureBlockData.size(), pData);
+		else
+			glBufferData(GL_UNIFORM_BUFFER, m_textureBlockData.size(), m_textureBlockData.data(), GL_STATIC_DRAW);
+	}
 }
 
 void UniformBlock::updateLightParameters()
@@ -253,7 +263,9 @@ void UniformBlock::updateLightParameters()
 		glBindBuffer(GL_UNIFORM_BUFFER, m_lightBlock.m_buffer);
 	}
 
-	if (m_renderer != OGLRender::glrAdreno)
+	if (m_renderer != OGLRender::glrAdreno &&
+		m_renderer != OGLRender::glrPowerVR &&
+		m_renderer != OGLRender::glrMali)
 		glBufferSubData(GL_UNIFORM_BUFFER, m_lightBlock.m_offsets[luLightDirection], m_lightBlockData.size(), pData);
 	else
 		glBufferData(GL_UNIFORM_BUFFER, m_lightBlockData.size(), m_lightBlockData.data(), GL_STATIC_DRAW);

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -1723,6 +1723,10 @@ void OGLRender::_initExtensions()
 	const GLubyte * strRenderer = glGetString(GL_RENDERER);
 	if (strstr((const char*)strRenderer, "Adreno") != nullptr)
 		m_oglRenderer = glrAdreno;
+	else if (strstr((const char*)strRenderer, "PowerVR") != nullptr)
+		m_oglRenderer = glrPowerVR;
+	else if (strstr((const char*)strRenderer, "Mali") != nullptr)
+		m_oglRenderer = glrMali;
 	LOG(LOG_VERBOSE, "OpenGL renderer: %s\n", strRenderer);
 
 	fboFormats.init();

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -165,7 +165,9 @@ public:
 
 	enum OGL_RENDERER {
 		glrOther,
-		glrAdreno
+		glrAdreno,
+		glrPowerVR,
+		glrMali
 	};
 	OGL_RENDERER getRenderer() const { return m_oglRenderer; }
 


### PR DESCRIPTION
These changes seem to fix frame buffer emulation in Raspberry Pi and PowerVR devices.

The glClear fixes PowerVR
The depth buffer invalidate fixes Raspberry Pi.

Edit: Added additional commit that speeds up PowerVR.