### PR TITLE
Check for GL_ARB_shader_image_load_store

### DIFF
--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -2089,7 +2089,7 @@ void OGLRender::_initExtensions()
 
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 #ifndef GLESX
-	m_bImageTexture = (majorVersion >= 4) && (minorVersion >= 3) && (glBindImageTexture != nullptr);
+	m_bImageTexture = (((majorVersion >= 4) && (minorVersion >= 3)) || OGLVideo::isExtensionSupported("GL_ARB_shader_image_load_store"))&& (glBindImageTexture != nullptr);
 #elif defined(GLES3_1)
 	m_bImageTexture = (majorVersion >= 3) && (minorVersion >= 1) && (glBindImageTexture != nullptr);
 #else


### PR DESCRIPTION
Image Textures might be available on devices with OpenGL < 4.3 if they support GL_ARB_shader_image_load_store