### PR TITLE
Fix internal depth format for GLES 2.0 Android devices

### DIFF
--- a/src/FBOTextureFormats.cpp
+++ b/src/FBOTextureFormats.cpp
@@ -10,10 +10,16 @@ void FBOTextureFormats::init()
 	monochromeType = GL_UNSIGNED_SHORT_5_6_5;
 	monochromeFormatBytes = 2;
 
+#ifndef VC
+	depthInternalFormat = GL_DEPTH_COMPONENT;
+	depthFormatBytes = 4;
+#else
 	depthInternalFormat = GL_DEPTH_COMPONENT16;
+	depthFormatBytes = 2;
+#endif
+
 	depthFormat = GL_DEPTH_COMPONENT;
 	depthType = GL_UNSIGNED_INT;
-	depthFormatBytes = 2;
 
 	if (OGLVideo::isExtensionSupported("GL_OES_rgb8_rgba8")) {
 		colorInternalFormat = GL_RGBA;


### PR DESCRIPTION
Fix internal depth format some GLES 2.0 Android devices. This change was originally made for Raspberry Pi, but it doesn't work with all Android GLES 2.0 devices.

Instead I added an #ifdef for VC