### PR TITLE
Fix various errors and HW lighting with shader storage

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -375,7 +375,7 @@ Storage format:
   uint32 - number of shaders
   shaders in binary form
 */
-static const u32 ShaderStorageFormatVersion = 0x08U;
+static const u32 ShaderStorageFormatVersion = 0x09U;
 void CombinerInfo::_saveShadersStorage() const
 {
 	if (m_shadersLoaded >= m_combiners.size())

--- a/src/Combiner.h
+++ b/src/Combiner.h
@@ -87,6 +87,7 @@
 #define ONE				19
 #define ZERO			20
 #define LIGHT			21
+#define HW_LIGHT		22
 
 struct CombinerOp
 {

--- a/src/FBOTextureFormats.cpp
+++ b/src/FBOTextureFormats.cpp
@@ -38,7 +38,7 @@ void FBOTextureFormats::init()
 	colorType = GL_UNSIGNED_BYTE;
 	colorFormatBytes = 4;
 
-	monochromeInternalFormat = GL_RED;
+	monochromeInternalFormat = GL_R8;
 	monochromeFormat = GL_RED;
 	monochromeType = GL_UNSIGNED_BYTE;
 	monochromeFormatBytes = 1;

--- a/src/GLSLCombiner.h
+++ b/src/GLSLCombiner.h
@@ -48,7 +48,7 @@ private:
 	friend class UniformSet;
 
 	struct iUniform	{
-		GLint loc;
+		GLint loc = -1;
 		int val;
 		void set(int _val, bool _force) {
 			if (loc >= 0 && (_force || val != _val)) {
@@ -59,7 +59,7 @@ private:
 	};
 
 	struct fUniform {
-		GLint loc;
+		GLint loc = -1;
 		float val;
 		void set(float _val, bool _force) {
 			if (loc >= 0 && (_force || val != _val)) {
@@ -70,7 +70,7 @@ private:
 	};
 
 	struct fv2Uniform {
-		GLint loc;
+		GLint loc = -1;
 		float val[2];
 		void set(float _val1, float _val2, bool _force) {
 			if (loc >= 0 && (_force || val[0] != _val1 || val[1] != _val2)) {
@@ -82,7 +82,7 @@ private:
 	};
 
 	struct iv2Uniform {
-		GLint loc;
+		GLint loc = -1;
 		int val[2];
 		void set(int _val1, int _val2, bool _force) {
 			if (loc >= 0 && (_force || val[0] != _val1 || val[1] != _val2)) {
@@ -94,7 +94,7 @@ private:
 	};
 
 	struct i4Uniform {
-		GLint loc;
+		GLint loc = -1;
 		int val0, val1, val2, val3;
 		void set(int _val0, int _val1, int _val2, int _val3, bool _force) {
 			if (loc < 0)

--- a/src/GLSLCombiner.h
+++ b/src/GLSLCombiner.h
@@ -37,6 +37,7 @@ public:
 	bool usesLOD() const { return (m_nInputs & (1 << LOD_FRACTION)) != 0; }
 	bool usesShade() const { return (m_nInputs & ((1 << SHADE) | (1 << SHADE_ALPHA))) != 0; }
 	bool usesShadeColor() const { return (m_nInputs & (1 << SHADE)) != 0; }
+	bool usesHwLighting() const { return (m_nInputs & (1 << HW_LIGHT)) != 0; }
 
 	friend std::ostream & operator<< (std::ostream & _os, const ShaderCombiner & _combiner);
 	friend std::istream & operator>> (std::istream & _os, ShaderCombiner & _combiner);

--- a/src/GLUniforms/UniformSet.cpp
+++ b/src/GLUniforms/UniformSet.cpp
@@ -42,7 +42,7 @@ void UniformSet::bindWithShaderCombiner(ShaderCombiner * _pCombiner)
 	_updateColorUniforms(location, true);
 
 	// Lights
-	if (config.generalEmulation.enableHWLighting != 0 && GBI.isHWLSupported() && _pCombiner->usesShadeColor()) {
+	if (_pCombiner->usesHwLighting()) {
 		// locate lights uniforms
 		char buf[32];
 		for (s32 i = 0; i < 8; ++i) {

--- a/src/GLUniforms/UniformSet.h
+++ b/src/GLUniforms/UniformSet.h
@@ -18,7 +18,7 @@ public:
 
 private:
 	struct fv3Uniform {
-		GLint loc;
+		GLint loc = -1;
 		float val[3];
 		void set(float * _pVal, bool _force) {
 			const size_t szData = sizeof(float)* 3;
@@ -30,7 +30,7 @@ private:
 	};
 
 	struct fv4Uniform {
-		GLint loc;
+		GLint loc = -1;
 		float val[4];
 		void set(float * _pVal, bool _force) {
 			const size_t szData = sizeof(float)* 4;

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -308,6 +308,9 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 	const bool bUseLod = usesLOD();
 	const bool bUseHWLight = config.generalEmulation.enableHWLighting != 0 && GBI.isHWLSupported() && usesShadeColor();
 
+	if( bUseHWLight )
+		m_nInputs |= 1 << HW_LIGHT;
+
 	if (usesTexture()) {
 		strFragmentShader.assign(fragment_shader_header_common_variables);
 		if (gDP.otherMode.cycleType == G_CYC_2CYCLE && config.generalEmulation.enableLegacyBlending == 0)

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -748,8 +748,9 @@ void ShaderCombiner::updateFrameBufferInfo(bool _bForce) {
 	}
 	m_uniforms.uFbMonochrome.set(nFbMonochromeMode0, nFbMonochromeMode1, _bForce);
 	m_uniforms.uFbFixedAlpha.set(nFbFixedAlpha0, nFbFixedAlpha1, _bForce);
+#ifdef GL_MULTISAMPLING_SUPPORT
 	m_uniforms.uMSTexEnabled.set(nMSTex0Enabled, nMSTex1Enabled, _bForce);
-
+#endif
 	gDP.changed &= ~CHANGED_FB_TEXTURE;
 }
 

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -83,8 +83,6 @@ m64p_error PluginAPI::PluginShutdown()
 	_callAPICommand(acRomClosed);
 	delete m_pRspThread;
 	m_pRspThread = nullptr;
-#else
-	video().stop();
 #endif
 	return M64ERR_SUCCESS;
 }


### PR DESCRIPTION
This fixes all GL errors encountered in my device along with HW lighting when shader storage is enabled.

See more details about the HW lighting issue here: https://github.com/gonetz/GLideN64/issues/1080