### PR TITLE
Remove copyDepthToRDRAM from GLideN64.custom.ini

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -9,7 +9,6 @@ frameBufferEmulation\N64DepthCompare=1
 [1080%20SNOWBOARDING]
 Good_Name=1080 Snowboarding (E)(JU)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [6D120CBF]
 Good_Name=64 De Hakken!! Tamagotchi - Minna De Tamagotchi World (J)
@@ -44,12 +43,10 @@ frameBufferEmulation\copyToRDRAM=2
 [BEETLE%20ADVENTURE%20RAC]
 Good_Name=Beetle Adventure Racing (E)(U)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BEETLE%20ADVENTURE%20JP]
 Good_Name=Beetle Adventure Racing (J)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [BIOFREAKS]
 Good_Name=Bio F.R.E.A.K.S. (E)(U)
@@ -82,7 +79,6 @@ Good_Name=Chou Snobow Kids (J)
 [CONKER%20BFD]
 Good_Name=Conker's Bad Fur Day (E)(U)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [362D06B6]
 Good_Name=Densha de Go! 64 (J)
@@ -90,22 +86,18 @@ Good_Name=Densha de Go! 64 (J)
 [DONALD%20DUCK%20GOIN%27%20QU]
 Good_Name=Donald Duck - Goin' Quackers (U)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [DONALD%20DUCK%20QUACK%20AT]
 Good_Name=Donald Duck - Quack Attack (E)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [DONKEY%20KONG%2064]
 Good_Name=Donkey Kong 64 (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [D%20K%20DISPLAY]
 Good_Name=Donkey Kong 64 Kiosk Demo (U)
 frameBufferEmulation\copyToRDRAM=1
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [72390C86]
 Good_Name=Doraemon - Nobita To 3tsu No Seireiseki (J)
@@ -122,9 +114,6 @@ frameBufferEmulation\copyFromRDRAM=1
 
 [67000C2B]
 Good_Name=Eikou No Saint Andrews (J)
-
-[EXCITEBIKE64]
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [EXTREME_G]
 Good_Name=Extreme-G (E)
@@ -182,7 +171,6 @@ Good_Name=Hiryuu No Ken Twin (J)
 [HSV%20ADVENTURE%20RACING]
 Good_Name=HSV Adventure Racing (A)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [83CA0DCA]
 Good_Name=Ide Yousuke No Mahjong Juku (J)
@@ -234,7 +222,6 @@ frameBufferEmulation\N64DepthCompare=1
 [MARIOGOLF64]
 Good_Name=Mario Golf (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [MARIOKART64]
 Good_Name=Mario Kart 64 (E)(J)(U)
@@ -257,12 +244,10 @@ frameBufferEmulation\copyToRDRAM=2
 
 [MICKEY%20USA%20PAL]
 Good_Name=Mickey's Speedway USA (E)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\copyToRDRAM=2
 
 [MICKEY%20USA]
 Good_Name=Mickey's Speedway USA (U) / Mickey No Racing Challenge USA (J)
-frameBufferEmulation\copyDepthToRDRAM=1
 frameBufferEmulation\copyToRDRAM=2
 
 [293D0695]
@@ -285,7 +270,6 @@ frameBufferEmulation\copyToRDRAM=0
 [PERFECT%20DARK]
 Good_Name=Perfect Dark (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [POKEMON%20SNAP]
 Good_Name=Pokemon Snap (U)
@@ -336,7 +320,6 @@ frameBufferEmulation\copyToRDRAM=0
 
 [STAR%20WARS%20EP1%20RACER]
 Good_Name=Star Wars Episode I - Racer (E)(U)(J)
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [67ED0B45]
 Good_Name=Super Robot Taisen 64 (J)
@@ -344,26 +327,19 @@ Good_Name=Super Robot Taisen 64 (J)
 [622D0C12]
 Good_Name=Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (J)
 
-[TWISTED%20EDGE]
-frameBufferEmulation\copyDepthToRDRAM=1
-
 [ZELDA%20MAJORA%27S%20MASK]
 Good_Name=The Legend Of Zelda - Majora's Mask (E)(U) / Zelda No Densetsu - Mujura No Karmen (J)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [MAJORA%27S%20MASK]
 Good_Name=The Legend Of Zelda - Majora's Mask Demo (U)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [THE%20LEGEND%20OF%20ZELDA]
 Good_Name=The Legend Of Zelda - Ocarina Of Time (E)(U) / Zelda No Densetsu - Toki No Ocarina (J)
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [ZELDA%20MASTER%20QUEST]
 Good_Name=The Legend Of Zelda - Ocarina Of Time - Master Quest
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [TIGGER%27S%20HONEY%20HUNT]
 Good_Name=Tigger's Honey Hunt (E)(U)
@@ -378,7 +354,6 @@ Good_Name=Ucchan Nanchan No Hono No Challenger - Denryuu Ira Ira Bou (J)
 
 [VIGILANTE%208]
 Good_Name=Vigilante 8 (E)(F)(G)(U)
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [4C2E093B]
 Good_Name=Virtual Pro Wrestling 2 - Oudou Keishou (J)
@@ -392,7 +367,6 @@ Good_Name=WWF Wrestlemania 2000 (J)
 [THE%20MASK%20OF%20MUJURA]
 Good_Name=Zelda No Densetsu - Mujura No Karmen (J)
 frameBufferEmulation\copyToRDRAM=2
-frameBufferEmulation\copyDepthToRDRAM=1
 
 [7BC50D43]
 Good_Name=Zool - Majuu Tsukai Densetsu (J)


### PR DESCRIPTION
Since software depth copy is the default these entries should be removed.

That is unless someone is aware of a game that requires VRAM copy?