### PR TITLE
Specify a specific CRC function for microcodes

### DIFF
--- a/src/CRC.h
+++ b/src/CRC.h
@@ -2,5 +2,6 @@
 
 void CRC_Init();
 
+u32 CRC_Calculate_Strict( u32 crc, const void *buffer, u32 count );
 u32 CRC_Calculate( u32 crc, const void *buffer, u32 count );
 u32 CRC_CalculatePalette( u32 crc, const void *buffer, u32 count );

--- a/src/CRC32.cpp
+++ b/src/CRC32.cpp
@@ -44,6 +44,11 @@ u32 CRC_Calculate( u32 crc, const void * buffer, u32 count )
 	return crc ^ orig;
 }
 
+u32 CRC_Calculate_Strict( u32 crc, const void * buffer, u32 count )
+{
+	return CRC_Calculate(crc, buffer, count);
+}
+
 u32 CRC_CalculatePalette(u32 crc, const void * buffer, u32 count )
 {
 	u8 *p;

--- a/src/GBI.cpp
+++ b/src/GBI.cpp
@@ -241,7 +241,7 @@ void GBIInfo::loadMicrocode(u32 uc_start, u32 uc_dstart, u16 uc_dsize)
 	current.type = NONE;
 
 	// See if we can identify it by CRC
-	const u32 uc_crc = CRC_Calculate( 0xFFFFFFFF, &RDRAM[uc_start & 0x1FFFFFFF], 4096 );
+	const u32 uc_crc = CRC_Calculate_Strict( 0xFFFFFFFF, &RDRAM[uc_start & 0x1FFFFFFF], 4096 );
 	const u32 numSpecialMicrocodes = sizeof(specialMicrocodes) / sizeof(SpecialMicrocodeInfo);
 	for (u32 i = 0; i < numSpecialMicrocodes; ++i) {
 		if (uc_crc == specialMicrocodes[i].crc) {


### PR DESCRIPTION
The CRC calculation in GBI.cpp is unique because it is comparing the results to a pre-created list of CRC's (specialMicrocodes):

https://github.com/gonetz/GLideN64/blob/master/src/GBI.cpp#L34-L56

GLupeN64 is using xxHash for the CRC calculations by intercepting the CRC_Calculate call and running xxHash instead of the regular function. The microcode check fails because that specific CRC needs to be run by the CRC32 calculation. This will allow me to implement xxHash for everything except the microcode calculation, which I will run with CRC32.

This won't change any functionality for the "regular" codepath.