### PR TITLE
[Refactor] Get GLES 2.0 working again

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -408,17 +408,7 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 	case graphics::SpecialFeatures::ImageTextures:
 		return m_glInfo.imageTextures;
 	case graphics::SpecialFeatures::ShaderProgramBinary:
-	{
-	   GLint numBinaryFormats = 0;
-#ifdef GL_NUM_PROGRAM_BINARY_FORMATS
-		glGetIntegerv(GL_NUM_PROGRAM_BINARY_FORMATS, &numBinaryFormats);
-#endif
-
-		if (m_glInfo.isGLESX)
-		   return numBinaryFormats != 0 && Utils::isExtensionSupported(m_glInfo, "GL_OES_get_program_binary");
-
-	   return numBinaryFormats != 0 && Utils::isExtensionSupported(m_glInfo, "GL_ARB_get_program_binary");
-	}
+		return m_glInfo.shaderStorage;
 	case graphics::SpecialFeatures::DepthFramebufferTextures:
 		if (!m_glInfo.isGLES2 || Utils::isExtensionSupported(m_glInfo, "GL_OES_depth_texture"))
 			return true;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1015,7 +1015,7 @@ void TextureCache::_loadBackground(CachedTexture *pTexture)
 		params.width = pTexture->realWidth;
 		params.height = pTexture->realHeight;
 		params.format = colorFormat::RGBA;
-		params.internalFormat = glInternalFormat;
+		params.internalFormat = gfxContext.convertGHQTextureFormat(u32(glInternalFormat));
 		params.dataType = glType;
 		params.data = pDest;
 		gfxContext.init2DTexture(params);
@@ -1338,7 +1338,7 @@ void TextureCache::_load(u32 _tile, CachedTexture *_pTexture)
 			params.msaaLevel = 0;
 			params.width = tmptex.realWidth;
 			params.height = tmptex.realHeight;
-			params.internalFormat = glInternalFormat;
+			params.internalFormat = gfxContext.convertGHQTextureFormat(u32(glInternalFormat));
 			params.format = colorFormat::RGBA;
 			params.dataType = glType;
 			params.data = pDest;


### PR DESCRIPTION
Ok, I got the GLES 2.0 version working again. I'm not getting any more GL errors and graphics appear to show correctly at least.

Also, I keep getting this in logcat:

E/libEGL: called unimplemented OpenGL ES API 
Now to track down which call is doing this will be difficult.

Another thing
3-point filtering seems to be broken with GLES 2.0