### PR TITLE
Use full CRC calculation for CRC_OPT and GBI

### DIFF
--- a/src/CRC.cpp
+++ b/src/CRC.cpp
@@ -31,7 +31,7 @@ void CRC_BuildTable()
 	}
 }
 
-u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
+u32 CRC_Calculate_Strict( u32 crc, const void * buffer, u32 count )
 {
 	u8 *p;
 	u32 orig = crc;
@@ -41,6 +41,11 @@ u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
 		crc = (crc >> 8) ^ CRCTable[(crc & 0xFF) ^ *p++];
 
 	return crc ^ orig;
+}
+
+u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
+{
+        return CRC_Calculate_Strict(crc, buffer, count);
 }
 
 u32 CRC_CalculatePalette(u32 crc, const void * buffer, u32 count )

--- a/src/CRC.h
+++ b/src/CRC.h
@@ -3,5 +3,6 @@
 void CRC_BuildTable();
 
 // CRC32
+u32 CRC_Calculate_Strict( u32 crc, const void *buffer, u32 count );
 u32 CRC_Calculate( u32 crc, const void *buffer, u32 count );
 u32 CRC_CalculatePalette( u32 crc, const void *buffer, u32 count );

--- a/src/CRC_ARMV8.cpp
+++ b/src/CRC_ARMV8.cpp
@@ -5,7 +5,7 @@ void CRC_BuildTable()
 {
 }
 
-u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
+u32 CRC_Calculate_Strict( u32 crc, const void * buffer, u32 count )
 {
 	u8 *p;
 	u32 orig = crc;
@@ -33,6 +33,11 @@ u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
 		crc = __crc32b(crc, *p);
 
 	return crc ^ orig;
+}
+
+u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
+{
+	return CRC_Calculate_Strict(crc, buffer, count);
 }
 
 u32 CRC_CalculatePalette(u32 crc, const void * buffer, u32 count )

--- a/src/CRC_OPT.cpp
+++ b/src/CRC_OPT.cpp
@@ -1,7 +1,46 @@
 #include "CRC.h"
 
+#define CRC32_POLYNOMIAL     0x04C11DB7
+
+unsigned int CRCTable[ 256 ];
+
+u32 Reflect( u32 ref, char ch )
+{
+	 u32 value = 0;
+
+	 // Swap bit 0 for bit 7
+	 // bit 1 for bit 6, etc.
+	 for (int i = 1; i < (ch + 1); ++i) {
+		  if(ref & 1)
+			value |= 1 << (ch - i);
+		  ref >>= 1;
+	 }
+	 return value;
+}
+
 void CRC_BuildTable()
 {
+	u32 crc;
+
+	for (int i = 0; i < 256; ++i) {
+		crc = Reflect( i, 8 ) << 24;
+		for (int j = 0; j < 8; ++j)
+			crc = (crc << 1) ^ (crc & (1 << 31) ? CRC32_POLYNOMIAL : 0);
+
+		CRCTable[i] = Reflect( crc, 32 );
+	}
+}
+
+u32 CRC_Calculate_Strict( u32 crc, const void * buffer, u32 count )
+{
+	u8 *p;
+	u32 orig = crc;
+
+	p = (u8*) buffer;
+	while (count--)
+		crc = (crc >> 8) ^ CRCTable[(crc & 0xFF) ^ *p++];
+
+	return crc ^ orig;
 }
 
 u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )

--- a/src/GBI.cpp
+++ b/src/GBI.cpp
@@ -241,7 +241,7 @@ void GBIInfo::loadMicrocode(u32 uc_start, u32 uc_dstart, u16 uc_dsize)
 	current.type = NONE;
 
 	// See if we can identify it by CRC
-	const u32 uc_crc = CRC_Calculate( 0xFFFFFFFF, &RDRAM[uc_start & 0x1FFFFFFF], 4096 );
+	const u32 uc_crc = CRC_Calculate_Strict( 0xFFFFFFFF, &RDRAM[uc_start & 0x1FFFFFFF], 4096 );
 	const u32 numSpecialMicrocodes = sizeof(specialMicrocodes) / sizeof(SpecialMicrocodeInfo);
 	for (u32 i = 0; i < numSpecialMicrocodes; ++i) {
 		if (uc_crc == specialMicrocodes[i].crc) {


### PR DESCRIPTION
The optimized CRC calculation doesn't work with GBIInfo::loadMicrocode, when you try to launch Perfect Dark, you get a "[GLideN64]: error - unknown ucode!!!" message.

This change makes CRC_OPT use the regular CRC calculator for the ucode calculation