### PR TITLE
Fix Depth Buffer emulation

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -387,7 +387,7 @@ void DepthBufferList::saveBuffer(u32 _address)
 		pDepthBuffer = nullptr;
 	}
 
-	if (pDepthBuffer == nullptr) {
+	if (m_pCurrent == nullptr) {
 		m_list.emplace_front();
 		DepthBuffer & buffer = m_list.front();
 
@@ -396,13 +396,10 @@ void DepthBufferList::saveBuffer(u32 _address)
 
 		buffer.initDepthBufferTexture(pFrameBuffer);
 
-		pDepthBuffer = &buffer;
+		m_pCurrent = &buffer;
 	}
 
-	if (pDepthBuffer->m_address == gDP.depthImageAddress) {
-		m_pCurrent = pDepthBuffer;
-		frameBufferList().attachDepthBuffer();
-	}
+	frameBufferList().attachDepthBuffer();
 
 #ifdef DEBUG
 		DebugMsg( DEBUG_HIGH | DEBUG_HANDLED, "DepthBuffer_SetBuffer( 0x%08X ); color buffer is 0x%08X\n",


### PR DESCRIPTION
This reverts part of commit https://github.com/gonetz/GLideN64/commit/8dad84cc39571c295d10a3b3c9326fa942478fcd to fix the depth buffer issue for Link's portrait in Orcarina of Time while still working with Toy Story 2.

![1](http://ks392457.kimsufi.com/orbea/stuff/pics/scrots/libretro/glupen64/Zelda%20OoT%2064-160926-022130.png)
![2](http://ks392457.kimsufi.com/orbea/stuff/pics/scrots/libretro/glupen64/Toy%20Story%202%20(E)%20%5b!%5d-160926-022058.png)