### PR TITLE
Optional fragment based writing of depth

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -384,7 +384,7 @@ Storage format:
   uint32 - number of shaders
   shaders in binary form
 */
-static const u32 ShaderStorageFormatVersion = 0x09U;
+static const u32 ShaderStorageFormatVersion = 0x10U;
 void CombinerInfo::_saveShadersStorage() const
 {
 	if (m_shadersLoaded >= m_combiners.size())

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -37,6 +37,8 @@ void Config::resetToDefaults()
 	generalEmulation.correctTexrectCoords = tcDisable;
 	generalEmulation.enableNativeResTexrects = 0;
 	generalEmulation.enableLegacyBlending = 0;
+	generalEmulation.enableFragmentBasedDepth = 1;
+
 	generalEmulation.hacks = 0;
 #ifdef ANDROID
 	generalEmulation.forcePolygonOffset = 0;

--- a/src/Config.h
+++ b/src/Config.h
@@ -4,7 +4,7 @@
 #include <string>
 #include "Types.h"
 
-#define CONFIG_VERSION_CURRENT 12U
+#define CONFIG_VERSION_CURRENT 13U
 
 #define BILINEAR_3POINT   0
 #define BILINEAR_STANDARD 1
@@ -50,6 +50,7 @@ struct Config
 		u32 correctTexrectCoords;
 		u32 enableNativeResTexrects;
 		u32 enableLegacyBlending;
+		u32 enableFragmentBasedDepth;
 		u32 hacks;
 #ifdef ANDROID
 		u32 forcePolygonOffset;

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -25,6 +25,7 @@ static GLuint  g_vertex_shader_object_notex;
 static GLuint  g_calc_light_shader_object;
 static GLuint  g_calc_mipmap_shader_object;
 static GLuint  g_calc_noise_shader_object;
+static GLuint  g_write_depth_shader_object;
 static GLuint  g_calc_depth_shader_object;
 static GLuint  g_readtex_shader_object;
 static GLuint  g_readtex_ms_shader_object;
@@ -215,6 +216,7 @@ void InitShaderCombiner()
 	g_calc_light_shader_object = _createShader(GL_FRAGMENT_SHADER, fragment_shader_calc_light);
 	g_calc_mipmap_shader_object = _createShader(GL_FRAGMENT_SHADER, fragment_shader_mipmap);
 	g_calc_noise_shader_object = _createShader(GL_FRAGMENT_SHADER, fragment_shader_noise);
+	g_write_depth_shader_object = _createShader(GL_FRAGMENT_SHADER, fragment_shader_depth);
 	g_readtex_shader_object = _createShader(GL_FRAGMENT_SHADER, config.texture.bilinearMode == BILINEAR_3POINT ? fragment_shader_readtex_3point : fragment_shader_readtex);
 	g_readtex_ms_shader_object = _createShader(GL_FRAGMENT_SHADER, fragment_shader_readtex_ms);
 	g_dither_shader_object = _createShader(GL_FRAGMENT_SHADER, fragment_shader_dither);
@@ -226,7 +228,8 @@ void InitShaderCombiner()
 	const int texLoc = glGetUniformLocation(g_monochrome_image_program, "uColorImage");
 	glUniform1i(texLoc, 0);
 
-	if ((config.generalEmulation.hacks&hack_LoadDepthTextures) != 0) {
+	if (config.generalEmulation.enableFragmentBasedDepth != 0 &&
+		(config.generalEmulation.hacks&hack_LoadDepthTextures) != 0) {
 		GLuint depth_texture_shader_object = _createShader(GL_FRAGMENT_SHADER, depth_texture_fragment_shader);
 		g_depth_texture_program = glCreateProgram();
 		glBindAttribLocation(g_depth_texture_program, SC_POSITION, "aPosition");
@@ -273,6 +276,8 @@ void DestroyShaderCombiner() {
 	g_readtex_ms_shader_object = 0;
 	glDeleteShader(g_calc_noise_shader_object);
 	g_calc_noise_shader_object = 0;
+	glDeleteShader(g_write_depth_shader_object);
+	g_write_depth_shader_object = 0;
 	glDeleteShader(g_dither_shader_object);
 	g_dither_shader_object = 0;
 	glDeleteShader(g_calc_depth_shader_object);
@@ -325,7 +330,7 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 
 		strFragmentShader.append(fragment_shader_header_noise);
 		strFragmentShader.append(fragment_shader_header_noise_dither);
-
+		strFragmentShader.append(fragment_shader_header_write_depth);
 		if (bUseLod)
 			strFragmentShader.append(fragment_shader_header_mipmap);
 		else {
@@ -346,6 +351,7 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 			strFragmentShader.append(fragment_shader_header_common_variables_blend_mux_2cycle);
 		strFragmentShader.append(fragment_shader_header_noise);
 		strFragmentShader.append(fragment_shader_header_noise_dither);
+		strFragmentShader.append(fragment_shader_header_write_depth);
 
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 		if (video().getRender().isImageTexturesSupported() && config.frameBufferEmulation.N64DepthCompare != 0)
@@ -397,26 +403,25 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 	if (video().getRender().isImageTexturesSupported() && config.frameBufferEmulation.N64DepthCompare != 0)
 		strFragmentShader.append("  if (!depth_compare()) discard; \n");
 
-	strFragmentShader.append(
-#ifdef GLESX
-		"#ifdef GL_NV_fragdepth							\n"
-#endif
-		"  if (uRenderTarget != 0) {					\n"
-		"    if (uRenderTarget > 1) {					\n"
-		"      ivec2 coord = ivec2(gl_FragCoord.xy);	\n"
-		"      if (gl_FragDepth >= texelFetch(uDepthTex, coord, 0).r) discard;	\n"
-		"    }											\n"
-		"    gl_FragDepth = fragColor.r;				\n"
-		"  }											\n"
-#ifdef GLESX
-		"#endif											\n"
-#endif
-	);
+	if (config.generalEmulation.enableFragmentBasedDepth != 0){
+		strFragmentShader.append(
+			"  if (uRenderTarget != 0) {					\n"
+			"    if (uRenderTarget > 1) {					\n"
+			"      ivec2 coord = ivec2(gl_FragCoord.xy);	\n"
+			"      if (gl_FragDepth >= texelFetch(uDepthTex, coord, 0).r) discard;	\n"
+			"    }											\n"
+			"    gl_FragDepth = fragColor.r;				\n"
+			"  }											\n"
+		);
+	}
 
 	strFragmentShader.append(fragment_shader_end);
 
 	if (config.generalEmulation.enableNoise == 0)
 		strFragmentShader.append(fragment_shader_dummy_noise);
+
+	if (config.generalEmulation.enableFragmentBasedDepth == 0)
+		strFragmentShader.append(fragment_shader_dummy_depth);
 
 	if (bUseLod && config.generalEmulation.enableLOD == 0)
 		strFragmentShader.append(fragment_shader_fake_mipmap);
@@ -441,6 +446,9 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 	if (config.generalEmulation.enableNoise != 0) {
 		strFragmentShader.append(fragment_shader_noise);
 		strFragmentShader.append(fragment_shader_dither);
+	}
+	if (config.generalEmulation.enableFragmentBasedDepth != 0){
+		strFragmentShader.append(fragment_shader_depth);
 	}
 #endif
 
@@ -474,6 +482,10 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 	if (config.generalEmulation.enableNoise != 0) {
 		glAttachShader(m_program, g_calc_noise_shader_object);
 		glAttachShader(m_program, g_dither_shader_object);
+	}
+
+	if (config.generalEmulation.enableFragmentBasedDepth != 0) {
+		glAttachShader(m_program, g_write_depth_shader_object);
 	}
 #endif
 	if (CombinerInfo::get().isShaderCacheSupported())
@@ -857,6 +869,7 @@ void ShaderCombiner::getShaderCombinerOptionsSet(std::vector<u32> & _vecOptions)
 	_vecOptions.push_back(config.generalEmulation.enableLOD);
 	_vecOptions.push_back(config.frameBufferEmulation.N64DepthCompare);
 	_vecOptions.push_back(config.generalEmulation.enableLegacyBlending);
+	_vecOptions.push_back(config.generalEmulation.enableFragmentBasedDepth);
 }
 
 #ifdef GL_IMAGE_TEXTURES_SUPPORT

--- a/src/OGL3X/Shaders_ogl3x.h
+++ b/src/OGL3X/Shaders_ogl3x.h
@@ -264,6 +264,8 @@ static const char* fragment_shader_header_common_variables_blend_mux_2cycle =
 
 static const char* fragment_shader_header_noise =
 	"lowp float snoise();\n";
+static const char* fragment_shader_header_write_depth =
+	"void writeDepth();\n";
 static const char* fragment_shader_header_calc_light =
 	"void calc_light(in lowp float fLights, in lowp vec3 input_color, out lowp vec3 output_color);\n";
 static const char* fragment_shader_header_mipmap =
@@ -317,13 +319,7 @@ static const char* fragment_shader_header_main =
 "									\n"
 "void main()						\n"
 "{									\n"
-#ifdef GLESX
-"#ifdef GL_NV_fragdepth			\n"
-"  gl_FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
-"#endif										\n"
-#else
-"  gl_FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
-#endif
+"  writeDepth();                                                                                    \n"
 "  lowp mat4 muxPM = mat4(vec4(0.0), vec4(0.0), uBlendColor, uFogColor);							\n"
 "  lowp vec4 muxA = vec4(0.0, uFogColor.a, vShadeColor.a, 0.0);										\n"
 "  lowp vec4 muxB = vec4(0.0, 1.0, 1.0, 0.0);														\n"
@@ -551,6 +547,23 @@ static const char* fragment_shader_dummy_noise =
 "}						\n"
 ;
 
+static const char* fragment_shader_depth =
+AUXILIARY_SHADER_VERSION
+#ifndef GLESX
+"uniform mediump vec2 uDepthScale;																	\n"
+#endif
+"void writeDepth()						        		\n"
+"{														\n"
+"  gl_FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
+"}														\n"
+;
+
+static const char* fragment_shader_dummy_depth =
+"void writeDepth()	    \n"
+"{						\n"
+"}						\n"
+;
+
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 static const char* depth_compare_shader_float =
 #ifndef GLESX
@@ -698,13 +711,7 @@ MAIN_SHADER_VERSION
 "in mediump vec2 vTexCoord0;					\n"
 "void main()									\n"
 "{												\n"
-#ifdef GLESX
-"#ifdef GL_NV_fragdepth							\n"
 "  gl_FragDepth = texture(uTex0, vTexCoord0).r;	\n"
-"#endif											\n"
-#else
-"  gl_FragDepth = texture(uTex0, vTexCoord0).r;	\n"
-#endif
 "}												\n"
 ;
 
@@ -785,13 +792,7 @@ const char * strTexrectDrawerFragmentShaderTex =
 "out lowp vec4 fragColor;																						\n"
 "void main()																									\n"
 "{																												\n"
-#ifdef GLESX
-"#ifdef GL_NV_fragdepth																							\n"
-"  gl_FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);				\n"
-"#endif																											\n"
-#else
-"  gl_FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);				\n"
-#endif
+"  writeDepth();                                                                                                \n"
 "  fragColor = texFilter(uTex0, vTexCoord0);																	\n"
 "  if (fragColor == uTestColor) discard;																		\n"
 "  if (uEnableAlphaTest == 1 && !(fragColor.a > 0.0)) discard;													\n"

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -398,9 +398,12 @@ void OGLRender::TexrectDrawer::init()
 	assert(m_textureBoundsLoc >= 0);
 	m_enableAlphaTestLoc = glGetUniformLocation(m_programTex, "uEnableAlphaTest");
 	assert(m_enableAlphaTestLoc >= 0);
+
 #ifndef GLES2
-	m_depthScaleLoc = glGetUniformLocation(m_programTex, "uDepthScale");
-	assert(m_depthScaleLoc >= 0);
+	if(config.generalEmulation.enableFragmentBasedDepth != 0){
+		m_depthScaleLoc = glGetUniformLocation(m_programTex, "uDepthScale");
+		assert(m_depthScaleLoc >= 0);
+	}
 #endif
 	glUseProgram(0);
 
@@ -570,10 +573,13 @@ bool OGLRender::TexrectDrawer::draw()
 	glUniform1i(m_enableAlphaTestLoc, enableAlphaTest);
 	float texBounds[4] = { s0, t0, s1, t1 };
 	glUniform4fv(m_textureBoundsLoc, 1, texBounds);
-	if (RSP.bLLE)
-		glUniform2f(m_depthScaleLoc, 0.5f, 0.5f);
-	else
-		glUniform2f(m_depthScaleLoc, gSP.viewport.vscale[2], gSP.viewport.vtrans[2]);
+	
+	if(m_depthScaleLoc != -1){
+		if (RSP.bLLE)
+			glUniform2f(m_depthScaleLoc, 0.5f, 0.5f);
+		else
+			glUniform2f(m_depthScaleLoc, gSP.viewport.vscale[2], gSP.viewport.vtrans[2]);
+	}
 	glEnableVertexAttribArray(SC_TEXCOORD0);
 
 	rect[0].x = m_ulx;

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -235,7 +235,7 @@ private:
 		GLuint m_programClean;
 		GLint m_enableAlphaTestLoc;
 		GLint m_textureBoundsLoc;
-		GLint m_depthScaleLoc;
+		GLint m_depthScaleLoc = -1;
 		gDPScissor m_scissor;
 		CachedTexture * m_pTexture;
 		FrameBuffer * m_pBuffer;

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -76,6 +76,8 @@ bool Config_SetDefault()
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "enableLegacyBlending", config.generalEmulation.enableLegacyBlending, "Do not use shaders to emulate N64 blending modes. Works faster on slow GPU. Can cause glitches.");
 	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableFragmentBasedDepth", config.generalEmulation.enableFragmentBasedDepth, "Enable fragment based depth. Fixes Pilotwings shadow.");
+	assert(res == M64ERR_SUCCESS);
 #ifdef ANDROID
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "ForcePolygonOffset", config.generalEmulation.forcePolygonOffset, "If true, use polygon offset values specified below");
 	assert(res == M64ERR_SUCCESS);
@@ -208,6 +210,7 @@ void Config_LoadConfig()
 	config.generalEmulation.correctTexrectCoords = ConfigGetParamInt(g_configVideoGliden64, "CorrectTexrectCoords");
 	config.generalEmulation.enableNativeResTexrects = ConfigGetParamBool(g_configVideoGliden64, "enableNativeResTexrects");
 	config.generalEmulation.enableLegacyBlending = ConfigGetParamBool(g_configVideoGliden64, "enableLegacyBlending");
+	config.generalEmulation.enableFragmentBasedDepth = ConfigGetParamBool(g_configVideoGliden64, "EnableFragmentBasedDepth");
 #ifdef ANDROID
 	config.generalEmulation.forcePolygonOffset = ConfigGetParamBool(g_configVideoGliden64, "ForcePolygonOffset");
 	config.generalEmulation.polygonOffsetFactor = ConfigGetParamFloat(g_configVideoGliden64, "PolygonOffsetFactor");


### PR DESCRIPTION
Optional writing of gl_Fragdepth. This is to address this issue:

https://github.com/gonetz/GLideN64/issues/1072

Please make sure it works in windows. It's hard to verify that.