### PR TITLE
Get GLSL version dynamically

### DIFF
--- a/src/GLES2/GLSLCombiner_gles2.cpp
+++ b/src/GLES2/GLSLCombiner_gles2.cpp
@@ -100,7 +100,8 @@ static
 GLuint _createShader(GLenum _type, const char * _strShader)
 {
 	GLuint shader_object = glCreateShader(_type);
-	glShaderSource(shader_object, 1, &_strShader, nullptr);
+	const char* shader_string = addGLSLVersion(_strShader);
+	glShaderSource(shader_object, 1, &shader_string, nullptr);
 	glCompileShader(shader_object);
 	assert(checkShaderCompileStatus(shader_object));
 	return shader_object;
@@ -212,7 +213,8 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 
 	GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
 	const GLchar * strShaderData = strFragmentShader.data();
-	glShaderSource(fragmentShader, 1, &strShaderData, nullptr);
+	const char* shader_string = addGLSLVersion(strShaderData);
+	glShaderSource(fragmentShader, 1, &shader_string, nullptr);
 	glCompileShader(fragmentShader);
 	if (!checkShaderCompileStatus(fragmentShader))
 		logErrorShader(GL_FRAGMENT_SHADER, strFragmentShader);

--- a/src/GLES2/Shaders_gles2.h
+++ b/src/GLES2/Shaders_gles2.h
@@ -1,9 +1,4 @@
-#define SHADER_VERSION "#version 100 \n" \
-"#extension GL_EXT_shader_texture_lod : enable \n" \
-"#extension GL_OES_standard_derivatives : enable \n"
-
 static const char* vertex_shader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)						\n"
 "# define IN in									\n"
 "# define OUT out								\n"
@@ -85,7 +80,6 @@ SHADER_VERSION
 ;
 
 static const char* vertex_shader_notex =
-SHADER_VERSION
 "#if (__VERSION__ > 120)			\n"
 "# define IN in						\n"
 "# define OUT out					\n"
@@ -138,7 +132,6 @@ SHADER_VERSION
 ;
 
 static const char* fragment_shader_header_common_variables =
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"
@@ -178,7 +171,6 @@ SHADER_VERSION
 ;
 
 static const char* fragment_shader_header_common_variables_notex =
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"
@@ -432,7 +424,6 @@ static const char* fragment_shader_dummy_noise =
 ;
 
 static const char* default_vertex_shader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)						\n"
 "# define IN in									\n"
 "#else											\n"
@@ -446,7 +437,6 @@ SHADER_VERSION
 ;
 
 static const char* zelda_monochrome_fragment_shader =
-SHADER_VERSION
 "uniform sampler2D uColorImage;									\n"
 "uniform mediump vec2 uScreenSize;								\n"
 "void main()													\n"
@@ -459,7 +449,6 @@ SHADER_VERSION
 ;
 
 const char * strTexrectDrawerVertexShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"
@@ -478,7 +467,6 @@ SHADER_VERSION
 ;
 
 const char * strTexrectDrawerTex3PointFilter =
-SHADER_VERSION
 "#if (__VERSION__ > 120)																						\n"
 "# define IN in																									\n"
 "# define OUT out																								\n"
@@ -512,7 +500,6 @@ SHADER_VERSION
 ;
 
 const char * strTexrectDrawerTexBilinearFilter =
-SHADER_VERSION
 "#if (__VERSION__ > 120)																						\n"
 "# define IN in																									\n"
 "# define OUT out																								\n"
@@ -564,7 +551,6 @@ const char * strTexrectDrawerFragmentShaderTex =
 ;
 
 const char * strTexrectDrawerFragmentShaderClean =
-SHADER_VERSION
 "lowp vec4 uTestColor = vec4(4.0/255.0, 2.0/255.0, 1.0/255.0, 0.0);	\n"
 "void main()																\n"
 "{																			\n"
@@ -573,7 +559,6 @@ SHADER_VERSION
 ;
 
 const char* strTextureCopyShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)								\n"
 "# define IN in											\n"
 "#else													\n"

--- a/src/OGL3X/GLSLCombiner_ogl3x.cpp
+++ b/src/OGL3X/GLSLCombiner_ogl3x.cpp
@@ -201,7 +201,8 @@ static
 GLuint _createShader(GLenum _type, const char * _strShader)
 {
 	GLuint shader_object = glCreateShader(_type);
-	glShaderSource(shader_object, 1, &_strShader, nullptr);
+	const char* shader_string = addGLSLVersion(_strShader);
+	glShaderSource(shader_object, 1, &shader_string, nullptr);
 	glCompileShader(shader_object);
 	assert(checkShaderCompileStatus(shader_object));
 	return shader_object;
@@ -453,7 +454,8 @@ ShaderCombiner::ShaderCombiner(Combiner & _color, Combiner & _alpha, const gDPCo
 
 	GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
 	const GLchar * strShaderData = strFragmentShader.data();
-	glShaderSource(fragmentShader, 1, &strShaderData, nullptr);
+	const char* shader_string = addGLSLVersion(strShaderData);
+	glShaderSource(fragmentShader, 1, &shader_string, nullptr);
 	glCompileShader(fragmentShader);
 	if (!checkShaderCompileStatus(fragmentShader))
 		logErrorShader(GL_FRAGMENT_SHADER, strFragmentShader);

--- a/src/OGL3X/Shaders_ogl3x.h
+++ b/src/OGL3X/Shaders_ogl3x.h
@@ -1,16 +1,4 @@
-#if defined(GLES3_1)
-#define MAIN_SHADER_VERSION "#version 310 es \n"
-#define AUXILIARY_SHADER_VERSION "\n"
-#elif defined(GLES3)
-#define MAIN_SHADER_VERSION "#version 300 es \n"
-#define AUXILIARY_SHADER_VERSION "\n"
-#else
-#define MAIN_SHADER_VERSION "#version 330 core \n"
-#define AUXILIARY_SHADER_VERSION "#version 330 core \n"
-#endif
-
 static const char* vertex_shader =
-MAIN_SHADER_VERSION
 "in highp vec4 aPosition;							\n"
 "in lowp vec4 aColor;								\n"
 "in highp vec2 aTexCoord0;							\n"
@@ -99,7 +87,6 @@ MAIN_SHADER_VERSION
 ;
 
 static const char* vertex_shader_notex =
-MAIN_SHADER_VERSION
 "in highp vec4 aPosition;			\n"
 "in lowp vec4 aColor;				\n"
 "in lowp float aNumLights;			\n"
@@ -148,7 +135,6 @@ MAIN_SHADER_VERSION
 ;
 
 static const char* fragment_shader_header_common_variables =
-MAIN_SHADER_VERSION
 "uniform sampler2D uTex0;		\n"
 "uniform sampler2D uTex1;		\n"
 "uniform sampler2D uDepthTex;	\n"
@@ -212,7 +198,6 @@ static const char* fragment_shader_header_common_variables_ms_tex1 =
 #endif
 
 static const char* fragment_shader_header_common_variables_notex =
-MAIN_SHADER_VERSION
 "uniform sampler2D uDepthTex;	\n"
 #ifdef GL_USE_UNIFORMBLOCK
 "layout (std140) uniform ColorsBlock {\n"
@@ -288,7 +273,6 @@ static const char* fragment_shader_header_alpha_noise_toonify =
 #endif
 
 static const char* fragment_shader_calc_light =
-AUXILIARY_SHADER_VERSION
 #ifdef GL_USE_UNIFORMBLOCK
 "layout (std140) uniform LightBlock {		\n"
 "  mediump vec3 uLightDirection[8];			\n"
@@ -330,7 +314,6 @@ static const char* fragment_shader_blend_mux =
 ;
 
 static const char* fragment_shader_dither =
-AUXILIARY_SHADER_VERSION
 "void colorNoiseDither(in lowp float _noise, inout lowp vec3 _color)	\n"
 "{															\n"
 "    mediump vec3 tmpColor = _color*255.0;					\n"
@@ -369,7 +352,6 @@ static const char* fragment_shader_end =
 
 static const char* fragment_shader_mipmap =
 #ifndef GLESX
-AUXILIARY_SHADER_VERSION
 "in mediump vec2 vTexCoord0;	\n"
 "in mediump vec2 vTexCoord1;	\n"
 "in mediump vec2 vLodTexCoord;	\n"
@@ -496,7 +478,6 @@ static const char* fragment_shader_readtex_3point =
 
 #ifdef GL_MULTISAMPLING_SUPPORT
 static const char* fragment_shader_readtex_ms =
-AUXILIARY_SHADER_VERSION
 "uniform lowp int uMSAASamples;	\n"
 "uniform lowp float uMSAAScale;	\n"
 "lowp vec4 sampleMS(in lowp sampler2DMS mstex, in mediump ivec2 ipos)			\n"
@@ -522,7 +503,6 @@ AUXILIARY_SHADER_VERSION
 #endif // GL_MULTISAMPLING_SUPPORT
 
 static const char* fragment_shader_noise =
-AUXILIARY_SHADER_VERSION
 #ifndef GLESX
 "uniform mediump vec2 uScreenScale;	\n"
 #endif
@@ -543,7 +523,6 @@ static const char* fragment_shader_dummy_noise =
 ;
 
 static const char* fragment_shader_depth =
-AUXILIARY_SHADER_VERSION
 #ifndef GLESX
 "uniform mediump vec2 uDepthScale;																	\n"
 #endif
@@ -562,7 +541,6 @@ static const char* fragment_shader_dummy_depth =
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 static const char* depth_compare_shader_float =
 #ifndef GLESX
-"#version 430								\n"
 "layout(binding = 2, rg32f) uniform coherent image2D uDepthImage;\n"
 #else
 "layout(binding = 2, rgba32f) highp uniform coherent image2D uDepthImage;\n"
@@ -620,7 +598,6 @@ static const char* depth_compare_shader_float =
 
 static const char* depth_render_shader =
 #ifndef GLESX
-"#version 430								\n"
 "layout(binding = 2, rg32f) uniform coherent image2D uDepthImage;\n"
 #else
 "layout(binding = 2, rgba32f) highp uniform coherent image2D uDepthImage;\n"
@@ -644,11 +621,9 @@ static const char* depth_render_shader =
 
 static const char* shadow_map_fragment_shader_float =
 #ifndef GLESX
-"#version 420 core											\n"
 "layout(binding = 0, r16ui) uniform readonly uimage2D uZlutImage;\n"
 "layout(binding = 1, r16ui) uniform readonly uimage2D uTlutImage;\n"
 #else
-MAIN_SHADER_VERSION
 "layout(binding = 0, r32ui) highp uniform readonly uimage2D uZlutImage;\n"
 "layout(binding = 1, r32ui) highp uniform readonly uimage2D uTlutImage;\n"
 #endif
@@ -676,7 +651,6 @@ MAIN_SHADER_VERSION
 #endif // GL_IMAGE_TEXTURES_SUPPORT
 
 static const char* default_vertex_shader =
-MAIN_SHADER_VERSION
 "in highp vec4 	aPosition;								\n"
 "void main()                                                    \n"
 "{                                                              \n"
@@ -686,7 +660,6 @@ MAIN_SHADER_VERSION
 
 #if 0 // Do palette based monochrome image. Exactly as N64 does
 static const char* zelda_monochrome_fragment_shader =
-"#version 420 core											\n"
 "layout(binding = 0) uniform sampler2D uColorImage;			\n"
 "layout(binding = 1, r16ui) uniform readonly uimage2D uTlutImage;\n"
 "out lowp vec4 fragColor;									\n"
@@ -710,7 +683,6 @@ static const char* zelda_monochrome_fragment_shader =
 ;
 #else // Cheat it
 static const char* zelda_monochrome_fragment_shader =
-MAIN_SHADER_VERSION
 "uniform sampler2D uColorImage;							\n"
 "out lowp vec4 fragColor;								\n"
 "void main()											\n"
@@ -725,7 +697,6 @@ MAIN_SHADER_VERSION
 #endif
 
 const char * strTexrectDrawerVertexShader =
-MAIN_SHADER_VERSION
 "in highp vec4 aPosition;		\n"
 "in highp vec2 aTexCoord0;		\n"
 "out mediump vec2 vTexCoord0;	\n"
@@ -737,7 +708,6 @@ MAIN_SHADER_VERSION
 ;
 
 const char * strTexrectDrawerTex3PointFilter =
-MAIN_SHADER_VERSION
 "uniform mediump vec4 uTextureBounds;																			\n"
 // 3 point texture filtering.
 // Original author: ArthurCarvalho
@@ -766,7 +736,6 @@ MAIN_SHADER_VERSION
 ;
 
 const char * strTexrectDrawerTexBilinearFilter =
-MAIN_SHADER_VERSION
 "uniform mediump vec4 uTextureBounds;																			\n"
 "#define TEX_OFFSET(off, tex, texCoord, texSize) texture(tex, texCoord - (off)/texSize)							\n"
 "#define TEX_FILTER(name, tex, texCoord)																		\\\n"
@@ -813,7 +782,6 @@ const char * strTexrectDrawerFragmentShaderTex =
 ;
 
 const char * strTexrectDrawerFragmentShaderClean =
-MAIN_SHADER_VERSION
 "lowp vec4 uTestColor = vec4(4.0/255.0, 2.0/255.0, 1.0/255.0, 0.0);	\n"
 "out lowp vec4 fragColor;													\n"
 "void main()																\n"
@@ -823,7 +791,6 @@ MAIN_SHADER_VERSION
 ;
 
 const char* strTextureCopyShader =
-MAIN_SHADER_VERSION
 "in mediump vec2 vTexCoord0;                            \n"
 "uniform sampler2D uTex0;				                \n"
 "out lowp vec4 fragColor;								\n"

--- a/src/OpenGL.cpp
+++ b/src/OpenGL.cpp
@@ -2080,12 +2080,12 @@ void OGLRender::_initExtensions()
 	glGetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, lineWidthRange);
 	m_maxLineWidth = lineWidthRange[1];
 
+	majorVersion = 0;
+	minorVersion = 0;
 #ifndef GLES2
-	GLint majorVersion = 0;
 	glGetIntegerv(GL_MAJOR_VERSION, &majorVersion);
 	LOG(LOG_VERBOSE, "OpenGL major version: %d\n", majorVersion);
 	assert(majorVersion >= 3 && "Plugin requires GL version 3 or higher.");
-	GLint minorVersion = 0;
 	glGetIntegerv(GL_MINOR_VERSION, &minorVersion);
 	LOG(LOG_VERBOSE, "OpenGL minor version: %d\n", minorVersion);
 #endif
@@ -2098,7 +2098,8 @@ void OGLRender::_initExtensions()
 
 #ifdef GL_IMAGE_TEXTURES_SUPPORT
 #ifndef GLESX
-	m_bImageTexture = (((majorVersion >= 4) && (minorVersion >= 3)) || OGLVideo::isExtensionSupported("GL_ARB_shader_image_load_store")) && (glBindImageTexture != nullptr);
+	int imageTextureExtension = OGLVideo::isExtensionSupported("GL_ARB_shader_image_load_store") && OGLVideo::isExtensionSupported("GL_ARB_compute_shader") && OGLVideo::isExtensionSupported("GL_ARB_shading_language_420pack");
+	m_bImageTexture = (((majorVersion >= 4) && (minorVersion >= 3)) || imageTextureExtension) && (glBindImageTexture != nullptr);
 #else
 	m_bImageTexture = (majorVersion >= 3) && (minorVersion >= 1) && (glBindImageTexture != nullptr);
 #endif

--- a/src/OpenGL.h
+++ b/src/OpenGL.h
@@ -169,6 +169,8 @@ public:
 	OGL_RENDERER getRenderer() const { return m_oglRenderer; }
 
 	void dropRenderState() {m_renderState = rsNone;}
+	GLint majorVersion;
+	GLint minorVersion;
 
 private:
 	OGLRender()

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -8,16 +8,6 @@
 #include "ShaderUtils.h"
 #include "Config.h"
 
-#if defined(GLES3_1)
-#define SHADER_VERSION "#version 310 es \n"
-#elif defined(GLES3)
-#define SHADER_VERSION "#version 300 es \n"
-#elif defined(GLES2)
-#define SHADER_VERSION "#version 100 \n"
-#else
-#define SHADER_VERSION "#version 330 core \n"
-#endif
-
 #ifdef GLES2
 #define FRAGMENT_SHADER_END "  gl_FragColor = fragColor; \n"
 #else
@@ -29,7 +19,6 @@ PostProcessor PostProcessor::processor;
 #endif
 
 static const char * vertexShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)						\n"
 "# define IN in									\n"
 "# define OUT out								\n"
@@ -47,7 +36,6 @@ SHADER_VERSION
 ;
 
 static const char* extractBloomShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"
@@ -84,7 +72,6 @@ static const char* seperableBlurShader =
 ///				http://www.nutty.ca
 ///
 /// Fragment shader for performing a seperable blur on the specified texture.
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"
@@ -159,7 +146,6 @@ static const char* glowShader =
 ///				http://www.nutty.ca
 ///
 /// Fragment shader for blending two textures using an algorithm that overlays the glowmap.
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"
@@ -220,7 +206,6 @@ FRAGMENT_SHADER_END
 ;
 
 static const char* gammaCorrectionShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)													\n"
 "# define IN in																\n"
 "# define OUT out															\n"
@@ -243,7 +228,6 @@ FRAGMENT_SHADER_END
 ;
 
 static const char* orientationCorrectionShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)													\n"
 "# define IN in																\n"
 "# define OUT out															\n"
@@ -267,12 +251,14 @@ static
 GLuint _createShaderProgram(const char * _strVertex, const char * _strFragment)
 {
 	GLuint vertex_shader_object = glCreateShader(GL_VERTEX_SHADER);
-	glShaderSource(vertex_shader_object, 1, &_strVertex, nullptr);
+	const char* vertex_shader_string = addGLSLVersion(_strVertex);
+	glShaderSource(vertex_shader_object, 1, &vertex_shader_string, nullptr);
 	glCompileShader(vertex_shader_object);
 	assert(checkShaderCompileStatus(vertex_shader_object));
 
 	GLuint fragment_shader_object = glCreateShader(GL_FRAGMENT_SHADER);
-	glShaderSource(fragment_shader_object, 1, &_strFragment, nullptr);
+	const char* fragment_shader_string = addGLSLVersion(_strFragment);
+	glShaderSource(fragment_shader_object, 1, &fragment_shader_string, nullptr);
 	glCompileShader(fragment_shader_object);
 	assert(checkShaderCompileStatus(fragment_shader_object));
 

--- a/src/ShaderUtils.h
+++ b/src/ShaderUtils.h
@@ -4,6 +4,7 @@
 #include "OpenGL.h"
 #include "Combiner.h"
 
+const char* addGLSLVersion(const char* shaderString);
 GLuint createShaderProgram(const char * _strVertex, const char * _strFragment);
 bool checkShaderCompileStatus(GLuint obj);
 bool checkProgramLinkStatus(GLuint obj);

--- a/src/TextDrawer.cpp
+++ b/src/TextDrawer.cpp
@@ -35,16 +35,6 @@ struct point {
 // Maximum texture width
 #define MAXWIDTH 1024
 
-#if defined(GLES3_1)
-#define SHADER_VERSION "#version 310 es \n"
-#elif defined(GLES3)
-#define SHADER_VERSION "#version 300 es \n"
-#elif defined(GLES2)
-#define SHADER_VERSION "#version 100 \n"
-#else
-#define SHADER_VERSION "#version 330 core \n"
-#endif
-
 #ifdef GLES2
 const GLenum monohromeformat = GL_LUMINANCE;
 const GLenum monohromeInternalformat = GL_LUMINANCE;
@@ -55,7 +45,6 @@ const GLenum monohromeInternalformat = GL_R8;
 
 static
 const char * strDrawTextVertexShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)						\n"
 "# define IN in									\n"
 "# define OUT out								\n"
@@ -73,7 +62,6 @@ SHADER_VERSION
 
 static
 const char * strDrawTextFragmentShader =
-SHADER_VERSION
 "#if (__VERSION__ > 120)		\n"
 "# define IN in					\n"
 "# define OUT out				\n"


### PR DESCRIPTION
Instead of hardcoding the ```#version XXX core``` header into the GLSL sources, this will use GL_MAJOR_VERSION and GL_MINOR_VERSION to automatically generate the header.

For instance, if the user has a GFX card that reports OpenGL 4.2, the header will become ```#version 420 core```

The purpose here is to get rid of the separate GLES3.1 version of the plugin. With this change, even when using the GLES3 version, the GLSL header will be ```#version 310 es``` if the user's phone supports it. This will allow GL_MULTISAMPLING_SUPPORT and GL_IMAGE_TEXTURE_SUPPORT to work in the GLES3 version of the plugin if the user's phone supports GLES3.1.