### PR TITLE
Implement N64 depth compare for GLES3.x

### DIFF
--- a/src/DepthBuffer.h
+++ b/src/DepthBuffer.h
@@ -25,8 +25,10 @@ struct DepthBuffer
 
 	u32 m_address, m_width;
 	u32 m_ulx, m_uly, m_lrx, m_lry; // Parameters of fillrect command.
-	graphics::ObjectHandle m_depthImageFBO;
-	CachedTexture *m_pDepthImageTexture;
+	graphics::ObjectHandle m_depthImageZFBO;
+	graphics::ObjectHandle m_depthImageDeltaZFBO;
+	CachedTexture *m_pDepthImageZTexture;
+	CachedTexture *m_pDepthImageDeltaZTexture;
 	CachedTexture *m_pDepthBufferTexture;
 	graphics::ObjectHandle m_depthRenderbuffer;
 	u32 m_depthRenderbufferWidth;
@@ -40,6 +42,8 @@ struct DepthBuffer
 	bool m_copied;
 
 private:
+	void _initDepthImageTexture(FrameBuffer * _pBuffer, CachedTexture& _cachedTexture,
+								graphics::ObjectHandle& _depthImageFBO);
 	void _initDepthBufferTexture(FrameBuffer * _pBuffer, CachedTexture *_pTexture, bool _multisample);
 	void _initDepthBufferRenderbuffer(FrameBuffer * _pBuffer);
 	void _DepthBufferTexture(FrameBuffer * _pBuffer);

--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -492,10 +492,10 @@ protected:
 		depthType = GL_UNSIGNED_INT;
 		depthFormatBytes = 4;
 
-		depthImageInternalFormat = GL_RGBA32F;
-		depthImageFormat = GL_RGBA;
+		depthImageInternalFormat = GL_R32F;
+		depthImageFormat = GL_RED;
 		depthImageType = GL_FLOAT;
-		depthImageFormatBytes = 16;
+		depthImageFormatBytes = 4;
 
 		lutInternalFormat = GL_R32UI;
 		lutFormat = GL_RED_INTEGER;
@@ -538,10 +538,10 @@ protected:
 		depthType = GL_FLOAT;
 		depthFormatBytes = 4;
 
-		depthImageInternalFormat = GL_RG32F;
-		depthImageFormat = GL_RG;
+		depthImageInternalFormat = GL_R32F;
+		depthImageFormat = GL_RED;
 		depthImageType = GL_FLOAT;
-		depthImageFormatBytes = 8;
+		depthImageFormatBytes = 4;
 
 		lutInternalFormat = GL_R32UI;
 		lutFormat = GL_RED_INTEGER;

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.h
@@ -3,7 +3,7 @@
 #include <Graphics/ColorBufferReader.h>
 #include "opengl_CachedFunctions.h"
 
-#include <Graphics/OpenGLContext/GraphicBUfferPrivateApi/GraphicBuffer.h>
+#include <Graphics/OpenGLContext/GraphicBufferPrivateApi/GraphicBuffer.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 

--- a/src/Graphics/OpenGLContext/opengl_Parameters.cpp
+++ b/src/Graphics/OpenGLContext/opengl_Parameters.cpp
@@ -72,7 +72,8 @@ namespace graphics {
 	namespace textureImageUnits {
 		ImageUnitParam Zlut(0U);
 		ImageUnitParam Tlut(1U);
-		ImageUnitParam Depth(2U);
+		ImageUnitParam DepthZ(2U);
+		ImageUnitParam DepthDeltaZ(3U);
 	}
 
 	namespace textureImageAccessMode {

--- a/src/Graphics/Parameters.h
+++ b/src/Graphics/Parameters.h
@@ -72,7 +72,8 @@ namespace graphics {
 	namespace textureImageUnits {
 		extern ImageUnitParam Zlut;
 		extern ImageUnitParam Tlut;
-		extern ImageUnitParam Depth;
+		extern ImageUnitParam DepthZ;
+		extern ImageUnitParam DepthDeltaZ;
 	}
 
 	namespace textureImageAccessMode {


### PR DESCRIPTION
I need some guidance here. I attempted to implement N64 depth compare that is compatible with GLES 3.x, but I'm getting stuck on how to handle m_depthImageFBO that the depth image texture attaches to.

Since there are now two depth image textures, one for red and one for green, and we only have 1 depth image FBO. Any idea about what to handle that?