### PR TITLE
Faster noise emulation

### DIFF
--- a/src/NoiseTexture.h
+++ b/src/NoiseTexture.h
@@ -2,9 +2,7 @@
 #include <memory>
 #include "Types.h"
 
-namespace graphics {
-	class PixelWriteBuffer;
-}
+#define NOISE_TEX_NUM 30
 
 struct CachedTexture;
 
@@ -18,9 +16,9 @@ public:
 	void update();
 
 private:
-	CachedTexture * m_pTexture;
-	std::unique_ptr<graphics::PixelWriteBuffer> m_pbuf;
+	CachedTexture * m_pTexture[NOISE_TEX_NUM];
 	u32 m_DList;
+	u32 m_currTex, m_prevTex;
 };
 
 extern NoiseTexture g_noiseTexture;


### PR DESCRIPTION
Sorry for the onslaught of PR's

Right now, noise textures are generated "on-the-fly". Some games do this every single frame (GoldenEye, Star Wars Ep I Racer, probably many others). This results is glTexSubImage2D (texture upload) happening every frame.

This has resulted in some performance problems like this:
https://github.com/gonetz/GLideN64/issues/710

This change generates 30 random noise textures at launch, and cycles through them randomly. I looked at the character selection screen in Super Smash Bros and the result looks the same to me, although someone with a keener eye could verify. The "30" number could always be increased to increase the randomness.

This should result in a pretty big performance improvement for noise emulation.