### PR TITLE
Faster and less strict CRC calculator

### DIFF
--- a/src/CRC.cpp
+++ b/src/CRC.cpp
@@ -6,77 +6,79 @@ unsigned int CRCTable[ 256 ];
 
 u32 Reflect( u32 ref, char ch )
 {
-	 u32 value = 0;
+	u32 value = 0;
 
-	 // Swap bit 0 for bit 7
-	 // bit 1 for bit 6, etc.
-	 for (int i = 1; i < (ch + 1); ++i) {
-		  if(ref & 1)
+	// Swap bit 0 for bit 7
+	// bit 1 for bit 6, etc.
+	for (int i = 1; i < (ch + 1); i++)
+	{
+		if(ref & 1)
 			value |= 1 << (ch - i);
-		  ref >>= 1;
-	 }
-	 return value;
+		ref >>= 1;
+	}
+	return value;
 }
 
 void CRC_BuildTable()
 {
 	u32 crc;
 
-	for (int i = 0; i < 256; ++i) {
+	for (int i = 0; i < 256; i++)
+	{
 		crc = Reflect( i, 8 ) << 24;
-		for (int j = 0; j < 8; ++j)
+		for (int j = 0; j < 8; j++)
 			crc = (crc << 1) ^ (crc & (1 << 31) ? CRC32_POLYNOMIAL : 0);
 
 		CRCTable[i] = Reflect( crc, 32 );
 	}
 }
 
-u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
+u32 CRC_Calculate(void *buffer, u32 count)
 {
 	u8 *p;
-	u32 orig = crc;
+	u32 crc = 0xffffffff;
 
 	p = (u8*) buffer;
+
 	while (count--)
 		crc = (crc >> 8) ^ CRCTable[(crc & 0xFF) ^ *p++];
 
-	return crc ^ orig;
+	return ~crc;
 }
 
-u32 CRC_CalculatePalette(u32 crc, const void * buffer, u32 count )
+u32 Hash_CalculatePalette(void *buffer, u32 count)
 {
-	u8 *p;
-	u32 orig = crc;
+	unsigned int i;
+	u16 *data = (u16 *) buffer;
+	u32 hash = 0xffffffff;
 
-	p = (u8*) buffer;
-	while (count--) {
-		crc = (crc >> 8) ^ CRCTable[(crc & 0xFF) ^ *p++];
-		crc = (crc >> 8) ^ CRCTable[(crc & 0xFF) ^ *p++];
-
-		p += 6;
+	count /= 4;
+	for(i = 0; i < count; ++i) {
+		hash += data[i << 2];
+		hash += (hash << 10);
+		hash ^= (hash >> 6);
 	}
 
-	return crc ^ orig;
+	hash += (hash << 3);
+	hash ^= (hash >> 11);
+	hash += (hash << 15);
+	return hash;
 }
 
-u32 textureCRC(u8 * addr, u32 height, u32 stride)
+u32 Hash_Calculate(u32 hash, void *buffer, u32 count)
 {
-	const u32 width = stride / 8;
-	const u32 line = stride % 8;
-	u64 crc = 0;
-	u64 twopixel_crc;
+	unsigned int i;
+	u32 *data = (u32 *) buffer;
 
-	u32 *  pixelpos = (u32*)addr;
-	for (; height; height--) {
-		int col = 0;
-		for (u32 i = width; i; --i) {
-			twopixel_crc = i * ((u64)(pixelpos[1] & 0xFFFEFFFE) + (u64)(pixelpos[0] & 0xFFFEFFFE) + crc);
-			crc = (twopixel_crc >> 32) + twopixel_crc;
-			pixelpos += 2;
-		}
-		crc = (height * crc >> 32) + height * crc;
-		pixelpos = (u32*)((u8*)pixelpos + line);
+	count /= 4;
+	for(i = 0; i < count; ++i) {
+		hash += data[i];
+		hash += (hash << 10);
+		hash ^= (hash >> 6);
 	}
 
-	return crc&0xFFFFFFFF;
+	hash += (hash << 3);
+	hash ^= (hash >> 11);
+	hash += (hash << 15);
+	return hash;
 }

--- a/src/CRC.h
+++ b/src/CRC.h
@@ -2,8 +2,7 @@
 
 void CRC_BuildTable();
 
-// CRC32
-u32 CRC_Calculate( u32 crc, const void *buffer, u32 count );
-u32 CRC_CalculatePalette( u32 crc, const void *buffer, u32 count );
-// Fast checksum calculation from Glide64
-u32 textureCRC(u8 * addr, u32 height, u32 stride);
+u32 CRC_Calculate(void *buffer, u32 count);
+u32 Hash_CalculatePalette(void *buffer, u32 count);
+u32 Hash_Calculate(u32 hash, void *buffer, u32 count);
+

--- a/src/GBI.cpp
+++ b/src/GBI.cpp
@@ -241,7 +241,7 @@ void GBIInfo::loadMicrocode(u32 uc_start, u32 uc_dstart, u16 uc_dsize)
 	current.type = NONE;
 
 	// See if we can identify it by CRC
-	const u32 uc_crc = CRC_Calculate( 0xFFFFFFFF, &RDRAM[uc_start & 0x1FFFFFFF], 4096 );
+	const u32 uc_crc = CRC_Calculate( &RDRAM[uc_start & 0x1FFFFFFF], 4096 );
 	const u32 numSpecialMicrocodes = sizeof(specialMicrocodes) / sizeof(SpecialMicrocodeInfo);
 	for (u32 i = 0; i < numSpecialMicrocodes; ++i) {
 		if (uc_crc == specialMicrocodes[i].crc) {

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -682,11 +682,11 @@ void gDPLoadTLUT( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt )
 			dest += 4;
 		}
 
-		gDP.paletteCRC16[pal] = CRC_CalculatePalette(0xFFFFFFFF, &TMEM[256 + (pal << 4)], 16);
+		gDP.paletteCRC16[pal] = Hash_CalculatePalette(&TMEM[256 + (pal << 4)], 16);
 		++pal;
 	}
 
-	gDP.paletteCRC256 = CRC_Calculate(0xFFFFFFFF, gDP.paletteCRC16, 64);
+	gDP.paletteCRC256 = Hash_Calculate(0xFFFFFFFF, gDP.paletteCRC16, 64);
 
 	if (TFH.isInited()) {
 		const u16 start = gDP.tiles[tile].tmem - 256; // starting location in the palettes


### PR DESCRIPTION
Taken from https://github.com/ricrpi/mupen64plus-video-gles2n64

Fixes some issues noted in https://github.com/gonetz/GLideN64/issues/1015

I've tested this and I can't see any texture corruption, but i welcome othet testing. This fixes many (but not all) duplicate textures I noticed in issue #1015 

According to @gizmo98 (https://github.com/ricrpi/mupen64plus-video-gles2n64/commit/4ab0d6fe39fc8ffee4de2a4ad8f57b8b39250de1) this should be much faster, that combined with the fact that we aren't loading as many duplicate textures should provide performance improvements. GoldenEye amd Smash Bros seem a little snappier to me using this, but that might be in my head.