### PR TITLE
Aspect: "Adjust:" -> "Try to adjust"; "Per-pixel" -> "Phong shading"; fixing OSD autoselect

### DIFF
--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -368,7 +368,7 @@
              <item>
               <widget class="QRadioButton" name="aspectAdjustRadioButton">
                <property name="text">
-                <string>Adjust game to fit</string>
+                <string>Try to adjust game to fit</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">aspectButtonGroup</string>
@@ -984,10 +984,10 @@
            <item>
             <widget class="QCheckBox" name="enableHWLightingCheckBox">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In traditional PC games lighting is calculated per vertex. This option enables per-pixel shader-based lighting. When checked, lighting is smoother and more accurate to the N64.&lt;br/&gt;&lt;br/&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Your preference&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In traditional PC games lighting is calculated per vertex. This option enables Phong shading. When checked, lighting is smoother and more accurate to the N64.&lt;br/&gt;&lt;br/&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Your preference&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
-              <string>Enable hardware lighting (HLE only)</string>
+              <string>Enable per-pixel lighting (better quality, slower, HLE only)</string>
              </property>
             </widget>
            </item>
@@ -2563,6 +2563,9 @@
                   <property name="autoExclusive">
                    <bool>true</bool>
                   </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
+                  </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
                   </attribute>
@@ -2612,6 +2615,9 @@
                   <property name="autoExclusive">
                    <bool>true</bool>
                   </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
+                  </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
                   </attribute>
@@ -2660,6 +2666,9 @@
                   </property>
                   <property name="autoExclusive">
                    <bool>true</bool>
+                  </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
                   </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
@@ -2720,6 +2729,9 @@
                   <property name="autoExclusive">
                    <bool>true</bool>
                   </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
+                  </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
                   </attribute>
@@ -2755,6 +2767,9 @@
                   </property>
                   <property name="text">
                    <string/>
+                  </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
                   </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
@@ -2807,6 +2822,9 @@
                   </property>
                   <property name="autoExclusive">
                    <bool>true</bool>
+                  </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
                   </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
@@ -2861,6 +2879,9 @@
                   <property name="autoExclusive">
                    <bool>true</bool>
                   </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
+                  </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
                   </attribute>
@@ -2910,6 +2931,9 @@
                   <property name="autoExclusive">
                    <bool>true</bool>
                   </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
+                  </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
                   </attribute>
@@ -2958,6 +2982,9 @@
                   </property>
                   <property name="autoExclusive">
                    <bool>true</bool>
+                  </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
                   </property>
                   <attribute name="buttonGroup">
                    <string notr="true">osdButtonGroup</string>
@@ -4498,11 +4525,11 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="osdButtonGroup"/>
-  <buttongroup name="fixTexrectCoordsButtonGroup"/>
   <buttongroup name="factorButtonGroup"/>
+  <buttongroup name="fixTexrectCoordsButtonGroup"/>
+  <buttongroup name="screenshotButtonGroup"/>
+  <buttongroup name="osdButtonGroup"/>
   <buttongroup name="bloomBlendModeButtonGroup"/>
   <buttongroup name="aspectButtonGroup"/>
-  <buttongroup name="screenshotButtonGroup"/>
  </buttongroups>
 </ui>

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -4523,13 +4523,173 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>factor0xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorOffLabel</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>195</x>
+     <y>252</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor0xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>resolutionFactorSlider</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>391</x>
+     <y>258</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor0xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorHighLabel</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>589</x>
+     <y>252</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor0xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorLabelVal</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>283</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor0xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorXLabel</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>394</x>
+     <y>283</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor1xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorOffLabel</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>195</x>
+     <y>252</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor1xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>resolutionFactorSlider</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>391</x>
+     <y>258</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor1xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorHighLabel</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>589</x>
+     <y>252</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor1xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorLabelVal</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>283</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>factor1xRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>factorXLabel</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>94</x>
+     <y>251</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>394</x>
+     <y>283</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="factorButtonGroup"/>
   <buttongroup name="fixTexrectCoordsButtonGroup"/>
   <buttongroup name="screenshotButtonGroup"/>
-  <buttongroup name="osdButtonGroup"/>
   <buttongroup name="bloomBlendModeButtonGroup"/>
+  <buttongroup name="factorButtonGroup"/>
   <buttongroup name="aspectButtonGroup"/>
+  <buttongroup name="osdButtonGroup"/>
  </buttongroups>
 </ui>

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -420,105 +420,126 @@
                   <number>10</number>
                  </property>
                  <item>
-                  <widget class="QLabel" name="aliasingOffLabel">
-                   <property name="text">
-                    <string>Off</string>
+                  <layout class="QHBoxLayout" name="horizontalLayout_31">
+                   <property name="topMargin">
+                    <number>9</number>
                    </property>
-                  </widget>
+                   <item alignment="Qt::AlignTop">
+                    <widget class="QLabel" name="aliasingOffLabel">
+                     <property name="text">
+                      <string>Off</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                  <item>
-                  <widget class="QSlider" name="aliasingSlider">
-                   <property name="maximum">
-                    <number>8</number>
-                   </property>
-                   <property name="singleStep">
+                  <layout class="QVBoxLayout" name="verticalLayout_44">
+                   <property name="spacing">
                     <number>2</number>
                    </property>
-                   <property name="pageStep">
-                    <number>2</number>
-                   </property>
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="tickPosition">
-                    <enum>QSlider::TicksAbove</enum>
-                   </property>
-                   <property name="tickInterval">
-                    <number>2</number>
-                   </property>
-                  </widget>
+                   <item>
+                    <widget class="QSlider" name="aliasingSlider">
+                     <property name="maximum">
+                      <number>8</number>
+                     </property>
+                     <property name="singleStep">
+                      <number>2</number>
+                     </property>
+                     <property name="pageStep">
+                      <number>2</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="tickPosition">
+                      <enum>QSlider::TicksAbove</enum>
+                     </property>
+                     <property name="tickInterval">
+                      <number>2</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_3">
+                     <property name="spacing">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <spacer name="horizontalSpacer">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::MinimumExpanding</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="aliasingLabelVal">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="text">
+                        <string notr="true">0</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="aliasingXLabel">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="text">
+                        <string notr="true">x</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_2">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::MinimumExpanding</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
                  </item>
                  <item>
-                  <widget class="QLabel" name="aliasingHighLabel">
-                   <property name="text">
-                    <string>High</string>
+                  <layout class="QHBoxLayout" name="horizontalLayout_32">
+                   <property name="topMargin">
+                    <number>9</number>
                    </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_3">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <spacer name="horizontalSpacer">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::MinimumExpanding</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="aliasingLabelVal">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string notr="true">0</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="aliasingXLabel">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string notr="true">x</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::MinimumExpanding</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
+                   <item alignment="Qt::AlignTop">
+                    <widget class="QLabel" name="aliasingHighLabel">
+                     <property name="text">
+                      <string>High</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                 </layout>
                </item>
@@ -545,111 +566,132 @@
                   <number>10</number>
                  </property>
                  <item>
-                  <widget class="QLabel" name="anisotropicOffLabel">
-                   <property name="text">
-                    <string>Off</string>
+                  <layout class="QHBoxLayout" name="horizontalLayout_33">
+                   <property name="topMargin">
+                    <number>9</number>
                    </property>
-                  </widget>
+                   <item alignment="Qt::AlignTop">
+                    <widget class="QLabel" name="anisotropicOffLabel">
+                     <property name="text">
+                      <string>Off</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                  <item>
-                  <widget class="QSlider" name="anisotropicSlider">
-                   <property name="maximum">
-                    <number>16</number>
-                   </property>
-                   <property name="singleStep">
+                  <layout class="QVBoxLayout" name="verticalLayout_46">
+                   <property name="spacing">
                     <number>2</number>
                    </property>
-                   <property name="pageStep">
-                    <number>2</number>
-                   </property>
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="invertedAppearance">
-                    <bool>false</bool>
-                   </property>
-                   <property name="invertedControls">
-                    <bool>false</bool>
-                   </property>
-                   <property name="tickPosition">
-                    <enum>QSlider::TicksAbove</enum>
-                   </property>
-                   <property name="tickInterval">
-                    <number>2</number>
-                   </property>
-                  </widget>
+                   <item>
+                    <widget class="QSlider" name="anisotropicSlider">
+                     <property name="maximum">
+                      <number>16</number>
+                     </property>
+                     <property name="singleStep">
+                      <number>2</number>
+                     </property>
+                     <property name="pageStep">
+                      <number>2</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="invertedAppearance">
+                      <bool>false</bool>
+                     </property>
+                     <property name="invertedControls">
+                      <bool>false</bool>
+                     </property>
+                     <property name="tickPosition">
+                      <enum>QSlider::TicksAbove</enum>
+                     </property>
+                     <property name="tickInterval">
+                      <number>2</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_4">
+                     <property name="spacing">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <spacer name="horizontalSpacer_3">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::MinimumExpanding</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="anisotropicLabelVal">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="text">
+                        <string notr="true">0</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="anisotropicXLabel">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="text">
+                        <string notr="true">x</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_6">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::MinimumExpanding</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
                  </item>
                  <item>
-                  <widget class="QLabel" name="anisotropicHighLabel">
-                   <property name="text">
-                    <string>High</string>
+                  <layout class="QHBoxLayout" name="horizontalLayout_34">
+                   <property name="topMargin">
+                    <number>9</number>
                    </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <spacer name="horizontalSpacer_3">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::MinimumExpanding</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="anisotropicLabelVal">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string notr="true">0</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="anisotropicXLabel">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string notr="true">x</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_6">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::MinimumExpanding</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </spacer>
+                   <item alignment="Qt::AlignTop">
+                    <widget class="QLabel" name="anisotropicHighLabel">
+                     <property name="text">
+                      <string>High</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                 </layout>
                </item>
@@ -1067,7 +1109,7 @@
                <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_28">
                  <property name="topMargin">
-                  <number>2</number>
+                  <number>9</number>
                  </property>
                  <item alignment="Qt::AlignTop">
                   <widget class="QLabel" name="factorOffLabel">
@@ -1081,7 +1123,7 @@
                <item>
                 <layout class="QVBoxLayout" name="verticalLayout_9">
                  <property name="spacing">
-                  <number>4</number>
+                  <number>2</number>
                  </property>
                  <item>
                   <widget class="QSlider" name="resolutionFactorSlider">
@@ -1098,7 +1140,7 @@
                     <enum>Qt::Horizontal</enum>
                    </property>
                    <property name="tickPosition">
-                    <enum>QSlider::TicksBelow</enum>
+                    <enum>QSlider::TicksAbove</enum>
                    </property>
                    <property name="tickInterval">
                     <number>1</number>
@@ -1175,7 +1217,7 @@
                <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_29">
                  <property name="topMargin">
-                  <number>2</number>
+                  <number>9</number>
                  </property>
                  <item alignment="Qt::AlignTop">
                   <widget class="QLabel" name="factorHighLabel">
@@ -4685,11 +4727,11 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="fixTexrectCoordsButtonGroup"/>
+  <buttongroup name="osdButtonGroup"/>
+  <buttongroup name="aspectButtonGroup"/>
+  <buttongroup name="factorButtonGroup"/>
   <buttongroup name="screenshotButtonGroup"/>
   <buttongroup name="bloomBlendModeButtonGroup"/>
-  <buttongroup name="factorButtonGroup"/>
-  <buttongroup name="aspectButtonGroup"/>
-  <buttongroup name="osdButtonGroup"/>
+  <buttongroup name="fixTexrectCoordsButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
"Phong shading" actually isn't a bad label for the checkbox, but "per-pixel lighting" might be better for novice users.