### PR TITLE
Changes to support mingw

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -393,7 +393,7 @@ void CombinerInfo::_saveShadersStorage() const
 	wchar_t fileName[PLUGIN_PATH_SIZE];
 	getStorageFileName(fileName);
 
-#ifdef OS_WINDOWS
+#if defined(OS_WINDOWS) && !defined(MINGW)
 	std::ofstream fout(fileName, std::ofstream::binary | std::ofstream::trunc);
 #else
 	char fileName_c[PATH_MAX];
@@ -431,7 +431,7 @@ bool CombinerInfo::_loadShadersStorage()
 	getStorageFileName(fileName);
 	m_configOptionsBitSet = _getConfigOptionsBitSet();
 
-#ifdef OS_WINDOWS
+#if defined(OS_WINDOWS) && !defined(MINGW)
 	std::ifstream fin(fileName, std::ofstream::binary);
 #else
 	char fileName_c[PATH_MAX];

--- a/src/Log.h
+++ b/src/Log.h
@@ -42,8 +42,8 @@ inline void LOG( u16 type, const char * format, ... ) {
 
 #endif
 
-#ifdef OS_WINDOWS
-#include "windows/GLideN64_Windows.h"
+#if defined(OS_WINDOWS) && !defined(MINGW)
+#include "windows/GLideN64_windows.h"
 #include <stdio.h>
 
 inline void debugPrint(const char * format, ...) {


### PR DESCRIPTION
I am working on porting this to RetroArch on Windows. It is compiled using mingw, not Visual Studio, and there are some minor differences in the required code syntax (it is a little more Unix like).

These changes allow it to be compiled using mingw by setting OS_WINDOWS and MINGW.

I also noticed and fixed a small typo (#include "windows/GLideN64_Windows.h")