### PR TITLE
Fix GL Error on GLES3

### DIFF
--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -745,8 +745,9 @@ void ShaderCombiner::updateFrameBufferInfo(bool _bForce) {
 	}
 	m_uniforms.uFbMonochrome.set(nFbMonochromeMode0, nFbMonochromeMode1, _bForce);
 	m_uniforms.uFbFixedAlpha.set(nFbFixedAlpha0, nFbFixedAlpha1, _bForce);
+#ifdef GL_MULTISAMPLING_SUPPORT
 	m_uniforms.uMSTexEnabled.set(nMSTex0Enabled, nMSTex1Enabled, _bForce);
-
+#endif
 	gDP.changed &= ~CHANGED_FB_TEXTURE;
 }
 


### PR DESCRIPTION
uMSTexEnabled is only used when GL_MULTISAMPLING_SUPPORT is set, and it is not supported with GLES3. This line was throwing a GL Error since uMSTexEnabled wasn't present in the shader for GLES3