### PR TITLE
Add support for LOD with GLES2

### DIFF
--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -189,25 +189,31 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 	if (config.generalEmulation.enableNoise == 0)
 		strFragmentShader.append(fragment_shader_dummy_noise);
 
+	if (bUseLod && config.generalEmulation.enableLOD == 0)
+		strFragmentShader.append(fragment_shader_fake_mipmap);
+
 	if (bUseHWLight)
 		strFragmentShader.append(fragment_shader_calc_light);
-	if (bUseLod)
-		strFragmentShader.append(fragment_shader_fake_mipmap);
-	else if (usesTexture()) {
+	if (bUseLod) {
+		if (config.generalEmulation.enableLOD != 0)
+			strFragmentShader.append(fragment_shader_mipmap);
+	}else if (usesTexture()) {
 		if (config.texture.bilinearMode == BILINEAR_3POINT)
 			strFragmentShader.append(fragment_shader_readtex_3point);
 		else
 			strFragmentShader.append(fragment_shader_readtex);
 	}
-	if (config.generalEmulation.enableNoise != 0)
+
+	if (config.generalEmulation.enableNoise != 0) {
 		strFragmentShader.append(fragment_shader_noise);
+	}
 
 	GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
 	const GLchar * strShaderData = strFragmentShader.data();
 	glShaderSource(fragmentShader, 1, &strShaderData, NULL);
 	glCompileShader(fragmentShader);
 	if (!checkShaderCompileStatus(fragmentShader))
-		LOG(LOG_ERROR, "Error in fragment shader:\n%s\n", strFragmentShader.data());
+		logErrorShader(GL_FRAGMENT_SHADER, strFragmentShader);
 
 	m_program = glCreateProgram();
 	_locate_attributes();
@@ -251,6 +257,7 @@ void ShaderCombiner::_locateUniforms() {
 	LocateUniform(uFbMonochrome);
 	LocateUniform(uFbFixedAlpha);
 	LocateUniform(uMaxTile)
+	LocateUniform(uTextureDetail);
 	LocateUniform(uTexturePersp);
 	LocateUniform(uTextureFilterMode);
 	LocateUniform(uForceBlendCycle1);
@@ -388,9 +395,20 @@ void ShaderCombiner::updateDitherMode(bool _bForce)
 
 void ShaderCombiner::updateLOD(bool _bForce)
 {
-	if (usesLOD()) {
-		m_uniforms.uMinLod.set(gDP.primColor.m, _bForce);
-		m_uniforms.uMaxTile.set(gSP.texture.level, _bForce);
+	if (!usesLOD())
+		return;
+
+	m_uniforms.uMinLod.set(gDP.primColor.m, _bForce);
+	m_uniforms.uMaxTile.set(gSP.texture.level, _bForce);
+
+	if (config.generalEmulation.enableLOD != 0) {
+		const int uCalcLOD = (gDP.otherMode.textureLOD == G_TL_LOD) ? 1 : 0;
+		m_uniforms.uEnableLod.set(uCalcLOD, _bForce);
+		if (config.frameBufferEmulation.nativeResFactor == 0)
+			m_uniforms.uScreenScale.set(video().getScaleX(), video().getScaleY(), _bForce);
+		else
+			m_uniforms.uScreenScale.set(float(config.frameBufferEmulation.nativeResFactor), float(config.frameBufferEmulation.nativeResFactor), _bForce);
+		m_uniforms.uTextureDetail.set(gDP.otherMode.textureDetail, _bForce);
 	}
 }
 

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -2102,6 +2102,14 @@ void OGLRender::_initExtensions()
 	} else
 		config.texture.maxAnisotropyF = 0.0f;
 	LOG(LOG_VERBOSE, "Max Anisotropy: %f\n", config.texture.maxAnisotropyF);
+
+#ifdef GLES2
+	if(!OGLVideo::isExtensionSupported("GL_EXT_shader_texture_lod") ||
+	!OGLVideo::isExtensionSupported("GL_OES_standard_derivatives")){
+		config.generalEmulation.enableLOD = 0;
+	}
+
+#endif
 }
 
 void OGLRender::_initStates()

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1066,13 +1066,11 @@ void TextureCache::_load(u32 _tile, CachedTexture *_pTexture)
 	pDest = (u32*)malloc(_pTexture->textureBytes);
 	assert(pDest != nullptr);
 
-	GLint mipLevel = 0, maxLevel = 0;
-#ifndef GLES2
-	if (config.generalEmulation.enableLOD != 0 && gSP.texture.level > 1)
-		maxLevel = _tile == 0 ? 0 : gSP.texture.level - 1;
-#endif
+	GLint mipLevel = 0;
+	_pTexture->max_level = 0;
 
-	_pTexture->max_level = maxLevel;
+	if (config.generalEmulation.enableLOD != 0 && gSP.texture.level > 1)
+		_pTexture->max_level = static_cast<u8>(_tile == 0 ? 0 : gSP.texture.level - 1);
 
 	CachedTexture tmptex(0);
 	memcpy(&tmptex, _pTexture, sizeof(CachedTexture));
@@ -1099,7 +1097,7 @@ void TextureCache::_load(u32 _tile, CachedTexture *_pTexture)
 
 		bool bLoaded = false;
 		if ((config.textureFilter.txEnhancementMode | config.textureFilter.txFilterMode) != 0 &&
-				maxLevel == 0 &&
+				_pTexture->max_level == 0 &&
 				(config.textureFilter.txFilterIgnoreBG == 0 || (RSP.cmd != G_TEXRECT && RSP.cmd != G_TEXRECTFLIP)) &&
 				TFH.isInited())
 		{
@@ -1135,7 +1133,7 @@ void TextureCache::_load(u32 _tile, CachedTexture *_pTexture)
 					tmptex.realHeight, 0, GL_RGBA, glType, pDest);
 #endif
 		}
-		if (mipLevel == maxLevel)
+		if (mipLevel == _pTexture->max_level)
 			break;
 		++mipLevel;
 		const u32 tileMipLevel = gSP.texture.tile + mipLevel + 1;


### PR DESCRIPTION
This requires that the GLES2 device support certain extensions:

GL_EXT_shader_texture_lod
GL_OES_standard_derivatives

99% of the code came from the GLES 3.0 version.