### PR TITLE
Another fix for FBE on Raspberry Pi

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -712,6 +712,10 @@ void FrameBufferList::attachDepthBuffer()
 	if (m_pCurrent == nullptr)
 		return;
 
+#ifdef VC
+	const GLenum discards[]  = {GL_DEPTH_ATTACHMENT};
+	glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, discards);
+#endif
 	DepthBuffer * pDepthBuffer = depthBufferList().getCurrent();
 	if (m_pCurrent->m_FBO > 0 && pDepthBuffer != nullptr) {
 		pDepthBuffer->initDepthImageTexture(m_pCurrent);


### PR DESCRIPTION
One of the items I removed in https://github.com/gonetz/GLideN64/commit/a20dc97a5aa96b3372130e63f0bb3311a4d2f636 should not have been removed.

User testing (https://github.com/RetroPie/RetroPie-Setup/pull/1568) has happened and this fixes the issue. Sorry about all these pull requests this is such a strange bug.

@gizmo98 has tested a good number of games and this fixes almost all of them.