### PR TITLE
A few GL fixes

### DIFF
--- a/src/Graphics/OpenGLContext/GLFunctions.cpp
+++ b/src/Graphics/OpenGLContext/GLFunctions.cpp
@@ -290,10 +290,4 @@ void initGLFunctions()
 	GL_GET_PROC_ADR(PFNGLCREATEFRAMEBUFFERSPROC, glCreateFramebuffers);
 	GL_GET_PROC_ADR(PFNGLNAMEDFRAMEBUFFERTEXTUREPROC, glNamedFramebufferTexture);
 	GL_GET_PROC_ADR(PFNGLDRAWELEMENTSBASEVERTEXPROC, glDrawElementsBaseVertex);
-#ifdef EGL
-	if (g_glBufferStorage == nullptr)
-		g_glBufferStorage = (PFNGLBUFFERSTORAGEPROC) eglGetProcAddress("glBufferStorageEXT");
-	if (g_glTexStorage2D == nullptr)
-		g_glTexStorage2D = (PFNGLTEXSTORAGE2DPROC) eglGetProcAddress("glTexStorage2DEXT");
-#endif
 }

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -2,6 +2,9 @@
 #include <Config.h>
 #include "opengl_Utils.h"
 #include "opengl_GLInfo.h"
+#ifdef EGL
+#include <EGL/egl.h>
+#endif
 
 using namespace opengl;
 
@@ -40,9 +43,12 @@ void GLInfo::init() {
 	}
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");
+#ifdef EGL
+	if (isGLESX && bufferStorage)
+		g_glBufferStorage = (PFNGLBUFFERSTORAGEPROC) eglGetProcAddress("glBufferStorageEXT");
+#endif
 	texStorage = (isGLESX && (numericVersion >= 30)) || (!isGLESX && numericVersion >= 42) ||
-			Utils::isExtensionSupported(*this, "GL_ARB_texture_storage") ||
-			Utils::isExtensionSupported(*this, "GL_EXT_texture_storage");
+			Utils::isExtensionSupported(*this, "GL_ARB_texture_storage");
 
 	shaderStorage = false;
 	if (config.generalEmulation.enableShadersStorage != 0) {

--- a/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -8,7 +8,7 @@
 using namespace opengl;
 
 bool Utils::isExtensionSupported(const opengl::GLInfo & _glinfo, const char *extension) {
-	if (!_glinfo.isGLES2 && !_glinfo.majorVersion >= 3) {
+	if (_glinfo.majorVersion >= 3) {
 		GLint count = 0;
 		glGetIntegerv(GL_NUM_EXTENSIONS, &count);
 		assert(count >= 0);


### PR DESCRIPTION
This makes sure it only uses glBufferStorageEXT if glBufferStorage isn't supportd.

It also removes support for EXT_texture_storage (glTexStorage2D in GLES2),since glTexStorage2D requires sized internal formats (ie GL_RGBA8, not GL_RGBA), and we aren't setup to support that.

It also changes the check for using GL_NUM_EXTENSIONS to ```_glinfo.majorVersion >= 3```, which basically excludes everything except GLES2.

@fzurita perhaps you could review this to make sure it's all ok