### PR TITLE
Add compiler macro to produce backtrace on GL Error for all GL functions

### DIFF
--- a/src/Graphics/OpenGLContext/GLFunctions.h
+++ b/src/Graphics/OpenGLContext/GLFunctions.h
@@ -15,38 +15,53 @@
 #endif
 
 #include <GL/glext.h>
+#include <stdexcept>
+#include <sstream>
+#include "Log.h"
+
+#ifdef GL_ERROR_DEBUG
+#define CHECKED_GL_FUNCTION(proc_name, ...) checked([&]() { proc_name(__VA_ARGS__);}, #proc_name)
+#define CHECKED_GL_FUNCTION_WITH_RETURN(proc_name, ReturnType, ...) checkedWithReturn<ReturnType>([&]() { return proc_name(__VA_ARGS__);}, #proc_name)
+#else
+#define CHECKED_GL_FUNCTION(proc_name, ...) proc_name(__VA_ARGS__)
+#define CHECKED_GL_FUNCTION_WITH_RETURN(proc_name, ReturnType, ...) proc_name(__VA_ARGS__)
+#endif
+
+#define IS_GL_FUNCTION_VALID(proc_name) g_##proc_name != nullptr
+#define GET_GL_FUNCTION(proc_name) g_##proc_name
 
 #ifdef EGL
-#define glBlendFunc g_glBlendFunc
-#define glPixelStorei g_glPixelStorei
-#define glClearColor g_glClearColor
-#define glCullFace g_glCullFace
-#define glDepthFunc g_glDepthFunc
-#define glDepthMask g_glDepthMask
-#define glDisable g_glDisable
-#define glEnable g_glEnable
-#define glPolygonOffset g_glPolygonOffset
-#define glScissor g_glScissor
-#define glViewport g_glViewport
-#define glBindTexture g_glBindTexture
-#define glTexImage2D g_glTexImage2D
-#define glTexParameteri g_glTexParameteri
-#define glGetIntegerv g_glGetIntegerv
-#define glGetString g_glGetString
-#define glReadPixels g_glReadPixels
-#define glTexSubImage2D g_glTexSubImage2D
-#define glDrawArrays g_glDrawArrays
+
 #define glGetError g_glGetError
-#define glDrawElements g_glDrawElements
-#define glLineWidth g_glLineWidth
-#define glClear g_glClear
-#define glGetFloatv g_glGetFloatv
-#define glDeleteTextures g_glDeleteTextures
-#define glGenTextures g_glGenTextures
-#define glTexParameterf g_glTexParameterf
-#define glActiveTexture g_glActiveTexture
-#define glBlendColor g_glBlendColor
-#define glReadBuffer g_glReadBuffer
+#define glBlendFunc(...) CHECKED_GL_FUNCTION(g_glBlendFunc, __VA_ARGS__)
+#define glPixelStorei(...) CHECKED_GL_FUNCTION(g_glPixelStorei, __VA_ARGS__)
+#define glClearColor(...) CHECKED_GL_FUNCTION(g_glClearColor, __VA_ARGS__)
+#define glCullFace(...) CHECKED_GL_FUNCTION(g_glCullFace, __VA_ARGS__)
+#define glDepthFunc(...) CHECKED_GL_FUNCTION(g_glDepthFunc, __VA_ARGS__)
+#define glDepthMask(...) CHECKED_GL_FUNCTION(g_glDepthMask, __VA_ARGS__)
+#define glDisable(...) CHECKED_GL_FUNCTION(g_glDisable, __VA_ARGS__)
+#define glEnable(...) CHECKED_GL_FUNCTION(g_glEnable, __VA_ARGS__)
+#define glPolygonOffset(...) CHECKED_GL_FUNCTION(g_glPolygonOffset, __VA_ARGS__)
+#define glScissor(...) CHECKED_GL_FUNCTION(g_glScissor, __VA_ARGS__)
+#define glViewport(...) CHECKED_GL_FUNCTION(g_glViewport, __VA_ARGS__)
+#define glBindTexture(...) CHECKED_GL_FUNCTION(g_glBindTexture, __VA_ARGS__)
+#define glTexImage2D(...) CHECKED_GL_FUNCTION(g_glTexImage2D, __VA_ARGS__)
+#define glTexParameteri(...) CHECKED_GL_FUNCTION(g_glTexParameteri, __VA_ARGS__)
+#define glGetIntegerv(...) CHECKED_GL_FUNCTION(g_glGetIntegerv, __VA_ARGS__)
+#define glGetString(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glGetString, const GLubyte*, __VA_ARGS__)
+#define glReadPixels(...) CHECKED_GL_FUNCTION(g_glReadPixels, __VA_ARGS__)
+#define glTexSubImage2D(...) CHECKED_GL_FUNCTION(g_glTexSubImage2D, __VA_ARGS__)
+#define glDrawArrays(...) CHECKED_GL_FUNCTION(g_glDrawArrays, __VA_ARGS__)
+#define glDrawElements(...) CHECKED_GL_FUNCTION(g_glDrawElements, __VA_ARGS__)
+#define glLineWidth(...) CHECKED_GL_FUNCTION(g_glLineWidth, __VA_ARGS__)
+#define glClear(...) CHECKED_GL_FUNCTION(g_glClear, __VA_ARGS__)
+#define glGetFloatv(...) CHECKED_GL_FUNCTION(g_glGetFloatv, __VA_ARGS__)
+#define glDeleteTextures(...) CHECKED_GL_FUNCTION(g_glDeleteTextures, __VA_ARGS__)
+#define glGenTextures(...) CHECKED_GL_FUNCTION(g_glGenTextures, __VA_ARGS__)
+#define glTexParameterf(...) CHECKED_GL_FUNCTION(g_glTexParameterf, __VA_ARGS__)
+#define glActiveTexture(...) CHECKED_GL_FUNCTION(g_glActiveTexture, __VA_ARGS__)
+#define glBlendColor(...) CHECKED_GL_FUNCTION(g_glBlendColor, __VA_ARGS__)
+#define glReadBuffer(...) CHECKED_GL_FUNCTION(g_glReadBuffer, __VA_ARGS__)
 
 extern PFNGLBLENDFUNCPROC g_glBlendFunc;
 extern PFNGLPIXELSTOREIPROC g_glPixelStorei;
@@ -88,99 +103,99 @@ extern PFNGLACTIVETEXTUREPROC g_glActiveTexture;
 extern PFNGLBLENDCOLORPROC g_glBlendColor;
 #endif
 
-#define glCreateShader g_glCreateShader
-#define glCompileShader g_glCompileShader
-#define glShaderSource g_glShaderSource
-#define glCreateProgram g_glCreateProgram
-#define glAttachShader g_glAttachShader
-#define glLinkProgram g_glLinkProgram
-#define glUseProgram g_glUseProgram
-#define glGetUniformLocation g_glGetUniformLocation
-#define glUniform1i g_glUniform1i
-#define glUniform1f g_glUniform1f
-#define glUniform2f g_glUniform2f
-#define glUniform2i g_glUniform2i
-#define glUniform4i  g_glUniform4i
+#define glCreateShader(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glCreateShader, GLuint, __VA_ARGS__)
+#define glCompileShader(...) CHECKED_GL_FUNCTION(g_glCompileShader, __VA_ARGS__)
+#define glShaderSource(...) CHECKED_GL_FUNCTION(g_glShaderSource, __VA_ARGS__)
+#define glCreateProgram(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glCreateProgram, GLuint, __VA_ARGS__)
+#define glAttachShader(...) CHECKED_GL_FUNCTION(g_glAttachShader, __VA_ARGS__)
+#define glLinkProgram(...) CHECKED_GL_FUNCTION(g_glLinkProgram, __VA_ARGS__)
+#define glUseProgram(...) CHECKED_GL_FUNCTION(g_glUseProgram, __VA_ARGS__)
+#define glGetUniformLocation(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glGetUniformLocation, GLint, __VA_ARGS__)
+#define glUniform1i(...) CHECKED_GL_FUNCTION(g_glUniform1i, __VA_ARGS__)
+#define glUniform1f(...) CHECKED_GL_FUNCTION(g_glUniform1f, __VA_ARGS__)
+#define glUniform2f(...) CHECKED_GL_FUNCTION(g_glUniform2f, __VA_ARGS__)
+#define glUniform2i(...) CHECKED_GL_FUNCTION(g_glUniform2i, __VA_ARGS__)
+#define glUniform4i(...) CHECKED_GL_FUNCTION(g_glUniform4i, __VA_ARGS__)
 
-#define glUniform4f g_glUniform4f
-#define glUniform3fv g_glUniform3fv
-#define glUniform4fv g_glUniform4fv
-#define glDetachShader g_glDetachShader
-#define glDeleteShader g_glDeleteShader
-#define glDeleteProgram g_glDeleteProgram
-#define glGetProgramInfoLog g_glGetProgramInfoLog
-#define glGetShaderInfoLog g_glGetShaderInfoLog
-#define glGetShaderiv g_glGetShaderiv
-#define glGetProgramiv g_glGetProgramiv
+#define glUniform4f(...) CHECKED_GL_FUNCTION(g_glUniform4f, __VA_ARGS__)
+#define glUniform3fv(...) CHECKED_GL_FUNCTION(g_glUniform3fv, __VA_ARGS__)
+#define glUniform4fv(...) CHECKED_GL_FUNCTION(g_glUniform4fv, __VA_ARGS__)
+#define glDetachShader(...) CHECKED_GL_FUNCTION(g_glDetachShader, __VA_ARGS__)
+#define glDeleteShader(...) CHECKED_GL_FUNCTION(g_glDeleteShader, __VA_ARGS__)
+#define glDeleteProgram(...) CHECKED_GL_FUNCTION(g_glDeleteProgram, __VA_ARGS__)
+#define glGetProgramInfoLog(...) CHECKED_GL_FUNCTION(g_glGetProgramInfoLog, __VA_ARGS__)
+#define glGetShaderInfoLog(...) CHECKED_GL_FUNCTION(g_glGetShaderInfoLog, __VA_ARGS__)
+#define glGetShaderiv(...) CHECKED_GL_FUNCTION(g_glGetShaderiv, __VA_ARGS__)
+#define glGetProgramiv(...) CHECKED_GL_FUNCTION(g_glGetProgramiv, __VA_ARGS__)
 
-#define glEnableVertexAttribArray g_glEnableVertexAttribArray
-#define glDisableVertexAttribArray g_glDisableVertexAttribArray
-#define glVertexAttribPointer g_glVertexAttribPointer
-#define glBindAttribLocation g_glBindAttribLocation
-#define glVertexAttrib1f g_glVertexAttrib1f
-#define glVertexAttrib4f g_glVertexAttrib4f
-#define glVertexAttrib4fv g_glVertexAttrib4fv
+#define glEnableVertexAttribArray(...) CHECKED_GL_FUNCTION(g_glEnableVertexAttribArray, __VA_ARGS__)
+#define glDisableVertexAttribArray(...) CHECKED_GL_FUNCTION(g_glDisableVertexAttribArray, __VA_ARGS__)
+#define glVertexAttribPointer(...) CHECKED_GL_FUNCTION(g_glVertexAttribPointer, __VA_ARGS__)
+#define glBindAttribLocation(...) CHECKED_GL_FUNCTION(g_glBindAttribLocation, __VA_ARGS__)
+#define glVertexAttrib1f(...) CHECKED_GL_FUNCTION(g_glVertexAttrib1f, __VA_ARGS__)
+#define glVertexAttrib4f(...) CHECKED_GL_FUNCTION(g_glVertexAttrib4f, __VA_ARGS__)
+#define glVertexAttrib4fv(...) CHECKED_GL_FUNCTION(g_glVertexAttrib4fv, __VA_ARGS__)
 
-#define glDepthRangef g_glDepthRangef
-#define glClearDepthf g_glClearDepthf
+#define glDepthRangef(...) CHECKED_GL_FUNCTION(g_glDepthRangef, __VA_ARGS__)
+#define glClearDepthf(...) CHECKED_GL_FUNCTION(g_glClearDepthf, __VA_ARGS__)
 
-#define glDrawBuffers g_glDrawBuffers
-#define glGenFramebuffers g_glGenFramebuffers
-#define glBindFramebuffer g_glBindFramebuffer
-#define glDeleteFramebuffers g_glDeleteFramebuffers
-#define glFramebufferTexture2D g_glFramebufferTexture2D
-#define glTexImage2DMultisample g_glTexImage2DMultisample
-#define glTexStorage2DMultisample g_glTexStorage2DMultisample
-#define glGenRenderbuffers g_glGenRenderbuffers
-#define glBindRenderbuffer g_glBindRenderbuffer
-#define glRenderbufferStorage g_glRenderbufferStorage
-#define glDeleteRenderbuffers g_glDeleteRenderbuffers
-#define glFramebufferRenderbuffer g_glFramebufferRenderbuffer
-#define glCheckFramebufferStatus g_glCheckFramebufferStatus
-#define glBlitFramebuffer g_glBlitFramebuffer
-#define glGenVertexArrays g_glGenVertexArrays
-#define glBindVertexArray g_glBindVertexArray
-#define glDeleteVertexArrays g_glDeleteVertexArrays;
-#define glGenBuffers g_glGenBuffers
-#define glBindBuffer g_glBindBuffer
-#define glBufferData g_glBufferData
-#define glMapBuffer g_glMapBuffer
-#define glMapBufferRange g_glMapBufferRange
-#define glUnmapBuffer g_glUnmapBuffer
-#define glDeleteBuffers g_glDeleteBuffers
-#define glBindImageTexture g_glBindImageTexture
-#define glMemoryBarrier g_glMemoryBarrier
-#define glGetStringi g_glGetStringi
-#define glInvalidateFramebuffer g_glInvalidateFramebuffer
-#define glBufferStorage g_glBufferStorage
-#define glFenceSync g_glFenceSync
-#define glClientWaitSync g_glClientWaitSync
-#define glDeleteSync g_glDeleteSync
+#define glBindBuffer(...) CHECKED_GL_FUNCTION(g_glBindBuffer, __VA_ARGS__)
+#define glBindFramebuffer(...) CHECKED_GL_FUNCTION(g_glBindFramebuffer, __VA_ARGS__)
+#define glBindRenderbuffer(...) CHECKED_GL_FUNCTION(g_glBindRenderbuffer, __VA_ARGS__)
+#define glDrawBuffers(...) CHECKED_GL_FUNCTION(g_glDrawBuffers, __VA_ARGS__)
+#define glGenFramebuffers(...) CHECKED_GL_FUNCTION(g_glGenFramebuffers, __VA_ARGS__)
+#define glDeleteFramebuffers(...) CHECKED_GL_FUNCTION(g_glDeleteFramebuffers, __VA_ARGS__)
+#define glFramebufferTexture2D(...) CHECKED_GL_FUNCTION(g_glFramebufferTexture2D, __VA_ARGS__)
+#define glTexImage2DMultisample(...) CHECKED_GL_FUNCTION(g_glTexImage2DMultisample, __VA_ARGS__)
+#define glTexStorage2DMultisample(...) CHECKED_GL_FUNCTION(g_glTexStorage2DMultisample, __VA_ARGS__)
+#define glGenRenderbuffers(...) CHECKED_GL_FUNCTION(g_glGenRenderbuffers, __VA_ARGS__)
+#define glRenderbufferStorage(...) CHECKED_GL_FUNCTION(g_glRenderbufferStorage, __VA_ARGS__)
+#define glDeleteRenderbuffers(...) CHECKED_GL_FUNCTION(g_glDeleteRenderbuffers, __VA_ARGS__)
+#define glFramebufferRenderbuffer(...) CHECKED_GL_FUNCTION(g_glFramebufferRenderbuffer, __VA_ARGS__)
+#define glCheckFramebufferStatus(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glCheckFramebufferStatus, GLenum, __VA_ARGS__)
+#define glBlitFramebuffer(...) CHECKED_GL_FUNCTION(g_glBlitFramebuffer, __VA_ARGS__)
+#define glGenVertexArrays(...) CHECKED_GL_FUNCTION(g_glGenVertexArrays, __VA_ARGS__)
+#define glBindVertexArray(...) CHECKED_GL_FUNCTION(g_glBindVertexArray, __VA_ARGS__)
+#define glDeleteVertexArrays(...) CHECKED_GL_FUNCTION(g_glDeleteVertexArrays, __VA_ARGS__);
+#define glGenBuffers(...) CHECKED_GL_FUNCTION(g_glGenBuffers, __VA_ARGS__)
+#define glBufferData(...) CHECKED_GL_FUNCTION(g_glBufferData, __VA_ARGS__)
+#define glMapBuffer(...) CHECKED_GL_FUNCTION(g_glMapBuffer, __VA_ARGS__)
+#define glMapBufferRange(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glMapBufferRange, void*, __VA_ARGS__)
+#define glUnmapBuffer(...) CHECKED_GL_FUNCTION(g_glUnmapBuffer, __VA_ARGS__)
+#define glDeleteBuffers(...) CHECKED_GL_FUNCTION(g_glDeleteBuffers, __VA_ARGS__)
+#define glBindImageTexture(...) CHECKED_GL_FUNCTION(g_glBindImageTexture, __VA_ARGS__)
+#define glMemoryBarrier(...) CHECKED_GL_FUNCTION(g_glMemoryBarrier, __VA_ARGS__)
+#define glGetStringi(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glGetStringi, const GLubyte*, __VA_ARGS__)
+#define glInvalidateFramebuffer(...) CHECKED_GL_FUNCTION(g_glInvalidateFramebuffer, __VA_ARGS__)
+#define glBufferStorage(...) CHECKED_GL_FUNCTION(g_glBufferStorage, __VA_ARGS__)
+#define glFenceSync(...) CHECKED_GL_FUNCTION_WITH_RETURN(g_glFenceSync, GLsync, __VA_ARGS__)
+#define glClientWaitSync(...) CHECKED_GL_FUNCTION(g_glClientWaitSync, __VA_ARGS__)
+#define glDeleteSync(...) CHECKED_GL_FUNCTION(g_glDeleteSync, __VA_ARGS__)
 
-#define glGetUniformBlockIndex g_glGetUniformBlockIndex
-#define glUniformBlockBinding g_glUniformBlockBinding
-#define glGetActiveUniformBlockiv g_glGetActiveUniformBlockiv
-#define glGetUniformIndices g_glGetUniformIndices
-#define glGetActiveUniformsiv g_glGetActiveUniformsiv
-#define glBindBufferBase g_glBindBufferBase
-#define glBufferSubData g_glBufferSubData
+#define glGetUniformBlockIndex(...) CHECKED_GL_FUNCTION(g_glGetUniformBlockIndex, __VA_ARGS__)
+#define glUniformBlockBinding(...) CHECKED_GL_FUNCTION(g_glUniformBlockBinding, __VA_ARGS__)
+#define glGetActiveUniformBlockiv(...) CHECKED_GL_FUNCTION(g_glGetActiveUniformBlockiv, __VA_ARGS__)
+#define glGetUniformIndices(...) CHECKED_GL_FUNCTION(g_glGetUniformIndices, __VA_ARGS__)
+#define glGetActiveUniformsiv(...) CHECKED_GL_FUNCTION(g_glGetActiveUniformsiv, __VA_ARGS__)
+#define glBindBufferBase(...) CHECKED_GL_FUNCTION(g_glBindBufferBase, __VA_ARGS__)
+#define glBufferSubData(...) CHECKED_GL_FUNCTION(g_glBufferSubData, __VA_ARGS__)
 
-#define glGetProgramBinary g_glGetProgramBinary
-#define glProgramBinary g_glProgramBinary
-#define glProgramParameteri g_glProgramParameteri
+#define glGetProgramBinary(...) CHECKED_GL_FUNCTION(g_glGetProgramBinary, __VA_ARGS__)
+#define glProgramBinary(...) CHECKED_GL_FUNCTION(g_glProgramBinary, __VA_ARGS__)
+#define glProgramParameteri(...) CHECKED_GL_FUNCTION(g_glProgramParameteri, __VA_ARGS__)
 
-#define glTexStorage2D g_glTexStorage2D
-#define glTextureStorage2D g_glTextureStorage2D
-#define glTextureSubImage2D g_glTextureSubImage2D
-#define glTextureStorage2DMultisample g_glTextureStorage2DMultisample
-#define glTextureParameteri g_glTextureParameteri
-#define glTextureParameterf g_glTextureParameterf
-#define glCreateTextures g_glCreateTextures
-#define glCreateBuffers g_glCreateBuffers
-#define glCreateFramebuffers g_glCreateFramebuffers
-#define glNamedFramebufferTexture g_glNamedFramebufferTexture
-#define glDrawElementsBaseVertex g_glDrawElementsBaseVertex
-#define glFlushMappedBufferRange g_glFlushMappedBufferRange
+#define glTexStorage2D(...) CHECKED_GL_FUNCTION(g_glTexStorage2D, __VA_ARGS__)
+#define glTextureStorage2D(...) CHECKED_GL_FUNCTION(g_glTextureStorage2D, __VA_ARGS__)
+#define glTextureSubImage2D(...) CHECKED_GL_FUNCTION(g_glTextureSubImage2D, __VA_ARGS__)
+#define glTextureStorage2DMultisample(...) CHECKED_GL_FUNCTION(g_glTextureStorage2DMultisample, __VA_ARGS__)
+#define glTextureParameteri(...) CHECKED_GL_FUNCTION(g_glTextureParameteri, __VA_ARGS__)
+#define glTextureParameterf(...) CHECKED_GL_FUNCTION(g_glTextureParameterf, __VA_ARGS__)
+#define glCreateTextures(...) CHECKED_GL_FUNCTION(g_glCreateTextures, __VA_ARGS__)
+#define glCreateBuffers(...) CHECKED_GL_FUNCTION(g_glCreateBuffers, __VA_ARGS__)
+#define glCreateFramebuffers(...) CHECKED_GL_FUNCTION(g_glCreateFramebuffers, __VA_ARGS__)
+#define glNamedFramebufferTexture(...) CHECKED_GL_FUNCTION(g_glNamedFramebufferTexture, __VA_ARGS__)
+#define glDrawElementsBaseVertex(...) CHECKED_GL_FUNCTION(g_glDrawElementsBaseVertex, __VA_ARGS__)
+#define glFlushMappedBufferRange(...) CHECKED_GL_FUNCTION(g_glFlushMappedBufferRange, __VA_ARGS__)
 
 extern PFNGLCREATESHADERPROC g_glCreateShader;
 extern PFNGLCOMPILESHADERPROC g_glCompileShader;
@@ -277,5 +292,31 @@ extern PFNGLDRAWELEMENTSBASEVERTEXPROC g_glDrawElementsBaseVertex;
 extern PFNGLFLUSHMAPPEDBUFFERRANGEPROC g_glFlushMappedBufferRange;
 
 void initGLFunctions();
+
+template<typename F> void checked(F fn, const char* _functionName)
+{
+	fn();
+	auto error = glGetError();
+	if (error != GL_NO_ERROR) {
+		std::stringstream errorString;
+		errorString << _functionName << " OpenGL error: 0x" << std::hex << error;
+		LOG(LOG_ERROR, errorString.str().c_str());
+		throw std::runtime_error(errorString.str().c_str());
+	}
+}
+
+template<typename R, typename F> R checkedWithReturn(F fn, const char* _functionName)
+{
+	R returnValue = fn();
+	auto error = glGetError();
+	if (error != GL_NO_ERROR) {
+		std::stringstream errorString;
+		errorString << _functionName << " OpenGL error: 0x" << std::hex << error;
+		LOG(LOG_ERROR, errorString.str().c_str());
+		throw std::runtime_error(errorString.str().c_str());
+	}
+
+	return returnValue;
+}
 
 #endif // GLFUNCTIONS_H

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
@@ -139,9 +139,9 @@ void CachedTextureUnpackAlignment::setTextureUnpackAlignment(s32 _param)
 /*---------------CachedFunctions-------------*/
 
 CachedFunctions::CachedFunctions(const GLInfo & _glinfo)
-: m_bindFramebuffer(glBindFramebuffer)
-, m_bindRenderbuffer(glBindRenderbuffer)
-, m_bindBuffer(glBindBuffer) {
+: m_bindFramebuffer(GET_GL_FUNCTION(glBindFramebuffer))
+, m_bindRenderbuffer(GET_GL_FUNCTION(glBindRenderbuffer))
+, m_bindBuffer(GET_GL_FUNCTION(glBindBuffer)) {
 	if (_glinfo.isGLESX) {
 		// Disable parameters, not avalible for GLESX
 		m_enables.emplace(GL_DEPTH_CLAMP, Parameter());

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
@@ -123,11 +123,11 @@ namespace opengl {
 		Bind m_bind;
 	};
 
-	typedef CachedBind<decltype(glBindFramebuffer)> CachedBindFramebuffer;
+	typedef CachedBind<decltype(GET_GL_FUNCTION(glBindFramebuffer))> CachedBindFramebuffer;
 
-	typedef CachedBind<decltype(glBindRenderbuffer)> CachedBindRenderbuffer;
+	typedef CachedBind<decltype(GET_GL_FUNCTION(glBindRenderbuffer))> CachedBindRenderbuffer;
 
-	typedef CachedBind<decltype(glBindBuffer)> CachedBindBuffer;
+	typedef CachedBind<decltype(GET_GL_FUNCTION(glBindBuffer))> CachedBindBuffer;
 
 	class CachedBindTexture : public Cached2<graphics::Parameter, graphics::ObjectHandle>
 	{

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -216,7 +216,7 @@ s32 ContextImpl::getMaxTextureSize() const
 
 void ContextImpl::bindImageTexture(const graphics::Context::BindImageTextureParameters & _params)
 {
-	if (glBindImageTexture != nullptr)
+	if (IS_GL_FUNCTION_VALID(glBindImageTexture))
 		glBindImageTexture(GLuint(_params.imageUnit), GLuint(_params.texture), 0, GL_FALSE, 0, GLenum(_params.accessMode), GLenum(_params.textureFormat));
 }
 

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -34,11 +34,11 @@ void GLInfo::init() {
 		imageTextures = false;
 		msaa = false;
 	} else if (isGLESX) {
-		imageTextures = (numericVersion >= 31) && (glBindImageTexture != nullptr);
+		imageTextures = (numericVersion >= 31) && IS_GL_FUNCTION_VALID(glBindImageTexture);
 		msaa = numericVersion >= 31;
 	} else {
 		imageTextures = ((numericVersion >= 43) || (Utils::isExtensionSupported(*this, "GL_ARB_shader_image_load_store") &&
-				Utils::isExtensionSupported(*this, "GL_ARB_compute_shader"))) && (glBindImageTexture != nullptr);
+				Utils::isExtensionSupported(*this, "GL_ARB_compute_shader"))) && IS_GL_FUNCTION_VALID(glBindImageTexture);
 		msaa = true;
 	}
 	if (!imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {

--- a/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
@@ -193,7 +193,7 @@ namespace opengl {
 				}
 
 				if (_params.ImageUnit.isValid()) {
-					assert(glBindImageTexture != nullptr);
+					assert(IS_GL_FUNCTION_VALID(glBindImageTexture));
 					glBindImageTexture(GLuint(_params.ImageUnit), GLuint(_params.handle),
 					0, GL_FALSE, GL_FALSE, GL_READ_ONLY, GLuint(_params.internalFormat));
 				}
@@ -276,7 +276,7 @@ namespace opengl {
 				_params.data);
 
 			if (_params.ImageUnit.isValid() && _params.internalFormat.isValid()) {
-				assert(glBindImageTexture != nullptr);
+				assert(IS_GL_FUNCTION_VALID(glBindImageTexture));
 				glBindImageTexture(GLuint(_params.ImageUnit), GLuint(_params.handle),
 				0, GL_FALSE, GL_FALSE, GL_READ_ONLY, GLuint(_params.internalFormat));
 			}


### PR DESCRIPTION
This will also log the function name and the error number when the GL error happens.

This is useful for Android 7.0, which lacks the built in back trace on GL error. I imagine this will be useful for other platforms as well.