### PR TITLE
Fixes some depth issues in Android

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -398,10 +398,7 @@ void DepthBufferList::saveBuffer(u32 _address)
 
 		m_pCurrent = &buffer;
 	}
-#ifdef ANDROID
-	//Fixes issues with PowerVR devices and potentially other Android devices
-	glClear( GL_DEPTH_BUFFER_BIT );
-#endif
+
 	frameBufferList().attachDepthBuffer();
 
 #ifdef DEBUG

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -1836,6 +1836,12 @@ void OGLRender::clearDepthBuffer(u32 _uly, u32 _lry)
 	depthBufferList().clearBuffer(_uly, _lry);
 
 	glDisable( GL_SCISSOR_TEST );
+
+#ifdef ANDROID
+	glDepthMask( FALSE );
+	glClear( GL_DEPTH_BUFFER_BIT );
+#endif
+
 	glDepthMask( TRUE );
 	glClear( GL_DEPTH_BUFFER_BIT );
 


### PR DESCRIPTION
The previous change was causing depth issues in Android. Moving the glClear to saveBuffer seems to fix those issues.