### PR TITLE
Don't load textures so much (GLES2)

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -835,8 +835,6 @@ void TextureCache::_loadBackground(CachedTexture *pTexture)
 		} else {
 			Textures::iterator iter = locations_iter->second;
 			glDeleteTextures(1, &pTexture->glName);
-			m_lruTextureLocations.erase(pTexture->crc);
-			m_textures.pop_front();
 			*pTexture = *iter;
 			m_cachedBytes -= pTexture->textureBytes;
 		}
@@ -1146,8 +1144,6 @@ void TextureCache::_load(u32 _tile, CachedTexture *_pTexture)
 			} else {
 				Textures::iterator iter = locations_iter->second;
 				glDeleteTextures(1, &_pTexture->glName);
-				m_lruTextureLocations.erase(_pTexture->crc);
-				m_textures.pop_front();
 				*_pTexture = *iter;
 				m_cachedBytes -= _pTexture->textureBytes;
 			}

--- a/src/Textures.h
+++ b/src/Textures.h
@@ -90,6 +90,7 @@ private:
 	typedef std::map<u32, CachedTexture> FBTextures;
 	Textures m_textures;
 	Texture_Locations m_lruTextureLocations;
+	Texture_Locations pDest_Locations;
 	FBTextures m_fbTextures;
 	CachedTexture * m_pDummy;
 	CachedTexture * m_pMSDummy;


### PR DESCRIPTION
I've tested this and it seems to work quite well. If you put a counter inside the else{} block you'll see that this happens quite a bit (finding duplicate textures).

It's only enabled for GLES2 right now, and only for regular textures (not highres/filtered), because I only have a GLES2 device to test.

Basically, glTexImage2D is a very expensive call, and it seems to be happening for duplicate textures. The CRC calculations aren't perfect, but they can happen very early so they are helpful. This happens further along the process, once we know the value of pDest. If it determines that pDest is a duplicate, it will "back out" of the texture loading, and just switch to using the "original" texture, thus saving us from having to do glTexImage2D.

They only thing left to implement is deleting the pDest_Locations value inside _checkCacheSize(), to do that I need to add a value to the CachedTexture struct, but it segfaults when I do that, I'm guessing the size of CachedTexture is being assumed somewhere?

I'm hoping someone else can test this to check for any texture corruption/issues. @fzurita I'm especially curious how this does on mobile devices, just anecdotally, the performance in GoldenEye seems to be much better (I need to figure out how to measure FPS on the Raspberry Pi).