### PR TITLE
Add optimized CRC calculator when OPT is on

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,6 +181,12 @@ if(OPT)
   add_definitions(
     -D__VEC4_OPT
   )
+  list(APPEND GLideN64_SOURCES
+    CRC_OPT.cpp
+  )
+  list(REMOVE_ITEM GLideN64_SOURCES
+    CRC.cpp
+  )
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
     STRING(REGEX REPLACE "^.*(neon).*$" "\\1" NEON_THERE ${CPUINFO})

--- a/src/CRC_OPT.cpp
+++ b/src/CRC_OPT.cpp
@@ -1,0 +1,41 @@
+#include "Types.h"
+
+void CRC_BuildTable()
+{
+}
+
+u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
+{
+        unsigned int i;
+        u32 *data = (u32 *) buffer;
+
+        count /= 4;
+        for(i = 0; i < count; ++i) {
+                crc += data[i];
+                crc += (crc << 10);
+                crc ^= (crc >> 6);
+        }
+
+        crc += (crc << 3);
+        crc ^= (crc >> 11);
+        crc += (crc << 15);
+        return crc;
+}
+
+u32 CRC_CalculatePalette( u32 crc, const void * buffer, u32 count )
+{
+	unsigned int i;
+	u16 *data = (u16 *) buffer;
+
+	count /= 4;
+	for(i = 0; i < count; ++i) {
+		crc += data[i << 2];
+		crc += (crc << 10);
+		crc ^= (crc >> 6);
+	}
+
+	crc += (crc << 3);
+	crc ^= (crc >> 11);
+	crc += (crc << 15);
+	return crc;
+}


### PR DESCRIPTION
Since this algorithm hasn't been tested extensively I thought it would make sense to only enable it if OPT is on.

Original discussion about this change was here:

https://github.com/gonetz/GLideN64/pull/1043

In my testing on the Raspberry Pi this resulted in a reduction in CPU usage of about 6-7%.

@gonetz If you would prefer that this be enabled just for ARM systems instead of OPT I'm fine with that as well.