### PR TITLE
Use GL_DEPTH_COMPONENT16 for renderbuffer

### DIFF
--- a/src/FBOTextureFormats.cpp
+++ b/src/FBOTextureFormats.cpp
@@ -10,7 +10,7 @@ void FBOTextureFormats::init()
 	monochromeType = GL_UNSIGNED_SHORT_5_6_5;
 	monochromeFormatBytes = 2;
 
-#ifndef VC
+#ifndef USE_DEPTH_RENDERBUFFER
 	depthInternalFormat = GL_DEPTH_COMPONENT;
 	depthFormatBytes = 4;
 #else


### PR DESCRIPTION
I tested USE_DEPTH_RENDERBUFFER on Android GLES2 and it produced a black screen.

According to https://www.khronos.org/opengles/sdk/docs/man/xhtml/glRenderbufferStorage.xml

GL_DEPTH_COMPONENT16 is the only valid internal format for GLES2 when using glRenderbufferStorage

This change solved the problem and allows USE_DEPTH_RENDERBUFFER to work on all GLES2 devices