### PR TITLE
Fix GLES 2.0 texture initialization errors

### DIFF
--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -257,7 +257,7 @@ void _initTexture(CachedTexture * pTexture)
 	initParams.handle = pTexture->name;
 	initParams.width = pTexture->realWidth;
 	initParams.height = pTexture->realHeight;
-	initParams.internalFormat = internalcolorFormat::RGBA8;
+	initParams.internalFormat = gfxContext.convertInternalTextureFormat(u32(internalcolorFormat::RGBA8));
 	initParams.format = colorFormat::RGBA;
 	initParams.dataType = datatype::UNSIGNED_BYTE;
 	gfxContext.init2DTexture(initParams);

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -626,7 +626,7 @@ void TextureCache::init()
 	params.width = m_pDummy->realWidth;
 	params.height = m_pDummy->realHeight;
 	params.format = colorFormat::RGBA;
-	params.internalFormat = internalcolorFormat::RGBA8;
+	params.internalFormat = gfxContext.convertInternalTextureFormat(u32(internalcolorFormat::RGBA8));
 	params.dataType = datatype::UNSIGNED_BYTE;
 	params.data = dummyTexture;
 	gfxContext.init2DTexture(params);
@@ -649,7 +649,7 @@ void TextureCache::init()
 		params.width = m_pMSDummy->realWidth;
 		params.height = m_pMSDummy->realHeight;
 		params.format = colorFormat::RGBA;
-		params.internalFormat = internalcolorFormat::RGBA8;
+		params.internalFormat = gfxContext.convertInternalTextureFormat(u32(internalcolorFormat::RGBA8));
 		params.dataType = datatype::UNSIGNED_BYTE;
 		gfxContext.init2DTexture(params);
 


### PR DESCRIPTION
It seems that not all GL errors were addressed. After making this change, I'm not seeing any more.