### PR TITLE
Fix issues when re-initializing Combiner class after destruction.

### DIFF
--- a/src/GLSLCombiner.h
+++ b/src/GLSLCombiner.h
@@ -50,7 +50,7 @@ private:
 
 	struct iUniform	{
 		GLint loc = -1;
-		int val;
+		int val = -999;
 		void set(int _val, bool _force) {
 			if (loc >= 0 && (_force || val != _val)) {
 				val = _val;
@@ -61,7 +61,7 @@ private:
 
 	struct fUniform {
 		GLint loc = -1;
-		float val;
+		float val = -9999.9f;
 		void set(float _val, bool _force) {
 			if (loc >= 0 && (_force || val != _val)) {
 				val = _val;
@@ -72,7 +72,7 @@ private:
 
 	struct fv2Uniform {
 		GLint loc = -1;
-		float val[2];
+		float val[2] = {-9999.9f, -9999.9f};
 		void set(float _val1, float _val2, bool _force) {
 			if (loc >= 0 && (_force || val[0] != _val1 || val[1] != _val2)) {
 				val[0] = _val1;
@@ -84,7 +84,7 @@ private:
 
 	struct iv2Uniform {
 		GLint loc = -1;
-		int val[2];
+		int val[2] = {-990, -999};
 		void set(int _val1, int _val2, bool _force) {
 			if (loc >= 0 && (_force || val[0] != _val1 || val[1] != _val2)) {
 				val[0] = _val1;
@@ -96,7 +96,7 @@ private:
 
 	struct i4Uniform {
 		GLint loc = -1;
-		int val0, val1, val2, val3;
+		int val0 = -999, val1 = -999, val2 = -999, val3 = -999;
 		void set(int _val0, int _val1, int _val2, int _val3, bool _force) {
 			if (loc < 0)
 				return;


### PR DESCRIPTION
This seems to fix https://github.com/gonetz/GLideN64/issues/975 at least in Android.

I'm not sure which of the changes in this file fixes the issue for me. The changes in the destroy method seem to be correct to me.

The updates in the setCombine method probably fixed it, but I don't understand fully why yet.