### PR TITLE
2D fixes UI controls stay enabled when FB emulation disabled

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -592,6 +592,12 @@ void ConfigDialog::on_cropImageComboBox_currentIndexChanged(int index)
 
 void ConfigDialog::on_frameBufferCheckBox_toggled(bool checked)
 {
+
+    if (!checked)
+    {
+        ui->nativeRes2DFrame->setEnabled(true);
+    }
+
 	ui->readColorChunkCheckBox->setEnabled(checked && ui->fbInfoEnableCheckBox->isChecked());
 	ui->readDepthChunkCheckBox->setEnabled(checked && ui->fbInfoEnableCheckBox->isChecked());
 


### PR DESCRIPTION
The original issue,

> If internal resolution is set to Original and then we disable FB emulation, 2D fixes remained disabled.

exists on the plugin before `QFrame`s were introduced. I hoped the new signal logic would solve this problem without additional code, but it seems like a small bit is needed.