### PR TITLE
Have android LOG function use __android_log_vprint

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1,5 +1,3 @@
-#ifndef ANDROID
-
 #include <stdarg.h>
 #include <stdio.h>
 #include "Log.h"
@@ -21,7 +19,7 @@ void LOG(u16 type, const char * format, ...) {
 	char cbuf[bufSize];
 	wcstombs(cbuf, logPath, bufSize);
 	FILE *dumpFile = fopen(cbuf, "a+");
-#endif
+#endif //OS_WINDOWS
 
 	if (dumpFile == nullptr)
 		return;
@@ -45,5 +43,3 @@ void debugPrint(const char * format, ...) {
 	va_end(va);
 }
 #endif
-
-#endif // ANDROID

--- a/src/Log.h
+++ b/src/Log.h
@@ -11,21 +11,11 @@
 #define LOG_LEVEL LOG_WARNING
 
 #if LOG_LEVEL > 0
-#ifdef ANDROID
-#include <android/log.h>
 
-#define LOG(A, ...) \
-    if (A <= LOG_LEVEL) \
-    { \
-		__android_log_print(ANDROID_LOG_DEBUG, "GLideN64", __VA_ARGS__); \
-    }
-
-#else // ANDROID
 #include "Types.h"
 
 void LOG(u16 type, const char * format, ...);
 
-#endif // ANDROID
 #else
 
 #define LOG(A, ...)

--- a/src/Log_android.cpp
+++ b/src/Log_android.cpp
@@ -1,0 +1,12 @@
+#include "Log.h"
+#include <android/log.h>
+
+void LOG(u16 type, const char * format, ...) {
+	if (type > LOG_LEVEL)
+		return;
+
+	va_list va;
+	va_start(va, format);
+	__android_log_vprint(ANDROID_LOG_DEBUG, "GLideN64", format, va);
+	va_end(va);
+}

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -50,6 +50,7 @@ MY_LOCAL_SRC_FILES :=                               \
     $(SRCDIR)/L3D.cpp                               \
     $(SRCDIR)/L3DEX2.cpp                            \
     $(SRCDIR)/L3DEX.cpp                             \
+    $(SRCDIR)/Log_android.cpp                       \
     $(SRCDIR)/MupenPlusPluginAPI.cpp                \
     $(SRCDIR)/N64.cpp                               \
     $(SRCDIR)/OpenGL.cpp                            \


### PR DESCRIPTION
This changes the Android LOG function from a Macro in Log.h to integrating it into Log.cpp

It also changes it from using ```__android_log_print``` to using ```__android_log_vprint```, since that is how the log messages are formatted.