### PR TITLE
Add "Animal Forest" to RSP list

### DIFF
--- a/src/GBI.cpp
+++ b/src/GBI.cpp
@@ -54,7 +54,8 @@ SpecialMicrocodeInfo specialMicrocodes[] =
 	{ F3DJFG,		false,	0xbde9d1fb, "Jet Force Gemini" },
 	{ F3DPD,		true,	0x1c4f7869, "Perfect Dark" },
 	{ Turbo3D,		false,	0x2bdcfc8a, "Turbo3D" },
-	{ F3DEX2CBFD,	true,	0x1b4ace88, "Conker's Bad Fur Day" }
+	{ F3DEX2CBFD,	true,	0x1b4ace88, "Conker's Bad Fur Day" },
+	{ F3DEX2MM,	true,	0xd39a0d4f, "Animal Forest" }
 };
 
 u32 G_RDPHALF_1, G_RDPHALF_2, G_RDPHALF_CONT;

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -337,7 +337,8 @@ void RSP_Init()
 		config.generalEmulation.hacks |= hack_pilotWings;
 	else if (strstr(RSP.romname, (const char *)"THE LEGEND OF ZELDA") != nullptr ||
 			 strstr(RSP.romname, (const char *)"ZELDA MASTER QUEST") != nullptr ||
-			 strstr(RSP.romname, (const char *)"DOUBUTSUNOMORI") != nullptr)
+			 strstr(RSP.romname, (const char *)"DOUBUTSUNOMORI") != nullptr ||
+			 strstr(RSP.romname, (const char *)"ANIMAL FOREST") != nullptr)
 		config.generalEmulation.hacks |= hack_subscreen;
 	else if (strstr(RSP.romname, (const char *)"LEGORacers") != nullptr)
 		config.generalEmulation.hacks |= hack_legoRacers;


### PR DESCRIPTION
Fan translations of Dōbutsu no Mori exist where the RSP.romname=ANIMAL FOREST

EDIT: Also for some reason on some versions of the ROM the ucode wasn't being detected properly, so I added the CRC to the special microcode list, and this allows the ROM to boot