### PR TITLE
GLES3 fix for nvc0

### DIFF
--- a/src/FBOTextureFormats.cpp
+++ b/src/FBOTextureFormats.cpp
@@ -43,9 +43,9 @@ void FBOTextureFormats::init()
 	monochromeType = GL_UNSIGNED_BYTE;
 	monochromeFormatBytes = 1;
 
-	depthInternalFormat = GL_DEPTH_COMPONENT32F;
+	depthInternalFormat = GL_DEPTH_COMPONENT24;
 	depthFormat = GL_DEPTH_COMPONENT;
-	depthType = GL_FLOAT;
+	depthType = GL_UNSIGNED_INT;
 	depthFormatBytes = 4;
 
 	depthImageInternalFormat = GL_RGBA32F;


### PR DESCRIPTION
This fix suggested by a nouveau dev will resolve a blending / transparency issue with Ocarina of Time, GLES3, GLupeN64 and the nouveau nvc0 driver. Strangely enough this problem does not occur with the intel, llvmpipe or nv50 drivers nor does it occur with OpenGL or GLES2.

Please read issue https://github.com/loganmc10/GLupeN64/issues/74 for more discussion.