### PR TITLE
Add getTextSize to TextDrawerStub

### DIFF
--- a/src/TextDrawerStub.cpp
+++ b/src/TextDrawerStub.cpp
@@ -4,6 +4,7 @@ TextDrawer::TextDrawer() {}
 void TextDrawer::init() {}
 void TextDrawer::destroy() {}
 void TextDrawer::renderText(const char * /*_pText*/, float /*x*/, float /*y*/) const {}
+void TextDrawer::getTextSize(const char *_pText, float & _w, float & _h) const {}
 TextDrawer & TextDrawer::get() {
 	static TextDrawer drawer;
 	return drawer;


### PR DESCRIPTION
Fixes compile when using TextDrawerStub.cpp instead of TextDrawer.cpp