### PR TITLE
Set the program before updating uniforms

### DIFF
--- a/src/GLUniforms/UniformSet.cpp
+++ b/src/GLUniforms/UniformSet.cpp
@@ -131,6 +131,8 @@ void UniformSet::updateUniforms(ShaderCombiner * _pCombiner, OGLRender::RENDER_S
 {
 	UniformSetLocation & location = m_uniforms.at(_pCombiner->getKey());
 
+	glUseProgram(_pCombiner->m_program);
+
 	_updateColorUniforms(location, false);
 
 	if ((_renderState == OGLRender::rsTriangle || _renderState == OGLRender::rsLine) && _pCombiner->usesTexture())


### PR DESCRIPTION
See https://github.com/loganmc10/GLupeN64/issues/64 for a disucussion on this issue.

Basically the proper program wasn't being set prior to updating the uniform values.

@gonetz if there is a better place to put this go ahead, this just seemed like the right place to me.