### PR TITLE
Fix runtime library loading errors with GLES 3.0.

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -10,9 +10,11 @@
 #include <N64.h>
 #include <VI.h>
 #include "Log.h"
-#ifndef GLES2
+#if !defined(GLES2) && !defined(GLES3)
 #include "ColorBufferToRDRAM_GL.h"
 #include "ColorBufferToRDRAM_BufferStorageExt.h"
+#elif defined (GLES3)
+#include "ColorBufferToRDRAM_GL.h"
 #elif defined(ANDROID) && defined (GLES2)
 #include "ColorBufferToRDRAM_GLES.h"
 #else
@@ -275,8 +277,7 @@ void ColorBufferToRDRAM::copyChunkToRDRAM(u32 _address)
 
 ColorBufferToRDRAM & ColorBufferToRDRAM::get()
 {
-#ifndef GLES2
-
+#if !defined(GLES2) && !defined(GLES3)
 	static bool supportsBufferStorage = OGLVideo::isExtensionSupported("GL_EXT_buffer_storage") ||
 		OGLVideo::isExtensionSupported("GL_ARB_buffer_storage");
 
@@ -287,7 +288,9 @@ ColorBufferToRDRAM & ColorBufferToRDRAM::get()
 		static ColorBufferToRDRAM_GL cbCopy;
 		return cbCopy;
 	}
-
+#elif defined (GLES3)
+	static ColorBufferToRDRAM_GL cbCopy;
+	return cbCopy;
 #elif defined(ANDROID) && defined (GLES2)
 	static ColorBufferToRDRAM_GLES cbCopy;
 	return cbCopy;

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -138,7 +138,7 @@ LOCAL_STATIC_LIBRARIES  := $(MY_LOCAL_STATIC_LIBRARIES)
 LOCAL_ARM_MODE          := $(MY_LOCAL_ARM_MODE)
 LOCAL_C_INCLUDES        := $(MY_LOCAL_C_INCLUDES) $(LOCAL_PATH)/GLES3/include/
 LOCAL_SRC_FILES         := $(MY_LOCAL_SRC_FILES) $(SRCDIR)/GLUniforms/UniformSet.cpp $(SRCDIR)/OGL3X/GLSLCombiner_ogl3x.cpp \
-                           $(SRCDIR)/BufferCopy/ColorBufferToRDRAM_GL.cpp $(SRCDIR)/BufferCopy/ColorBufferToRDRAM_BufferStorageExt.cpp
+                           $(SRCDIR)/BufferCopy/ColorBufferToRDRAM_GL.cpp
 LOCAL_CFLAGS            := $(MY_LOCAL_CFLAGS) -DGLES3
 LOCAL_CPPFLAGS          := $(MY_LOCAL_CPPFLAGS)
 LOCAL_LDFLAGS           := $(MY_LOCAL_LDFLAGS)


### PR DESCRIPTION
Some devices with GLES 3.0 support only are not tolerant of GLES 3.1
specific calls.