### PR TITLE
PowerVR performance improvement

### DIFF
--- a/src/OGL3X/UniformBlock.cpp
+++ b/src/OGL3X/UniformBlock.cpp
@@ -31,7 +31,8 @@ const char * strLightUniforms[UniformBlock::luTotal] = {
 	"uLightColor"
 };
 
-UniformBlock::UniformBlock() : m_currentBuffer(0), m_renderer(video().getRender().getRenderer())
+UniformBlock::UniformBlock() : m_currentBuffer(0),
+	m_isBufferSubDataSupported(video().getRender().isBufferSubDataSupported())
 {
 }
 
@@ -148,7 +149,7 @@ void UniformBlock::setColorData(ColorUniforms _index, u32 _dataSize, const void 
 		glBindBuffer(GL_UNIFORM_BUFFER, m_colorsBlock.m_buffer);
 	}
 
-	if (m_renderer != OGLRender::glrAdreno)
+	if (m_isBufferSubDataSupported)
 		glBufferSubData(GL_UNIFORM_BUFFER, m_colorsBlock.m_offsets[_index], _dataSize, _data);
 	else
 		glBufferData(GL_UNIFORM_BUFFER, m_colorsBlockData.size(), m_colorsBlockData.data(), GL_STATIC_DRAW);
@@ -159,7 +160,8 @@ void UniformBlock::updateTextureParameters()
 	if (m_textureBlock.m_buffer == 0)
 		return;
 
-	GLbyte * pData = m_textureBlockData.data();
+	std::vector<GLbyte> temp(m_textureBlockData.size(), 0);
+	GLbyte * pData = temp.data();
 	f32 texScale[4] = { gSP.texture.scales, gSP.texture.scalet, 0, 0 };
 	memcpy(pData + m_textureBlock.m_offsets[tuTexScale], texScale, m_textureBlock.m_offsets[tuTexOffset] - m_textureBlock.m_offsets[tuTexScale]);
 
@@ -230,11 +232,15 @@ void UniformBlock::updateTextureParameters()
 		m_currentBuffer = m_textureBlock.m_buffer;
 		glBindBuffer(GL_UNIFORM_BUFFER, m_textureBlock.m_buffer);
 	}
-
-	if (m_renderer != OGLRender::glrAdreno)
-		glBufferSubData(GL_UNIFORM_BUFFER, m_textureBlock.m_offsets[tuTexScale], m_textureBlockData.size(), pData);
-	else
-		glBufferData(GL_UNIFORM_BUFFER, m_textureBlockData.size(), m_textureBlockData.data(), GL_STATIC_DRAW);
+	
+	if(temp != m_textureBlockData)
+	{
+		m_textureBlockData = temp;
+		if (m_isBufferSubDataSupported)
+			glBufferSubData(GL_UNIFORM_BUFFER, m_textureBlock.m_offsets[tuTexScale], m_textureBlockData.size(), pData);
+		else
+			glBufferData(GL_UNIFORM_BUFFER, m_textureBlockData.size(), m_textureBlockData.data(), GL_STATIC_DRAW);
+	}
 }
 
 void UniformBlock::updateLightParameters()
@@ -253,7 +259,7 @@ void UniformBlock::updateLightParameters()
 		glBindBuffer(GL_UNIFORM_BUFFER, m_lightBlock.m_buffer);
 	}
 
-	if (m_renderer != OGLRender::glrAdreno)
+	if (m_isBufferSubDataSupported)
 		glBufferSubData(GL_UNIFORM_BUFFER, m_lightBlock.m_offsets[luLightDirection], m_lightBlockData.size(), pData);
 	else
 		glBufferData(GL_UNIFORM_BUFFER, m_lightBlockData.size(), m_lightBlockData.data(), GL_STATIC_DRAW);

--- a/src/OGL3X/UniformBlock.h
+++ b/src/OGL3X/UniformBlock.h
@@ -63,7 +63,7 @@ private:
 	};
 
 	GLuint m_currentBuffer;
-	OGLRender::OGL_RENDERER m_renderer;
+	bool m_isBufferSubDataSupported;
 
 	UniformBlockData<tuTotal, 1> m_textureBlock;
 	UniformBlockData<cuTotal, 2> m_colorsBlock;

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -1723,7 +1723,15 @@ void OGLRender::_initExtensions()
 	const GLubyte * strRenderer = glGetString(GL_RENDERER);
 	if (strstr((const char*)strRenderer, "Adreno") != nullptr)
 		m_oglRenderer = glrAdreno;
+	else if (strstr((const char*)strRenderer, "PowerVR") != nullptr)
+		m_oglRenderer = glrPowerVR;
+	else if (strstr((const char*)strRenderer, "Mali") != nullptr)
+		m_oglRenderer = glrMali;
 	LOG(LOG_VERBOSE, "OpenGL renderer: %s\n", strRenderer);
+
+	m_isBufferSubDataSupported = m_oglRenderer != OGLRender::glrAdreno &&
+		m_oglRenderer != OGLRender::glrPowerVR &&
+		m_oglRenderer != OGLRender::glrMali;
 
 	fboFormats.init();
 

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -165,9 +165,13 @@ public:
 
 	enum OGL_RENDERER {
 		glrOther,
-		glrAdreno
+		glrAdreno,
+		glrPowerVR,
+		glrMali
 	};
 	OGL_RENDERER getRenderer() const { return m_oglRenderer; }
+
+	bool isBufferSubDataSupported() const {return m_isBufferSubDataSupported;}
 
 	void dropRenderState() {m_renderState = rsNone;}
 
@@ -176,7 +180,8 @@ private:
 		: m_oglRenderer(glrOther)
 		, m_modifyVertices(0)
 		, m_bImageTexture(false)
-		, m_bFlatColors(false) {
+		, m_bFlatColors(false)
+		, m_isBufferSubDataSupported(true){
 	}
 	OGLRender(const OGLRender &);
 	friend class OGLVideo;
@@ -259,6 +264,8 @@ private:
 	TexrectDrawer m_texrectDrawer;
 
 	GLuint m_programCopyTex;
+
+	bool m_isBufferSubDataSupported;
 };
 
 class OGLVideo


### PR DESCRIPTION
Use BufferData instead of BufferSubData for PowerVR.

Also, only update texture uniform block if it has changed.