### PR TITLE
Remove dead code (glActiveTexture)

### DIFF
--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -116,9 +116,6 @@ void InitShaderCombiner()
 		}
 	}
 
-	glActiveTexture(GL_TEXTURE0);
-	glActiveTexture(GL_TEXTURE1);
-
 	g_vertex_shader_object = _createShader(GL_VERTEX_SHADER, vertex_shader);
 	g_vertex_shader_object_notex = _createShader(GL_VERTEX_SHADER, vertex_shader_notex);
 

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -206,9 +206,6 @@ GLuint _createShader(GLenum _type, const char * _strShader)
 
 void InitShaderCombiner()
 {
-	glActiveTexture(GL_TEXTURE0);
-	glActiveTexture(GL_TEXTURE1);
-
 	g_vertex_shader_object = _createShader(GL_VERTEX_SHADER, vertex_shader);
 	g_vertex_shader_object_notex = _createShader(GL_VERTEX_SHADER, vertex_shader_notex);
 


### PR DESCRIPTION
These are left over after these commits:

https://github.com/gonetz/GLideN64/pull/1028
https://github.com/gonetz/GLideN64/pull/1001

And they are no longer used.