### PR TITLE
Disable N64 Depth Compare if Image Textures are unsupported

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -22,7 +22,7 @@ DepthBuffer::DepthBuffer() : m_address(0), m_width(0), m_ulx(0), m_uly(0), m_lrx
 	m_pDepthBufferCopyTexture(nullptr), m_copied(false)
 {
 	m_copyFBO = gfxContext.createFramebuffer();
-	if (Context::imageTextures && config.frameBufferEmulation.N64DepthCompare != 0)
+	if (config.frameBufferEmulation.N64DepthCompare != 0)
 		m_depthImageFBO = gfxContext.createFramebuffer();
 }
 
@@ -58,7 +58,7 @@ DepthBuffer::~DepthBuffer()
 
 void DepthBuffer::initDepthImageTexture(FrameBuffer * _pBuffer)
 {
-	if (!Context::imageTextures || config.frameBufferEmulation.N64DepthCompare == 0 || m_pDepthImageTexture != nullptr)
+	if (config.frameBufferEmulation.N64DepthCompare == 0 || m_pDepthImageTexture != nullptr)
 		return;
 
 	const FramebufferTextureFormats & fbTexFormat = gfxContext.getFramebufferTextureFormats();
@@ -471,7 +471,7 @@ void DepthBufferList::clearBuffer(u32 _ulx, u32 _uly, u32 _lrx, u32 _lry)
 	m_pCurrent->m_lrx = _lrx;
 	m_pCurrent->m_lry = _lry;
 
-	if (!m_pCurrent->m_depthImageFBO.isNotNull() || !Context::imageTextures || config.frameBufferEmulation.N64DepthCompare == 0)
+	if (!m_pCurrent->m_depthImageFBO.isNotNull() || config.frameBufferEmulation.N64DepthCompare == 0)
 		return;
 
 

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -780,7 +780,7 @@ void FrameBufferList::attachDepthBuffer()
 		if (goodDepthBufferTexture) {
 			m_pCurrent->m_pDepthBuffer = pDepthBuffer;
 			pDepthBuffer->setDepthAttachment(m_pCurrent->m_FBO, bufferTarget::DRAW_FRAMEBUFFER);
-			if (Context::imageTextures && config.frameBufferEmulation.N64DepthCompare != 0)
+			if (config.frameBufferEmulation.N64DepthCompare != 0)
 				pDepthBuffer->bindDepthImageTexture();
 		} else
 			m_pCurrent->m_pDepthBuffer = nullptr;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -762,7 +762,7 @@ public:
 				"uniform lowp int uRenderTarget;	\n"
 				"uniform mediump vec2 uDepthScale;	\n"
 				;
-			if (_glinfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+			if (config.frameBufferEmulation.N64DepthCompare != 0) {
 				m_part +=
 					"uniform lowp int uEnableDepthCompare;	\n"
 					;
@@ -836,7 +836,7 @@ public:
 				"uniform lowp int uRenderTarget;	\n"
 				"uniform mediump vec2 uDepthScale;	\n"
 				;
-			if (_glinfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+			if (config.frameBufferEmulation.N64DepthCompare != 0) {
 				m_part +=
 					"uniform lowp int uEnableDepthCompare;	\n"
 					;
@@ -932,7 +932,7 @@ class ShaderFragmentHeaderDepthCompare : public ShaderPart
 public:
 	ShaderFragmentHeaderDepthCompare(const opengl::GLInfo & _glinfo)
 	{
-		if (_glinfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+		if (config.frameBufferEmulation.N64DepthCompare != 0) {
 			m_part = _glinfo.isGLESX
 				? "layout(binding = 2, rgba32f) highp uniform coherent image2D uDepthImage;\n"
 				: "layout(binding = 2, rg32f) highp uniform coherent image2D uDepthImage;\n"
@@ -1128,7 +1128,7 @@ class ShaderFragmentCallN64Depth : public ShaderPart
 public:
 	ShaderFragmentCallN64Depth(const opengl::GLInfo & _glinfo)
 	{
-		if (!_glinfo.isGLES2 && _glinfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+		if (config.frameBufferEmulation.N64DepthCompare != 0) {
 			m_part =
 				"  if (uRenderTarget != 0) { if (!depth_render(fragColor.r)) discard; } \n"
 				"  else if (!depth_compare()) discard; \n"
@@ -1142,7 +1142,7 @@ class ShaderFragmentRenderTarget : public ShaderPart
 public:
 	ShaderFragmentRenderTarget(const opengl::GLInfo & _glinfo)
 	{
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableFragmentDepthWrite != 0) {
+		if (config.generalEmulation.enableFragmentDepthWrite != 0) {
 			m_part =
 				"  if (uRenderTarget != 0) {					\n"
 				"    if (uRenderTarget > 1) {					\n"
@@ -1544,7 +1544,7 @@ class ShaderN64DepthCompare : public ShaderPart
 public:
 	ShaderN64DepthCompare(const opengl::GLInfo & _glinfo)
 	{
-		if (_glinfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+		if (config.frameBufferEmulation.N64DepthCompare != 0) {
 			m_part =
 				"uniform lowp int uDepthMode;							\n"
 				"uniform lowp int uDepthSource;							\n"
@@ -1602,7 +1602,7 @@ class ShaderN64DepthRender : public ShaderPart
 public:
 	ShaderN64DepthRender(const opengl::GLInfo & _glinfo)
 	{
-		if (_glinfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+		if (config.frameBufferEmulation.N64DepthCompare != 0) {
 			m_part =
 				"bool depth_render(highp float Z)						\n"
 				"{														\n"

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -820,10 +820,10 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 	if (!m_glInfo.isGLES2)
 		_uniforms.emplace_back(new UDepthScale(_program));
 
-	if (m_glInfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0)
+	if (config.frameBufferEmulation.N64DepthCompare != 0)
 		_uniforms.emplace_back(new UDepthInfo(_program));
 
-	if (!m_glInfo.isGLES2 && config.generalEmulation.enableFragmentDepthWrite != 0)
+	if (config.generalEmulation.enableFragmentDepthWrite != 0)
 		_uniforms.emplace_back(new URenderTarget(_program));
 
 	_uniforms.emplace_back(new UScreenCoordsScale(_program));

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -41,6 +41,12 @@ void GLInfo::init() {
 				Utils::isExtensionSupported(*this, "GL_ARB_compute_shader"))) && (glBindImageTexture != nullptr);
 		msaa = true;
 	}
+	if (!imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
+		config.frameBufferEmulation.N64DepthCompare = 0;
+		LOG(LOG_WARNING, "N64 depth compare and depth based fog will not work without Image Textures support provided in OpenGL >= 4.3 or GLES >= 3.1\n");
+	}
+	if (isGLES2)
+		config.generalEmulation.enableFragmentDepthWrite = 0;
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");
 #ifdef EGL

--- a/src/Graphics/OpenGLContext/opengl_UnbufferedDrawer.cpp
+++ b/src/Graphics/OpenGLContext/opengl_UnbufferedDrawer.cpp
@@ -39,7 +39,7 @@ bool UnbufferedDrawer::_updateAttribPointer(u32 _index, const void * _ptr)
 
 void UnbufferedDrawer::drawTriangles(const graphics::Context::DrawTriangleParameters & _params)
 {
-	if (m_glInfo.imageTextures && config.frameBufferEmulation.N64DepthCompare != 0)
+	if (config.frameBufferEmulation.N64DepthCompare != 0)
 		glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 
 	{

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -749,7 +749,7 @@ void gDPFillRectangle( s32 ulx, s32 uly, s32 lrx, s32 lry )
 		// If color is not depth clear color, that is most likely the case
 		if (gDP.fillColor.color == DepthClearColor) {
 			frameBufferList().fillRDRAM(ulx, uly, lrx, lry);
-			if (config.generalEmulation.enableFragmentDepthWrite == 0 || !gfxContext.isSupported(graphics::SpecialFeatures::FragmentDepthWrite) ||
+			if (config.generalEmulation.enableFragmentDepthWrite == 0 ||
 				(ulx == 0 && uly == 0 && lrx == gDP.scissor.lrx && lry == gDP.scissor.lry)) {
 				drawer.clearDepthBuffer(ulx, uly, lrx, lry);
 				bBufferCleared = true;
@@ -759,7 +759,7 @@ void gDPFillRectangle( s32 ulx, s32 uly, s32 lrx, s32 lry )
 	} else if (gDP.fillColor.color == DepthClearColor && gDP.otherMode.cycleType == G_CYC_FILL) {
 		depthBufferList().saveBuffer(gDP.colorImage.address);
 		frameBufferList().fillRDRAM(ulx, uly, lrx, lry);
-		if (config.generalEmulation.enableFragmentDepthWrite == 0 || !gfxContext.isSupported(graphics::SpecialFeatures::FragmentDepthWrite) ||
+		if (config.generalEmulation.enableFragmentDepthWrite == 0 ||
 			(ulx == 0 && uly == 0 && lrx == gDP.scissor.lrx && lry == gDP.scissor.lry)) {
 			drawer.clearDepthBuffer(ulx, uly, lrx, lry);
 			bBufferCleared = true;


### PR DESCRIPTION
Instead of checking for the config setting and checking for Image Texture support every time we need it, this disables the config setting in GLInfo.

The same goes for Fragment based depth writing and GLES2