### PR TITLE
Fix some more graphical glitches with FBE on the Raspberry Pi

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -160,6 +160,10 @@ void FrameBuffer::init(u32 _address, u32 _endAddress, u16 _format, u16 _size, u1
 	m_fingerprint = false;
 
 	_initTexture(_width, _height, _format, _size, m_pTexture);
+#ifdef VC
+	const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
+	glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
+#endif
 	glBindFramebuffer(GL_FRAMEBUFFER, m_FBO);
 
 #ifdef GL_MULTISAMPLING_SUPPORT
@@ -590,6 +594,10 @@ void FrameBufferList::saveBuffer(u32 _address, u16 _format, u16 _size, u16 _widt
 			m_pCurrent = nullptr;
 		} else {
 			m_pCurrent->m_resolved = false;
+#ifdef VC
+			const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
+			glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
+#endif
 			glBindFramebuffer(GL_FRAMEBUFFER, m_pCurrent->m_FBO);
 			if (m_pCurrent->m_size != _size) {
 				f32 fillColor[4];


### PR DESCRIPTION
On the Raspberry Pi some games were still experiencing issues as described in:

https://github.com/gonetz/GLideN64/issues/1011

For instance:
https://github.com/RetroPie/RetroPie-Setup/pull/1563
https://github.com/gonetz/GLideN64/pull/1043#issuecomment-230656938

Adding these lines clears up all the graphical glitches. All 3 instances (these 2 and the original one) of ```glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);``` are required or some portion of the screen won't display correctly.