### PR TITLE
Add GL_MAP_INVALIDATE_BUFFER_BIT to PBO writes

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -144,7 +144,7 @@ public:
 	{
 		if (_size > m_size)
 			_size = m_size;
-		return glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, _size, GL_MAP_WRITE_BIT);
+		return glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, _size, GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
 	}
 
 	void closeWriteBuffer() override


### PR DESCRIPTION
In the current master, glBufferData(...NULL...) is called before glMapBufferRange. This tells the GL driver "I don't care about the previous contents".

In this refactoring, glBufferData(...NULL..) is only called when the PBO is created, not every time glMapBufferRange is called. This results in peformance warnings like this:

```
api performance issue 24: CPU mapping a busy MapBufferRange BO stalled and took 1.797 ms.
```

Because it has to stall and wait to make sure the buffer contents are not in use.

GL_MAP_INVALIDATE_BUFFER_BIT+ GL_MAP_UNSYNCHRONIZED_BIT tells it "I don't care about the previous contents", and accomplishes the same thing as doing glBufferData(...NULL...)

Adding this flag gets rid of those performance warnings.