### PR TITLE
remove inline specifier for gSPFlushTriangles

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -24,7 +24,7 @@
 
 using namespace std;
 
-inline void gSPFlushTriangles()
+void gSPFlushTriangles()
 {
 	if ((gSP.geometryMode & G_SHADING_SMOOTH) == 0) {
 		video().getRender().drawTriangles();

--- a/src/gSP.h
+++ b/src/gSP.h
@@ -223,5 +223,5 @@ extern void (*gSPLightVertex)(SPVertex & _vtx);
 extern void (*gSPPointLightVertex)(SPVertex & _vtx, float * _vPos);
 extern void (*gSPBillboardVertex)(u32 v, u32 i);
 void gSPSetupFunctions();
-inline void gSPFlushTriangles();
+void gSPFlushTriangles();
 #endif


### PR DESCRIPTION
This is failing to compile on Linux for me otherwise.

You can't have an inline function in one .cpp file be used in another .cpp file. The whole function would need to live inside a shared .h file, but I don't know how feasible that is in this case.

Perhaps someone with more C++ knowledges knows a better way around this, but removing the inline specifier fixes the compilation/linking for me.