### PR TITLE
Improve PBO writer performance

### DIFF
--- a/src/PaletteTexture.cpp
+++ b/src/PaletteTexture.cpp
@@ -90,7 +90,7 @@ void PaletteTexture::update()
 
 	if (m_paletteCRC256 == gDP.paletteCRC256)
 		return;
-	
+
 	m_paletteCRC256 = gDP.paletteCRC256;
 
 	PixelBufferBinder<PixelWriteBuffer> binder(m_pbuf.get());


### PR DESCRIPTION
See https://github.com/gonetz/GLideN64/pull/1350 for my comments on why I added ```GL_MAP_UNSYNCHRONIZED_BIT | GL_MAP_INVALIDATE_BUFFER_BIT``` to the glMapBufferRange call.

This adds a new PixelWriteBuffer implementation that uses ARB/EXT_buffer_storage. It should offer a pretty good performance improvement, especially on mobile devices.

I tested this with Dr. Mario since I know it's a game that uses CopyColorFromRDRAM for the pills and it worked well. My laptop doesn't support image textures so I was unable to test that.