### PR TITLE
Fix crash with software depth buffer when loading save states

### DIFF
--- a/src/SoftwareRender.cpp
+++ b/src/SoftwareRender.cpp
@@ -163,6 +163,10 @@ int clipW(const SPVertex ** _vsrc, SPVertex * _vdst)
 
 void renderTriangles(const SPVertex * _pVertices, const GLubyte * _pElements, u32 _numElements)
 {
+	//Current depth buffer can be null if we are loading from a save state
+	if(depthBufferList().getCurrent() == nullptr)
+		return;
+
 	vertexclip vclip[16];
 	vertexi vdraw[12];
 	const SPVertex * vsrc[4];


### PR DESCRIPTION
Fix crash with software depth buffer when loading save states.

See https://github.com/gonetz/GLideN64/issues/1187