### PR TITLE
Enable Framebuffer Emulation on the Raspberry Pi

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ if(EXISTS "/opt/vc/include/bcm_host.h")
   set(GLES2 ON)
   add_definitions(
     -DVC
+    -DUSE_DEPTH_RENDERBUFFER
   )
   include_directories(
     "/opt/vc/include"

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -43,11 +43,7 @@ void Config::resetToDefaults()
 	generalEmulation.polygonOffsetUnits = 0.0f;
 #endif
 
-#ifdef VC
-	frameBufferEmulation.enable = 0;
-#else
 	frameBufferEmulation.enable = 1;
-#endif
 	frameBufferEmulation.copyDepthToRDRAM = cdDisable;
 	frameBufferEmulation.copyFromRDRAM = 0;
 	frameBufferEmulation.copyAuxToRDRAM = 0;

--- a/src/DepthBuffer.h
+++ b/src/DepthBuffer.h
@@ -25,6 +25,8 @@ struct DepthBuffer
 	GLuint m_depthImageFBO;
 	CachedTexture *m_pDepthImageTexture;
 	CachedTexture *m_pDepthBufferTexture;
+	GLuint m_depthRenderbuffer;
+	u32 m_depthRenderbufferWidth;
 	bool m_cleared;
 	// multisampling
 	CachedTexture *m_pResolveDepthBufferTexture;
@@ -36,6 +38,7 @@ struct DepthBuffer
 
 private:
 	void _initDepthBufferTexture(FrameBuffer * _pBuffer, CachedTexture *_pTexture, bool _multisample);
+	void _initDepthBufferRenderbuffer(FrameBuffer * _pBuffer);
 	void _DepthBufferTexture(FrameBuffer * _pBuffer);
 };
 

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -707,16 +707,24 @@ void FrameBufferList::attachDepthBuffer()
 {
 	if (m_pCurrent == nullptr)
 		return;
+#ifdef VC
+	const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
+	glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
+#endif
 
 	DepthBuffer * pDepthBuffer = depthBufferList().getCurrent();
 	if (m_pCurrent->m_FBO > 0 && pDepthBuffer != nullptr) {
 		pDepthBuffer->initDepthImageTexture(m_pCurrent);
 		pDepthBuffer->initDepthBufferTexture(m_pCurrent);
+#ifndef USE_DEPTH_RENDERBUFFER
 #ifdef GLES2
 		if (pDepthBuffer->m_pDepthBufferTexture->realWidth == m_pCurrent->m_pTexture->realWidth) {
 #else
 		if (pDepthBuffer->m_pDepthBufferTexture->realWidth >= m_pCurrent->m_pTexture->realWidth) {
-#endif
+#endif // GLES2
+#else
+		if (pDepthBuffer->m_depthRenderbufferWidth == m_pCurrent->m_pTexture->realWidth) {
+#endif // USE_DEPTH_RENDERBUFFER
 			m_pCurrent->m_pDepthBuffer = pDepthBuffer;
 			pDepthBuffer->setDepthAttachment(GL_DRAW_FRAMEBUFFER);
 			if (video().getRender().isImageTexturesSupported() && config.frameBufferEmulation.N64DepthCompare != 0)

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -15,6 +15,7 @@
 #include <GLideN64_libretro.h>
 #elif GLES2
 #include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
 #define GL_DRAW_FRAMEBUFFER GL_FRAMEBUFFER
 #define GL_READ_FRAMEBUFFER GL_FRAMEBUFFER
 #define NO_BLIT_BUFFER_COPY


### PR DESCRIPTION
renderbuffer code was written by gonetz, not me

Since https://github.com/gonetz/GLideN64/pull/1031 isn't quite ready to merge I though I'd submit this, since it's scope is a little different.

I have tested this using Perfect Park, Pokemon Stadium, Legend of Zelda: OoT and it all works very well.