### PR TITLE
Zelda subscreen hack always enables copy color to RDRAM

### DIFF
--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -119,7 +119,7 @@ void VI_UpdateScreen()
 			gDP.changed |= CHANGED_CPU_FB_WRITE;
 		else if (!FBInfo::fbInfo.isSupported() && !pBuffer->isValid(true)) {
 			gDP.changed |= CHANGED_CPU_FB_WRITE;
-			if (config.frameBufferEmulation.copyToRDRAM == 0)
+			if (config.frameBufferEmulation.copyToRDRAM == 0 && (config.generalEmulation.hacks & hack_subscreen) == 0)
 				pBuffer->copyRdram();
 		}
 

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -899,7 +899,7 @@ void gDPFullSync()
 	video().getRender().flush();
 
 	const bool sync = config.frameBufferEmulation.copyToRDRAM == Config::ctSync;
-	if (config.frameBufferEmulation.copyToRDRAM != Config::ctDisable &&
+	if ((config.frameBufferEmulation.copyToRDRAM != Config::ctDisable || (config.generalEmulation.hacks & hack_subscreen) != 0) &&
 		!FBInfo::fbInfo.isSupported() &&
 		frameBufferList().getCurrent() != nullptr &&
 		!frameBufferList().getCurrent()->isAuxiliary()


### PR DESCRIPTION
Zelda subscreen hack always enables copy color to RDRAM. It's annoying to have to tell people to enable CopyColorToRDRAM to fix the subscreen delay for zelda games.