### PR TITLE
cmake: separate optimization options

### DIFF
--- a/projects/cmake/Readme.txt
+++ b/projects/cmake/Readme.txt
@@ -1,9 +1,10 @@
 cmake project files located inside src folder. To build the project with cmake, run
 
-cmake [-DCMAKE_BUILD_TYPE=Debug] [-DOPT=On] [-DNOHQ=On] [-DUSE_UNIFORMBLOCK=On] -DMUPENPLUSAPI=On ../../src/
+cmake [-DCMAKE_BUILD_TYPE=Debug] [-DVEC4_OPT=On] [-DCRC_OPT=On] [-DNEON_OPT=On] [-DNOHQ=On] [-DUSE_UNIFORMBLOCK=On] -DMUPENPLUSAPI=On ../../src/
 
 -DCMAKE_BUILD_TYPE=Debug - optional parameter, if you want debug build. Default buid type is Release
--DOPT=On - optional parameter. set it if you want to enable additional optimizations (can cause additional bugs).
--DNOHQ=On - build without realtime texture enhancer library (GLideNHQ)
+-DVEC4_OPT=On  - optional parameter. set it if you want to enable additional VEC4 optimization (can cause additional bugs).
+-DCRC_OPT=On  - optional parameter. set it if you want to enable additional CRC optimization (can cause additional bugs).
+-DNEON_OPT=On - optional parameter. set it if you want to enable additional ARM NEON optimization (can cause additional bugs).-DNOHQ=On - build without realtime texture enhancer library (GLideNHQ)
 -DUSE_UNIFORMBLOCK=On - Use uniform blocks in shaders. May help to improve performance. Not supported by GLES2 hardware.
 -DMUPENPLUSAPI=On - currently cmake build works only for mupen64plus version of the plugin.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,16 +177,22 @@ endif(UNIX OR BCMHOST)
 FIND_PACKAGE( Freetype REQUIRED )
 include_directories( ${FREETYPE_INCLUDE_DIRS} )
 
-if(OPT)
+if(VEC4_OPT)
   add_definitions(
     -D__VEC4_OPT
   )
+endif(VEC4_OPT)
+
+if(CRC_OPT)
   list(APPEND GLideN64_SOURCES
     CRC_OPT.cpp
   )
   list(REMOVE_ITEM GLideN64_SOURCES
     CRC.cpp
   )
+endif(CRC_OPT)
+
+if(NEON_OPT)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
     STRING(REGEX REPLACE "^.*(neon).*$" "\\1" NEON_THERE ${CPUINFO})
@@ -203,7 +209,7 @@ if(OPT)
       )
     endif(NEON_THERE STREQUAL "neon")
   endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-endif(OPT)
+endif(NEON_OPT)
 
 # Build type
 


### PR DESCRIPTION
The new CRC optimization breaks Zelda OoT fairy glow on a rpi. To get at least some optimizations it would be better to enable/disable them separately.
![dsc01628](https://cloud.githubusercontent.com/assets/6412699/16709450/7a91a9d8-4611-11e6-8224-a61239fdc7f6.JPG)
