### PR TITLE
Silence some compiler warnings

### DIFF
--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -4,7 +4,9 @@
 #include <vector>
 
 #ifdef OS_WINDOWS
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include "winlnxdefs.h"

--- a/src/osal/osal_files.h
+++ b/src/osal/osal_files.h
@@ -36,7 +36,9 @@ extern "C" {
 #if defined(OS_WINDOWS)
 #define EXPORT	__declspec(dllexport)
 #define CALL		__cdecl
+#ifndef PATH_MAX
 #define PATH_MAX _MAX_PATH
+#endif
 #define strdup _strdup
 #else  /* Not WIN32 */
 #define EXPORT 	__attribute__((visibility("default")))


### PR DESCRIPTION
I'm not sure about Visual Studio, but when cross compiling this project with MinGW, I get a lot of warnings because these things are already defined in system headers. This just silences the warnings by not re-defining them.