### PR TITLE
Fixes corrupt graphics in PowerVR

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -398,7 +398,10 @@ void DepthBufferList::saveBuffer(u32 _address)
 
 		m_pCurrent = &buffer;
 	}
-
+#ifdef ANDROID
+	//Fixes issues with PowerVR devices and potentially other Android devices
+	glClear( GL_DEPTH_BUFFER_BIT );
+#endif
 	frameBufferList().attachDepthBuffer();
 
 #ifdef DEBUG


### PR DESCRIPTION
Gonetz, would this be an ok place to clear the depth buffer without negatively affecting the N64 depth buffer? This fixes PowerVR graphics as well.