### PR TITLE
Remove some GLES3_1 ifdefs

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -145,7 +145,7 @@ void DepthBuffer::_initDepthBufferTexture(FrameBuffer * _pBuffer, CachedTexture 
 #ifdef GL_MULTISAMPLING_SUPPORT
 	if (_multisample) {
 		glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, _pTexture->glName);
-#if defined(GLES3_1)
+#if defined(GLESX)
 		glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling, fboFormats.depthInternalFormat, _pTexture->realWidth, _pTexture->realHeight, false);
 #else
 		glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling, fboFormats.depthInternalFormat, _pTexture->realWidth, _pTexture->realHeight, false);

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -141,7 +141,7 @@ void FrameBuffer::init(u32 _address, u32 _endAddress, u16 _format, u16 _size, u1
 #ifdef GL_MULTISAMPLING_SUPPORT
 	if (config.video.multisampling != 0) {
 		glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, m_pTexture->glName);
-#if defined(GLES3_1)
+#if defined(GLESX)
 		if (_size > G_IM_SIZ_8b)
 			glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling, GL_RGBA8, m_pTexture->realWidth, m_pTexture->realHeight, false);
 		else

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -2095,10 +2095,8 @@ void OGLRender::_initExtensions()
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 #ifndef GLESX
 	m_bImageTexture = (((majorVersion >= 4) && (minorVersion >= 3)) || OGLVideo::isExtensionSupported("GL_ARB_shader_image_load_store")) && (glBindImageTexture != nullptr);
-#elif defined(GLES3_1)
-	m_bImageTexture = (majorVersion >= 3) && (minorVersion >= 1) && (glBindImageTexture != nullptr);
 #else
-	m_bImageTexture = false;
+	m_bImageTexture = (majorVersion >= 3) && (minorVersion >= 1) && (glBindImageTexture != nullptr);
 #endif
 #else
 	m_bImageTexture = false;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -489,7 +489,7 @@ void TextureCache::init()
 
 		glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, m_pMSDummy->glName);
 
-#if defined(GLES3_1)
+#if defined(GLESX)
 		glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, config.video.multisampling,
 					GL_RGBA8, m_pMSDummy->realWidth, m_pMSDummy->realHeight, false);
 #else

--- a/src/mupenplus/OpenGL_mupenplus.cpp
+++ b/src/mupenplus/OpenGL_mupenplus.cpp
@@ -13,7 +13,7 @@
 #endif
 
 #ifndef EGL
-#if !defined(OS_WINDOWS) || defined(GLES2) || defined(GLES3) || defined(GLES3_1)
+#if !defined(OS_WINDOWS) || defined(GLESX)
 
 void initGLFunctions()
 {


### PR DESCRIPTION
Anytime that GL_IMAGE_TEXTURES_SUPPORT is defined.

This is just a small step towards getting rid of the need for the GLES3_1 define. Right now GL_IMAGE_TEXTURES_SUPPORT is only defined for GLES3_1 (not GLES2 or GLES3), so was redundant anyway.

With this change, you should be able to define GL_IMAGE_TEXTURES_SUPPORT for GLES3. The only problem is that you'll probably run into some compile time issues because of missing definitions for glBindImageTexure (and glMemoryBarrier).

That could get sorted out with eglGetProcAddress for those GLES calls. GLupeN64 handles all that in the background, so this change is all that is needed to get Image Texture support working in our GLES3 plugin. However I'm sure something would need to be done for @fzurita, but I'm not sure exactly how that would be handled.