### PR TITLE
Fix Texture Cache slow down and crashes

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -526,12 +526,14 @@ void TextureCache::_checkCacheSize()
 #ifdef VC
 	const size_t maxCacheSize = 15000;
 #else
-	const size_t maxCacheSize = 128000;
+	const size_t maxCacheSize = 16384;
 #endif
-	// Clear cache if its size is too large.
 	if (m_textures.size() >= maxCacheSize) {
-		_clear();
-		return;
+		CachedTexture& clsTex = m_textures.back();
+		m_cachedBytes -= clsTex.textureBytes;
+		glDeleteTextures(1, &clsTex.glName);
+		m_lruTextureLocations.erase(clsTex.crc);
+		m_textures.pop_back();
 	}
 
 	if (m_cachedBytes <= m_maxBytes)


### PR DESCRIPTION
I experienced an issue on Slackware64-current, nouveau, GLideN64 and the game Beetle Adventure Racing where after playing for a while the game would begin to lag progressively worse until it would clear the texture cache and potentially bring my entire system down.

The problem was that Beetle Adventure Racing is capable of producing infinite textures and that GLideN64 had a max cache limit of 128,000 textures. This is problematic because some video drivers such as nouveau convert every single one of these textures into a 128 KB "large" page which would require 16 GB of vram where I have 3 GB.  After discussing this with the nouveau developers at #nouveau @ freenode it was suggested to have this limit as 16,384 instead which would require 2 GB of vram and is much saner. 

This avoided the slow down and crashes, but introduced an annoying issue where the game would freeze (Hiccup) momentarily every time it hit that limit and cleared the cache. To combat this loganmc10 suggested to clear only the oldest textures instead of the entire cache. This works wonderfully and solves all issues encountered.

So in short, this will fix slow downs, crashes and hiccups with GLideN64 and Beetle Adventure Racing while using some linux video drivers.

Please read this issue report that this PR will fix for more information.
https://github.com/loganmc10/GLupeN64/issues/56