### PR TITLE
Remove old arm assembler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,6 @@ if(EXISTS "/opt/vc/include/bcm_host.h")
   add_definitions(
     -DVC
     -DUSE_DEPTH_RENDERBUFFER
-    -DARM_ASM
   )
   include_directories(
     "/opt/vc/include"
@@ -167,7 +166,6 @@ if(PANDORA)
   -DPANDORA
   -DPowerVR_SGX_540
   -DGLES2
-  -DARM_ASM
    )
 endif(PANDORA)
 

--- a/src/convert.h
+++ b/src/convert.h
@@ -164,12 +164,7 @@ inline u16 swapword( u16 value )
 		xchg	ah, al
 	}
 #else // WIN32_ASM
-#ifdef ARM_ASM
-	asm("rev16 %0, %0" : "+r"(value)::);
-	return value;
-#else
 	return (value << 8) | (value >> 8);
-#endif // ARM_ASM
 #endif // WIN32_ASM
 }
 

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -97,7 +97,6 @@ ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
     # Use for ARM7a:
     MY_LOCAL_SRC_FILES += $(SRCDIR)/3DMathNeon.cpp.neon
     MY_LOCAL_SRC_FILES += $(SRCDIR)/gSPNeon.cpp.neon
-    MY_LOCAL_CFLAGS += -DARM_ASM
     MY_LOCAL_CFLAGS += -D__NEON_OPT
     MY_LOCAL_CFLAGS += -D__VEC4_OPT -mfpu=neon -mfloat-abi=softfp -ftree-vectorize -mvectorize-with-neon-quad -ftree-vectorizer-verbose=2 -funsafe-math-optimizations
 


### PR DESCRIPTION
GCC replaces (value << 8) | (value >> 8) with __builtin_bswap16 if -Os,
-O1 or higher optimization levels are used. __builtin_bswap16 is as fast as the assembler
declaration.