### PR TITLE
Fixes crash at GoldenEye startup

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -84,8 +84,6 @@ void ColorBufferToRDRAM::_initFBTexture(void)
 
 void ColorBufferToRDRAM::_destroyFBTexure(void)
 {
-	_destroyBuffers();
-
 	if (m_pTexture != nullptr) {
 		textureCache().removeFrameBufferTexture(m_pTexture);
 		m_pTexture = nullptr;

--- a/src/BufferCopy/ColorBufferToRDRAM.h
+++ b/src/BufferCopy/ColorBufferToRDRAM.h
@@ -31,7 +31,6 @@ private:
 	virtual void _init() = 0;
 	virtual void _destroy() = 0;
 	virtual void _initBuffers(void) = 0;
-	virtual void _destroyBuffers(void) = 0;
 	virtual bool _readPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync) = 0;
 	virtual void _cleanUp() = 0;
 

--- a/src/BufferCopy/ColorBufferToRDRAM_GL.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM_GL.cpp
@@ -15,7 +15,6 @@ private:
 	bool _readPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync)  override;
 	void _cleanUp()  override;
 	void _initBuffers(void) override;
-	void _destroyBuffers(void) override;
 	static const int _numPBO = 3;
 	GLuint m_PBO[_numPBO];
 	u32 m_curIndex;
@@ -58,10 +57,6 @@ void ColorBufferToRDRAM_GL::_initBuffers(void)
 		glBufferData(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, nullptr, GL_DYNAMIC_READ);
 	}
 	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-}
-
-void ColorBufferToRDRAM_GL::_destroyBuffers(void)
-{
 }
 
 bool ColorBufferToRDRAM_GL::_readPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync)

--- a/src/BufferCopy/ColorBufferToRDRAM_GLES.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM_GLES.cpp
@@ -26,7 +26,6 @@ private:
 	bool _readPixels(GLint _x0, GLint _y0, GLsizei _width, GLsizei _height, u32 _size, bool _sync)  override;
 	void _cleanUp()  override;
 	void _initBuffers(void) override;
-	void _destroyBuffers(void) override;
 
 	GraphicBuffer* m_window;
 	EGLImageKHR m_image;
@@ -62,16 +61,11 @@ void ColorBufferToRDRAM_GLES::_initBuffers(void)
 	m_window->reallocate(m_pTexture->realWidth, m_pTexture->realHeight,
 		PIXEL_FORMAT_RGBA_8888, GraphicBuffer::USAGE_SW_READ_OFTEN | GraphicBuffer::USAGE_HW_TEXTURE);
 	EGLint eglImgAttrs[] = { EGL_IMAGE_PRESERVED_KHR, EGL_TRUE, EGL_NONE, EGL_NONE };
-	m_image = eglCreateImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_NO_CONTEXT,
-		EGL_NATIVE_BUFFER_ANDROID, (EGLClientBuffer)m_window->getNativeBuffer(), eglImgAttrs);
-}
 
-void ColorBufferToRDRAM_GLES::_destroyBuffers(void)
-{
-	if(m_image != 0)
+	if(m_image == 0)
 	{
-	    eglDestroyImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), m_image);
-	    m_image = 0;
+		m_image = eglCreateImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_NO_CONTEXT,
+			EGL_NATIVE_BUFFER_ANDROID, (EGLClientBuffer)m_window->getNativeBuffer(), eglImgAttrs);
 	}
 }
 


### PR DESCRIPTION
It seems that once the EGLImageKHR buffer is created, it's then managed by Android itself, so it's a bad idea to destroy it.

This fixes a crash in GoldenEye startup.