### PR TITLE
Implement generic copy color to RDRAM for GLES2 devices

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.cpp
@@ -1,0 +1,43 @@
+#include <Graphics/Context.h>
+#include "opengl_ColorBufferReaderWithReadPixels.h"
+#include <algorithm>
+
+using namespace graphics;
+using namespace opengl;
+
+ColorBufferReaderWithReadPixels::ColorBufferReaderWithReadPixels(CachedTexture *_pTexture)
+	: ColorBufferReader(_pTexture)
+{
+
+}
+
+u8 * ColorBufferReaderWithReadPixels::readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync)
+{
+	const graphics::FramebufferTextureFormats & fbTexFormat = gfxContext.getFramebufferTextureFormats();
+	GLenum colorFormat, colorType, colorFormatBytes;
+	if (_size > G_IM_SIZ_8b) {
+		colorFormat = GLenum(fbTexFormat.colorFormat);
+		colorType = GLenum(fbTexFormat.colorType);
+		colorFormatBytes = GLenum(fbTexFormat.colorFormatBytes);
+	} else {
+		colorFormat = GLenum(fbTexFormat.monochromeFormat);
+		colorType = GLenum(fbTexFormat.monochromeType);
+		colorFormatBytes = GLenum(fbTexFormat.monochromeFormatBytes);
+	}
+
+	// No async pixel buffer copies are supported in this class, this is a last resort fallback
+	auto pixelData = std::unique_ptr<GLubyte[]>(new GLubyte[m_pTexture->realWidth * _height * colorFormatBytes]) ;
+	glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, pixelData.get());
+
+	int widthBytes = _width*colorFormatBytes;
+	int strideBytes = m_pTexture->realWidth * colorFormatBytes;
+
+	for (unsigned int lnIndex = 0; lnIndex < _height; ++lnIndex) {
+		std::copy_n(pixelData.get() + (lnIndex*strideBytes), widthBytes, m_pixelData.data() + lnIndex*widthBytes);
+	}
+	return m_pixelData.data();
+}
+
+void ColorBufferReaderWithReadPixels::cleanUp()
+{
+}

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <Graphics/ColorBufferReader.h>
+#include "opengl_CachedFunctions.h"
+
+namespace opengl {
+
+class ColorBufferReaderWithReadPixels :
+		public graphics::ColorBufferReader
+{
+public:
+	ColorBufferReaderWithReadPixels(CachedTexture * _pTexture);
+	~ColorBufferReaderWithReadPixels() = default;
+
+	u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) override;
+	void cleanUp() override;
+};
+
+}

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -8,6 +8,7 @@
 #include "opengl_ColorBufferReaderWithPixelBuffer.h"
 #include "opengl_ColorBufferReaderWithBufferStorage.h"
 //#include "opengl_ColorBufferReaderWithEGLImage.h"
+#include "opengl_ColorBufferReaderWithReadPixels.h"
 #include "opengl_Utils.h"
 #include "GLSL/glsl_CombinerProgramBuilder.h"
 #include "GLSL/glsl_SpecialShadersFactory.h"
@@ -299,14 +300,17 @@ graphics::PixelReadBuffer * ContextImpl::createPixelReadBuffer(size_t _sizeInByt
 graphics::ColorBufferReader * ContextImpl::createColorBufferReader(CachedTexture * _pTexture)
 {
 	/*
-#ifdef EGL
+#if defined(EGL) && defined(OS_ANDROID)
 	return new ColorBufferReaderWithEGLImage(_pTexture, m_cachedFunctions->getCachedBindTexture());
 #endif*/
 
 	if (m_glInfo.bufferStorage)
 		return new ColorBufferReaderWithBufferStorage(_pTexture, m_cachedFunctions->getCachedBindBuffer());
 
-	return new ColorBufferReaderWithPixelBuffer(_pTexture, m_cachedFunctions->getCachedBindBuffer());
+	if (!m_glInfo.isGLES2)
+		return new ColorBufferReaderWithPixelBuffer(_pTexture, m_cachedFunctions->getCachedBindBuffer());
+
+	return new ColorBufferReaderWithReadPixels(_pTexture);
 }
 
 /*---------------Shaders-------------*/

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -89,6 +89,7 @@ MY_LOCAL_SRC_FILES :=                               \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_CachedFunctions.cpp                    \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp   \
+    $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.cpp    \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ContextImpl.cpp                        \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_GLInfo.cpp                             \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_Parameters.cpp                         \

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -211,12 +211,7 @@ void Config_LoadConfig()
 	config.video.cropMode = ConfigGetParamInt(g_configVideoGliden64, "CropMode");
 	config.video.cropWidth = ConfigGetParamInt(g_configVideoGliden64, "CropWidth");
 	config.video.cropHeight = ConfigGetParamInt(g_configVideoGliden64, "CropHeight");
-
-#ifdef GL_MULTISAMPLING_SUPPORT
 	config.video.multisampling = ConfigGetParamInt(g_configVideoGliden64, "MultiSampling");
-#else
-	config.video.multisampling = 0;
-#endif
 	config.frameBufferEmulation.aspect = ConfigGetParamInt(g_configVideoGliden64, "AspectRatio");
 	config.frameBufferEmulation.bufferSwapMode = ConfigGetParamInt(g_configVideoGliden64, "BufferSwapMode");
 	config.frameBufferEmulation.nativeResFactor = ConfigGetParamInt(g_configVideoGliden64, "UseNativeResolutionFactor");


### PR DESCRIPTION
Async copy is not supported for GLES2 devices unless using EGL Image extension which has platform independent implementations.

I will add the EGL Image extension for Android next.