### PR TITLE
RPi HW Lighting

### DIFF
--- a/src/GLES2/Shaders_gles2.h
+++ b/src/GLES2/Shaders_gles2.h
@@ -232,7 +232,11 @@ static const char* fragment_shader_header_common_functions_notex =
 static const char* fragment_shader_calc_light =
 "uniform mediump vec3 uLightDirection[8];	\n"
 "uniform lowp vec3 uLightColor[8];			\n"
+#ifdef VC
+"uniform lowp vec3 uLightColor_VC;\n"
+#endif
 "void calc_light(in lowp float fLights, in lowp vec3 input_color, out lowp vec3 output_color) {\n"
+#ifndef VC
 "  output_color = input_color;									\n"
 "  lowp int nLights = int(floor(fLights + 0.5));				\n"
 "  if (nLights == 0)											\n"
@@ -244,6 +248,22 @@ static const char* fragment_shader_calc_light =
 "    intensity = max(dot(n, uLightDirection[i]), 0.0);			\n"
 "    output_color += intensity*uLightColor[i];					\n"
 "  };															\n"
+#else
+"  output_color = input_color;\n"
+"  lowp int nLights = int(floor(fLights + 0.5));\n"
+"  if(nLights == 0) return;\n"
+"  output_color = uLightColor_VC;\n"
+"  mediump vec3 n = normalize(input_color);\n"
+"  output_color += max(dot(n, uLightDirection[0]), 0.0)*uLightColor[0];\n"
+"  output_color += max(dot(n, uLightDirection[1]), 0.0)*uLightColor[1];\n"
+"  output_color += max(dot(n, uLightDirection[2]), 0.0)*uLightColor[2];\n"
+"  output_color += max(dot(n, uLightDirection[3]), 0.0)*uLightColor[3];\n"
+"  output_color += max(dot(n, uLightDirection[4]), 0.0)*uLightColor[4];\n"
+"  output_color += max(dot(n, uLightDirection[5]), 0.0)*uLightColor[5];\n"
+"  output_color += max(dot(n, uLightDirection[6]), 0.0)*uLightColor[6];\n"
+//"  output_color += max(dot(n, uLightDirection[7]), 0.0)*uLightColor[7];\n"
+// This light is unreachable?
+#endif
 "  clamp(output_color, 0.0, 1.0);								\n"
 "}																\n"
 ;

--- a/src/GLUniforms/UniformSet.cpp
+++ b/src/GLUniforms/UniformSet.cpp
@@ -51,6 +51,9 @@ void UniformSet::bindWithShaderCombiner(ShaderCombiner * _pCombiner)
 			sprintf(buf, "uLightColor[%d]", i);
 			location.uLightColor[i].loc = glGetUniformLocation(program, buf);
 		}
+#ifdef VC
+		location.uLightColor_VC.loc = glGetUniformLocation(program, "uLightColor_VC");
+#endif
 		_updateLightUniforms(location, true);
 	}
 }
@@ -125,6 +128,15 @@ void UniformSet::_updateLightUniforms(UniformSetLocation & _location, bool _bFor
 		_location.uLightDirection[i].set(&gSP.lights[i].x, _bForce);
 		_location.uLightColor[i].set(&gSP.lights[i].r, _bForce);
 	}
+
+#ifdef VC
+	_location.uLightColor_VC.set(&gSP.lights[gSP.numLights].r, _bForce);
+
+	// Clear unused and the last light's color to black so they don't add to the lighting
+	static const float black[3] = { 0.0f, 0.0f, 0.0f };
+	for (s32 i = gSP.numLights; i < 8; i++)
+		_location.uLightColor[i].set((float*)&black, _bForce);
+#endif
 }
 
 void UniformSet::updateUniforms(ShaderCombiner * _pCombiner, OGLRender::RENDER_STATE _renderState)

--- a/src/GLUniforms/UniformSet.h
+++ b/src/GLUniforms/UniformSet.h
@@ -57,6 +57,9 @@ private:
 
 		// Lights
 		fv3Uniform uLightDirection[8], uLightColor[8];
+#ifdef VC
+		fv3Uniform uLightColor_VC;
+#endif
 	};
 
 	void _updateColorUniforms(UniformSetLocation & _location, bool _bForce);


### PR DESCRIPTION
Fixes hw lighting for RPi.

It doesn't seem to work on some games with 3 point filtering enabled and legacy blend mode disabled, I'm guessing this is because of the shader being to long?