### PR TITLE
Remove need for USE_DEPTH_RENDERBUFFER

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,6 @@ if(EXISTS "/opt/vc/include/bcm_host.h")
   set(EGL ON)
   add_definitions(
     -DVC
-    -DUSE_DEPTH_RENDERBUFFER
   )
   include_directories(
     "/opt/vc/include"

--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -363,13 +363,13 @@ protected:
 		monochromeType = GL_UNSIGNED_SHORT_5_6_5;
 		monochromeFormatBytes = 2;
 
-#ifndef USE_DEPTH_RENDERBUFFER
-		depthInternalFormat = GL_DEPTH_COMPONENT;
-		depthFormatBytes = 4;
-#else
-		depthInternalFormat = GL_DEPTH_COMPONENT16;
-		depthFormatBytes = 2;
-#endif
+		if (Utils::isExtensionSupported("GL_OES_depth_texture")) {
+			depthInternalFormat = GL_DEPTH_COMPONENT;
+			depthFormatBytes = 4;
+		} else {
+			depthInternalFormat = GL_DEPTH_COMPONENT16;
+			depthFormatBytes = 2;
+		}
 
 		depthFormat = GL_DEPTH_COMPONENT;
 		depthType = GL_UNSIGNED_INT;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -399,11 +399,10 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 	   return numBinaryFormats != 0 && Utils::isExtensionSupported("GL_ARB_get_program_binary");
 	}
 	case graphics::SpecialFeatures::DepthFramebufferTextures:
-#ifndef USE_DEPTH_RENDERBUFFER
-		return true;
-#else
-		return false;
-#endif
+		if (!m_glInfo.isGLES2 || Utils::isExtensionSupported("GL_OES_depth_texture"))
+			return true;
+		else
+			return false;
 	}
 	return false;
 }


### PR DESCRIPTION
In GLES2, depth textures require GL_OES_depth_texture (https://www.khronos.org/registry/OpenGL/extensions/OES/OES_depth_texture.txt).

This extension is almost universal on Android, but it is missing on the Raspberry Pi, which is why renderbuffers were needed.

This change now has GLideN64 check for GL_OES_depth_texture instead of using the hardcoded USE_DEPTH_RENDERBUFFER