### PR TITLE
GLSL Improvements

### DIFF
--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -163,11 +163,11 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 	} else {
 		if (usesTile(0)) {
 			strFragmentShader.append("  nCurrentTile = 0; \n");
-			strFragmentShader.append("  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0] != 0); \n");
+			strFragmentShader.append("  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]); \n");
 		}
 		if (usesTile(1)) {
 			strFragmentShader.append("  nCurrentTile = 1; \n");
-			strFragmentShader.append("  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1] != 0); \n");
+			strFragmentShader.append("  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]); \n");
 		}
 	}
 	const bool bUseHWLight = config.generalEmulation.enableHWLighting != 0 && GBI.isHWLSupported() && usesShadeColor();

--- a/src/GLES2/Shaders_gles2.h
+++ b/src/GLES2/Shaders_gles2.h
@@ -217,7 +217,7 @@ static const char* fragment_shader_header_common_functions =
 "lowp float snoise();						\n"
 "void calc_light(in lowp float fLights, in lowp vec3 input_color, out lowp vec3 output_color);\n"
 "mediump float mipmap(out lowp vec4 readtex0, out lowp vec4 readtex1);		\n"
-"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha);	\n"
+"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha);	\n"
 #ifdef USE_TOONIFY
 "void toonify(in mediump float intensity);	\n"
 #endif
@@ -291,13 +291,13 @@ static const char* fragment_shader_fake_mipmap =
 ;
 
 static const char* fragment_shader_readtex =
-"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha)	\n"
+"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha)	\n"
 "{																			\n"
 "  lowp vec4 texColor = texture2D(tex, texCoord); 							\n"
 "  if (fbMonochrome == 1) texColor = vec4(texColor.r);						\n"
 "  else if (fbMonochrome == 2) 												\n"
 "    texColor.rgb = vec3(dot(vec3(0.2126, 0.7152, 0.0722), texColor.rgb));	\n"
-"  if (fbFixedAlpha) texColor.a = 0.825;									\n"
+"  if (fbFixedAlpha == 1) texColor.a = 0.825;									\n"
 "  return texColor;															\n"
 "}																			\n"
 ;
@@ -317,7 +317,7 @@ static const char* fragment_shader_readtex_3point =
 "  mediump vec2 texSize;		\n"
 "  if (nCurrentTile == 0)		\n"
 "    texSize = uTextureSize[0];		\n"
-"  else if (nCurrentTile == 1)		\n"
+"  else		\n"
 "    texSize = uTextureSize[1];		\n"
 #endif
 "  mediump vec2 offset = fract(texCoord*texSize - vec2(0.5));	\n"
@@ -327,7 +327,7 @@ static const char* fragment_shader_readtex_3point =
 "  lowp vec4 c2 = TEX_OFFSET(vec2(offset.x, offset.y - sign(offset.y)));	\n"
 "  return c0 + abs(offset.x)*(c1-c0) + abs(offset.y)*(c2-c0);				\n"
 "}																			\n"
-"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha)	\n"
+"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha)	\n"
 "{																			\n"
 "  lowp vec4 texStandard = texture2D(tex, texCoord); 						\n"
 "  lowp vec4 tex3Point = filter3point(tex, texCoord); 						\n"
@@ -335,7 +335,7 @@ static const char* fragment_shader_readtex_3point =
 "  if (fbMonochrome == 1) texColor = vec4(texColor.r);						\n"
 "  else if (fbMonochrome == 2) 												\n"
 "    texColor.rgb = vec3(dot(vec3(0.2126, 0.7152, 0.0722), texColor.rgb));	\n"
-"  if (fbFixedAlpha) texColor.a = 0.825;									\n"
+"  if (fbFixedAlpha == 1) texColor.a = 0.825;									\n"
 "  return texColor;															\n"
 "}																			\n"
 ;

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -373,24 +373,24 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 		if (usesTile(0)) {
 			if (config.video.multisampling > 0) {
 				strFragmentShader.append("  lowp vec4 readtex0; \n");
-				strFragmentShader.append("  if (uMSTexEnabled[0] == 0) readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0] != 0); \n");
-				strFragmentShader.append("  else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0] != 0); \n");
+				strFragmentShader.append("  if (uMSTexEnabled[0] == 0) readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]); \n");
+				strFragmentShader.append("  else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]); \n");
 			} else
-				strFragmentShader.append("  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0] != 0); \n");
+				strFragmentShader.append("  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]); \n");
 		}
 		if (usesTile(1)) {
 			if (config.video.multisampling > 0) {
 				strFragmentShader.append("  lowp vec4 readtex1; \n");
-				strFragmentShader.append("  if (uMSTexEnabled[1] == 0) readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1] != 0); \n");
-				strFragmentShader.append("  else readtex1 = readTexMS(uMSTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1] != 0); \n");
+				strFragmentShader.append("  if (uMSTexEnabled[1] == 0) readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]); \n");
+				strFragmentShader.append("  else readtex1 = readTexMS(uMSTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]); \n");
 			} else
-				strFragmentShader.append("  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1] != 0); \n");
+				strFragmentShader.append("  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]); \n");
 		}
 #else
 		if (usesTile(0))
-			strFragmentShader.append("  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0] != 0); \n");
+			strFragmentShader.append("  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]); \n");
 		if (usesTile(1))
-			strFragmentShader.append("  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1] != 0); \n");
+			strFragmentShader.append("  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]); \n");
 #endif // GL_MULTISAMPLING_SUPPORT
 	}
 	if (bUseHWLight)

--- a/src/OGL3X/Shaders_ogl3x.h
+++ b/src/OGL3X/Shaders_ogl3x.h
@@ -271,10 +271,10 @@ static const char* fragment_shader_header_calc_light =
 static const char* fragment_shader_header_mipmap =
 	"mediump float mipmap(out lowp vec4 readtex0, out lowp vec4 readtex1);\n";
 static const char* fragment_shader_header_readTex =
-	"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha);\n";
+	"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha);\n";
 #ifdef GL_MULTISAMPLING_SUPPORT
 static const char* fragment_shader_header_readTexMS =
-	"lowp vec4 readTexMS(in lowp sampler2DMS mstex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha);\n";
+	"lowp vec4 readTexMS(in lowp sampler2DMS mstex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha);\n";
 #endif // GL_MULTISAMPLING_SUPPORT
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 static const char* fragment_shader_header_depth_compare =
@@ -458,13 +458,13 @@ static const char* fragment_shader_fake_mipmap =
 
 static const char* fragment_shader_readtex =
 AUXILIARY_SHADER_VERSION
-"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha)	\n"
+"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha)	\n"
 "{												\n"
 "  lowp vec4 texColor = texture(tex, texCoord);	\n"
 "  if (fbMonochrome == 1) texColor = vec4(texColor.r);	\n"
 "  else if (fbMonochrome == 2) 						\n"
 "    texColor.rgb = vec3(dot(vec3(0.2126, 0.7152, 0.0722), texColor.rgb));	\n"
-"  if (fbFixedAlpha) texColor.a = 0.825;		\n"
+"  if (fbFixedAlpha == 1) texColor.a = 0.825;		\n"
 "  return texColor;								\n"
 "}												\n"
 ;
@@ -486,7 +486,7 @@ AUXILIARY_SHADER_VERSION
 "  lowp vec4 c2 = TEX_OFFSET(vec2(offset.x, offset.y - sign(offset.y)));	\n"
 "  return c0 + abs(offset.x)*(c1-c0) + abs(offset.y)*(c2-c0);				\n"
 "}																			\n"
-"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha)	\n"
+"lowp vec4 readTex(in sampler2D tex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha)	\n"
 "{																			\n"
 "  lowp vec4 texStandard = texture(tex, texCoord); 							\n"
 "  lowp vec4 tex3Point = filter3point(tex, texCoord); 						\n"
@@ -494,7 +494,7 @@ AUXILIARY_SHADER_VERSION
 "  if (fbMonochrome == 1) texColor = vec4(texColor.r);						\n"
 "  else if (fbMonochrome == 2) 												\n"
 "    texColor.rgb = vec3(dot(vec3(0.2126, 0.7152, 0.0722), texColor.rgb));	\n"
-"  if (fbFixedAlpha) texColor.a = 0.825;									\n"
+"  if (fbFixedAlpha == 1) texColor.a = 0.825;									\n"
 "  return texColor;															\n"
 "}																			\n"
 ;
@@ -512,7 +512,7 @@ AUXILIARY_SHADER_VERSION
 "  return texel * uMSAAScale;												\n"
 "}																			\n"
 "																			\n"
-"lowp vec4 readTexMS(in lowp sampler2DMS mstex, in mediump vec2 texCoord, in lowp int fbMonochrome, in bool fbFixedAlpha)	\n"
+"lowp vec4 readTexMS(in lowp sampler2DMS mstex, in mediump vec2 texCoord, in lowp int fbMonochrome, in lowp int fbFixedAlpha)	\n"
 "{																			\n"
 "  mediump vec2 msTexSize = vec2(textureSize(mstex));						\n"
 "  mediump ivec2 itexCoord = ivec2(msTexSize * texCoord);					\n"
@@ -520,7 +520,7 @@ AUXILIARY_SHADER_VERSION
 "  if (fbMonochrome == 1) texColor = vec4(texColor.r);						\n"
 "  else if (fbMonochrome == 2) 												\n"
 "    texColor.rgb = vec3(dot(vec3(0.2126, 0.7152, 0.0722), texColor.rgb));	\n"
-"  if (fbFixedAlpha) texColor.a = 0.825;									\n"
+"  if (fbFixedAlpha == 1) texColor.a = 0.825;									\n"
 "  return texColor;															\n"
 "}																			\n"
 ;


### PR DESCRIPTION
Putting ```uFbFixedAlpha[1] != 0``` in the definition of the function actually create a "shader computed variable", at least in Mesa, when Mesa expands the function.

Basically it forces the GLSL compiler to create an if statement like:
```
bool variable
if uFbFixedAlpha[1] !=0
   variable = true
else
  variable = false
```

Since the values of uFbFixedAlpha[] can only be 0 or 1, this simplification works. I also removed a needless "else if" statement, since there is only one other possible value.