### PR TITLE
UI: Fix gamma correction spinbox incorrectly enabled/disabled

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -238,7 +238,6 @@ void ConfigDialog::_init()
 
 	ui->gammaCorrectionGroupBox->setChecked(config.gammaCorrection.force != 0);
 	ui->gammaLevelSpinBox->setValue(config.gammaCorrection.level);
-	ui->gammaLevelSpinBox->setEnabled(ui->gammaCorrectionGroupBox->isChecked());
 
 	// OSD settings
 	QString fontName(config.font.name.c_str());


### PR DESCRIPTION
The line `ui->gammaCorrectionGroupBox->setChecked(config.gammaCorrection.force != 0);` will correctly enable or disable this spinbox when the form is loaded. I think this problem probably happened on the old UI too.