### PR TITLE
Fixes slow PBOs in Paper Mario.

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM_GL.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM_GL.cpp
@@ -63,7 +63,7 @@ bool ColorBufferToRDRAM_GL::_readPixels(GLint _x0, GLint _y0, GLsizei _width, GL
 {
 	GLenum colorFormat, colorType, colorFormatBytes;
 	if (_size > G_IM_SIZ_8b) {
-		colorFormat = fboFormats.colorFormat;
+		colorFormat = fboFormats.colorInternalFormat;
 		colorType = fboFormats.colorType;
 		colorFormatBytes = fboFormats.colorFormatBytes;
 	} else {

--- a/src/FBOTextureFormats.cpp
+++ b/src/FBOTextureFormats.cpp
@@ -33,7 +33,7 @@ void FBOTextureFormats::init()
 		colorFormatBytes = 2;
 	}
 #elif defined(GLES3) || defined (GLES3_1)
-	colorInternalFormat = GL_RGBA;
+	colorInternalFormat = GL_RGBA8;
 	colorFormat = GL_RGBA;
 	colorType = GL_UNSIGNED_BYTE;
 	colorFormatBytes = 4;


### PR DESCRIPTION
For some reason this only affected Paper Mario. The game now runs at a good speed with async copy color buffer to RDRAM on Adreno devices. I'm wondering if the same treatment needs to be applied to monochrome copies as well.

This issue: https://github.com/gonetz/GLideN64/issues/1091