### PR TITLE
MAX_PATH broke Ubuntu 16.04 build

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -5,6 +5,7 @@
 #include "Log.h"
 #include "PluginAPI.h"
 #include "wst.h"
+#include "Ext_TxFilter.h"
 
 void LOG(u16 type, const char * format, ...) {
 	if (type > LOG_LEVEL)


### PR DESCRIPTION
It's PATH_MAX on Ubuntu. I don't know all the platforms this is
supported on. Can build on Ubuntu 16.04 later if needs be. May have to
include linux/limits.h on Linux.

Logged issue here initially:

https://github.com/RetroPie/RetroPie-Setup/issues/1756