### PR TITLE
Force disable fragment depth writing in GLES2

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -823,7 +823,7 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 	if (m_glInfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0)
 		_uniforms.emplace_back(new UDepthInfo(_program));
 
-	if (config.generalEmulation.enableFragmentDepthWrite != 0)
+	if (!m_glInfo.isGLES2 && config.generalEmulation.enableFragmentDepthWrite != 0)
 		_uniforms.emplace_back(new URenderTarget(_program));
 
 	_uniforms.emplace_back(new UScreenCoordsScale(_program));

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -21,6 +21,7 @@
 #include "Combiner.h"
 #include "Performance.h"
 #include "DisplayWindow.h"
+#include <Graphics/Context.h>
 
 using namespace std;
 
@@ -748,7 +749,7 @@ void gDPFillRectangle( s32 ulx, s32 uly, s32 lrx, s32 lry )
 		// If color is not depth clear color, that is most likely the case
 		if (gDP.fillColor.color == DepthClearColor) {
 			frameBufferList().fillRDRAM(ulx, uly, lrx, lry);
-			if (config.generalEmulation.enableFragmentDepthWrite == 0 ||
+			if (config.generalEmulation.enableFragmentDepthWrite == 0 || !gfxContext.isSupported(graphics::SpecialFeatures::FragmentDepthWrite) ||
 				(ulx == 0 && uly == 0 && lrx == gDP.scissor.lrx && lry == gDP.scissor.lry)) {
 				drawer.clearDepthBuffer(ulx, uly, lrx, lry);
 				bBufferCleared = true;
@@ -758,7 +759,7 @@ void gDPFillRectangle( s32 ulx, s32 uly, s32 lrx, s32 lry )
 	} else if (gDP.fillColor.color == DepthClearColor && gDP.otherMode.cycleType == G_CYC_FILL) {
 		depthBufferList().saveBuffer(gDP.colorImage.address);
 		frameBufferList().fillRDRAM(ulx, uly, lrx, lry);
-		if (config.generalEmulation.enableFragmentDepthWrite == 0 ||
+		if (config.generalEmulation.enableFragmentDepthWrite == 0 || !gfxContext.isSupported(graphics::SpecialFeatures::FragmentDepthWrite) ||
 			(ulx == 0 && uly == 0 && lrx == gDP.scissor.lrx && lry == gDP.scissor.lry)) {
 			drawer.clearDepthBuffer(ulx, uly, lrx, lry);
 			bBufferCleared = true;


### PR DESCRIPTION
There were a few spots that weren't properly checking for enableFragmentDepthWrite support.