### PR TITLE
Disable async color buffer copies on non-android GLES2

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -67,4 +67,10 @@ void GLInfo::init() {
 			shaderStorage = numBinaryFormats > 0;
 		}
 	}
+#ifndef OS_ANDROID
+	if (isGLES2 && config.frameBufferEmulation.copyToRDRAM == ctAsync) {
+		config.frameBufferEmulation.copyToRDRAM = ctDisable;
+		LOG(LOG_WARNING, "Async color buffer copies are not supported on GLES2\n");
+	}
+#endif
 }


### PR DESCRIPTION
The implementation only supports synchronous copies, so this disables it altogether if they have async chosen (right now if they choose async it will give them sync)