### PR TITLE
Save/load shader cache on errors

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -410,9 +410,28 @@ void CombinerInfo::_saveShadersStorage() const
 	fout.write(strGLVersion, len);
 
 	len = m_combiners.size();
-	fout.write((char*)&len, sizeof(len));
+
+	u32 totalWritten = 0;
+	std::vector<char> allShaderData;
+
 	for (Combiners::const_iterator cur = m_combiners.begin(); cur != m_combiners.end(); ++cur)
-		fout << *(cur->second);
+	{
+		std::vector<char> data;
+		if(cur->second->getShaderCacheBinary(data))
+		{
+			allShaderData.insert(allShaderData.end(), data.begin(), data.end());
+			++totalWritten;
+		}
+		else
+		{
+			LOG(LOG_ERROR, "Error while writing shader with key key=0x%016lX",
+				static_cast<long unsigned int>(cur->second->getKey()));
+		}
+	}
+
+	fout.write((char*)&totalWritten, sizeof(totalWritten));
+	fout.write(allShaderData.data(), allShaderData.size());
+
 	fout.flush();
 	fout.close();
 }

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -12,6 +12,7 @@
 #include "Config.h"
 #include "PluginAPI.h"
 #include "RSP.h"
+#include "Log.h"
 
 static int saRGBExpanded[] =
 {
@@ -468,13 +469,12 @@ bool CombinerInfo::_loadShadersStorage()
 		}
 	}
 	catch (...) {
-		m_shadersLoaded = 0;
-		return false;
+		LOG(LOG_ERROR, "Stream error while loading shader cache! Buffer is probably not big enough");
 	}
 
 	m_shadersLoaded = m_combiners.size();
 	fin.close();
-	return !isGLError();
+	return true;
 }
 #else // GLES2
 void CombinerInfo::_saveShadersStorage() const

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -417,7 +417,7 @@ void CombinerInfo::_saveShadersStorage() const
 	for (Combiners::const_iterator cur = m_combiners.begin(); cur != m_combiners.end(); ++cur)
 	{
 		std::vector<char> data;
-		if(cur->second->getShaderCacheBinary(data))
+		if(cur->second->convertShaderCacheToBinary(data))
 		{
 			allShaderData.insert(allShaderData.end(), data.begin(), data.end());
 			++totalWritten;
@@ -481,7 +481,7 @@ bool CombinerInfo::_loadShadersStorage()
 		fin.read((char*)&len, sizeof(len));
 		for (u32 i = 0; i < len; ++i) {
 			m_pCurrent = new ShaderCombiner();
-			fin >> *m_pCurrent;
+			m_pCurrent->readShaderCacheFromFile(fin);
 			m_pCurrent->update(true);
 			m_pUniformCollection->bindWithShaderCombiner(m_pCurrent);
 			m_combiners[m_pCurrent->getKey()] = m_pCurrent;

--- a/src/GLSLCombiner.h
+++ b/src/GLSLCombiner.h
@@ -38,8 +38,8 @@ public:
 	bool usesShade() const { return (m_nInputs & ((1 << SHADE) | (1 << SHADE_ALPHA))) != 0; }
 	bool usesShadeColor() const { return (m_nInputs & (1 << SHADE)) != 0; }
 
-	bool getShaderCacheBinary(std::vector<char> & _shaderCache);
-	friend std::istream & operator>> (std::istream & _os, ShaderCombiner & _combiner);
+	bool convertShaderCacheToBinary(std::vector<char> & _shaderCache);
+	void readShaderCacheFromFile(std::istream & _is);
 
 	static void getShaderCombinerOptionsSet(std::vector<u32> & _vecOptions);
 

--- a/src/GLSLCombiner.h
+++ b/src/GLSLCombiner.h
@@ -38,7 +38,7 @@ public:
 	bool usesShade() const { return (m_nInputs & ((1 << SHADE) | (1 << SHADE_ALPHA))) != 0; }
 	bool usesShadeColor() const { return (m_nInputs & (1 << SHADE)) != 0; }
 
-	friend std::ostream & operator<< (std::ostream & _os, const ShaderCombiner & _combiner);
+	bool getShaderCacheBinary(std::vector<char> & _shaderCache);
 	friend std::istream & operator>> (std::istream & _os, ShaderCombiner & _combiner);
 
 	static void getShaderCombinerOptionsSet(std::vector<u32> & _vecOptions);

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -803,30 +803,47 @@ void ShaderCombiner::updateAlphaTestInfo(bool _bForce) {
 	m_uniforms.uCvgXAlpha.set(gDP.otherMode.cvgXAlpha, _bForce);
 }
 
-std::ostream & operator<< (std::ostream & _os, const ShaderCombiner & _combiner)
+bool ShaderCombiner::getShaderCacheBinary(std::vector<char> & _shaderCache)
 {
 	GLint  binaryLength;
-	glGetProgramiv(_combiner.m_program, GL_PROGRAM_BINARY_LENGTH, &binaryLength);
+	glGetProgramiv(m_program, GL_PROGRAM_BINARY_LENGTH, &binaryLength);
 
 	if (binaryLength < 1)
-		return _os;
+		return false;
 
 	std::vector<char> binary(binaryLength);
 
 	if (binary.size() == 0)
-		return _os;
+		return false;
 
 	GLenum binaryFormat;
-	glGetProgramBinary(_combiner.m_program, binaryLength, &binaryLength, &binaryFormat, binary.data());
+	glGetProgramBinary(m_program, binaryLength, &binaryLength, &binaryFormat, binary.data());
 	if (isGLError())
-		return _os;
+		return false;
 
-	_os.write((char*)&_combiner.m_key, sizeof(_combiner.m_key));
-	_os.write((char*)&_combiner.m_nInputs, sizeof(_combiner.m_nInputs));
-	_os.write((char*)&binaryFormat, sizeof(binaryFormat));
-	_os.write((char*)&binaryLength, sizeof(binaryLength));
-	_os.write(binary.data(), binaryLength);
-	return _os;
+	int totalSize = sizeof(m_key) + sizeof(m_nInputs) + sizeof(binaryFormat) +
+		sizeof(binaryLength) + binaryLength;
+	_shaderCache.resize(totalSize);
+
+	char* keyData = reinterpret_cast<char*>(&m_key);
+	std::copy_n(keyData, sizeof(m_key), _shaderCache.data());
+	int offset = sizeof(m_key);
+
+	char* inputData = reinterpret_cast<char*>(&m_nInputs);
+	std::copy_n(inputData, sizeof(m_nInputs), _shaderCache.data() + offset);
+	offset += sizeof(m_nInputs);
+
+	char* binaryFormatData = reinterpret_cast<char*>(&binaryFormat);
+	std::copy_n(binaryFormatData, sizeof(binaryFormat), _shaderCache.data() + offset);
+	offset += sizeof(binaryFormat);
+
+	char* binaryLengthData = reinterpret_cast<char*>(&binaryLength);
+	std::copy_n(binaryLengthData, sizeof(binaryLength), _shaderCache.data() + offset);
+	offset += sizeof(binaryLength);
+
+	std::copy_n(binary.data(), binaryLength, _shaderCache.data() + offset);
+
+	return true;
 }
 
 std::istream & operator>> (std::istream & _is, ShaderCombiner & _combiner)

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -803,7 +803,7 @@ void ShaderCombiner::updateAlphaTestInfo(bool _bForce) {
 	m_uniforms.uCvgXAlpha.set(gDP.otherMode.cvgXAlpha, _bForce);
 }
 
-bool ShaderCombiner::getShaderCacheBinary(std::vector<char> & _shaderCache)
+bool ShaderCombiner::convertShaderCacheToBinary(std::vector<char> & _shaderCache)
 {
 	GLint  binaryLength;
 	glGetProgramiv(m_program, GL_PROGRAM_BINARY_LENGTH, &binaryLength);
@@ -846,10 +846,10 @@ bool ShaderCombiner::getShaderCacheBinary(std::vector<char> & _shaderCache)
 	return true;
 }
 
-std::istream & operator>> (std::istream & _is, ShaderCombiner & _combiner)
+void ShaderCombiner::readShaderCacheFromFile(std::istream & _is)
 {
-	_is.read((char*)&_combiner.m_key, sizeof(_combiner.m_key));
-	_is.read((char*)&_combiner.m_nInputs, sizeof(_combiner.m_nInputs));
+	_is.read((char*)&m_key, sizeof(m_key));
+	_is.read((char*)&m_nInputs, sizeof(m_nInputs));
 	GLenum binaryFormat;
 	GLint  binaryLength;
 	_is.read((char*)&binaryFormat, sizeof(binaryFormat));
@@ -857,10 +857,9 @@ std::istream & operator>> (std::istream & _is, ShaderCombiner & _combiner)
 	std::vector<char> binary(binaryLength);
 	_is.read(binary.data(), binaryLength);
 
-	glProgramBinary(_combiner.m_program, binaryFormat, binary.data(), binaryLength);
-	assert(checkProgramLinkStatus(_combiner.m_program));
-	_combiner._locateUniforms();
-	return _is;
+	glProgramBinary(m_program, binaryFormat, binary.data(), binaryLength);
+	assert(checkProgramLinkStatus(m_program));
+	_locateUniforms();
 }
 
 void ShaderCombiner::getShaderCombinerOptionsSet(std::vector<u32> & _vecOptions)


### PR DESCRIPTION
This pull request correctly saves and loads shader cache when there are errors. I split it off from https://github.com/gonetz/GLideN64/pull/1077

That way we can decide separately if want to include it or not. I'm ok if you don't want to include it.