### PR TITLE
Fix link dirs on Raspberry Pi

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ if(EXISTS "/opt/vc/include/bcm_host.h")
   )
   link_directories(
     "/opt/vc/lib"
+    "/opt/vc/lib/GL"
   )
 else(EXISTS "/opt/vc/include/bcm_host.h")
   MESSAGE("bcm_host.h not found")


### PR DESCRIPTION
The latest Raspberry Pi firmware puts some library files inside a "GL" folder.