### PR TITLE
Simplify cmake and fix a typo

### DIFF
--- a/projects/cmake/Readme.txt
+++ b/projects/cmake/Readme.txt
@@ -5,6 +5,7 @@ cmake [-DCMAKE_BUILD_TYPE=Debug] [-DVEC4_OPT=On] [-DCRC_OPT=On] [-DNEON_OPT=On] 
 -DCMAKE_BUILD_TYPE=Debug - optional parameter, if you want debug build. Default buid type is Release
 -DVEC4_OPT=On  - optional parameter. set it if you want to enable additional VEC4 optimization (can cause additional bugs).
 -DCRC_OPT=On  - optional parameter. set it if you want to enable additional CRC optimization (can cause additional bugs).
--DNEON_OPT=On - optional parameter. set it if you want to enable additional ARM NEON optimization (can cause additional bugs).-DNOHQ=On - build without realtime texture enhancer library (GLideNHQ)
+-DNEON_OPT=On - optional parameter. set it if you want to enable additional ARM NEON optimization (can cause additional bugs).
+-DNOHQ=On - build without realtime texture enhancer library (GLideNHQ).
 -DUSE_UNIFORMBLOCK=On - Use uniform blocks in shaders. May help to improve performance. Not supported by GLES2 hardware.
 -DMUPENPLUSAPI=On - currently cmake build works only for mupen64plus version of the plugin.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,22 +193,16 @@ if(CRC_OPT)
 endif(CRC_OPT)
 
 if(NEON_OPT)
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    EXEC_PROGRAM(cat ARGS "/proc/cpuinfo" OUTPUT_VARIABLE CPUINFO)
-    STRING(REGEX REPLACE "^.*(neon).*$" "\\1" NEON_THERE ${CPUINFO})
-    if(NEON_THERE STREQUAL "neon")
-      add_definitions(
-        -D__NEON_OPT
-      )
-      list(APPEND GLideN64_SOURCES
-        3DMathNeon.cpp
-        gSPNeon.cpp
-      )
-      list(REMOVE_ITEM GLideN64_SOURCES
-        3DMath.cpp
-      )
-    endif(NEON_THERE STREQUAL "neon")
-  endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_definitions(
+    -D__NEON_OPT
+  )
+  list(APPEND GLideN64_SOURCES
+    3DMathNeon.cpp
+    gSPNeon.cpp
+  )
+  list(REMOVE_ITEM GLideN64_SOURCES
+    3DMath.cpp
+  )
 endif(NEON_OPT)
 
 # Build type


### PR DESCRIPTION
If the user needs to explicitly set NEON_OPT then there isn't much benefit to doing a search for NEON, it just makes the CMake file harder to read.