### PR TITLE
german translation: fix special signs

### DIFF
--- a/translations/gliden64_de.ts
+++ b/translations/gliden64_de.ts
@@ -157,7 +157,7 @@
     <message>
         <location filename="configDialog.ui" line="2898"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Gamma correction.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Some N64 games use gamma correction. Gamma correction makes image brighter. N64 applies gamma correction in its Video Interface. &lt;/p&gt;&lt;p&gt;GLideN64 emulates gamma correction as post-processing effect. That is, it works only when frame buffer emulation enabled. Gamma correction enabled automatically for games, which use it on real N64. You may force gamma correction for all games. Default level of gamma correction is 2, as on N64.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;use defaults&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Gammakorrektur.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Einige N64 Spiele verwenden Gammakorrektur. Gammakorrektur macht das Bild heller. Das N64 wendet Gammakorrektur in seinem Video Interface an. &lt;/p&gt;&lt;p&gt;GLideN64 emuliert Gammakorrektur als einen Nachbearbeitungseffekt. Das bedeutet, es funktioniert nur, wenn die Frame-Buffer-Emulation aktiviert ist. Gammakorrektur wird automatisch bei Spielen aktiviert, welche dieses Feature auf einem echten N64 verwenden. Du kannst Gammakorrektur für alle Spiele erzwingen. Der Standardwert für Gammakorrektur ist 2, wie auf einem N64.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;benutze Standardeinstellung&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Gammakorrektur.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Einige N64 Spiele verwenden Gammakorrektur. Gammakorrektur macht das Bild heller. Das N64 wendet Gammakorrektur in seinem Video Interface an. &lt;/p&gt;&lt;p&gt;GLideN64 emuliert Gammakorrektur mit einem Nachbearbeitungseffekt. Das bedeutet, es funktioniert nur, wenn die Frame-Buffer-Emulation aktiviert ist. Gammakorrektur wird automatisch bei Spielen aktiviert, welche dieses Feature auf einem echten N64 verwenden. Du kannst Gammakorrektur für alle Spiele erzwingen. Der Standardwert für Gammakorrektur ist 2, wie auf einem N64.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;benutze Standardeinstellung&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1999"/>
@@ -183,7 +183,7 @@
         <location filename="configDialog.ui" line="213"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can use this option to crop black borders. Use &lt;span style=&quot; font-weight:600;&quot;&gt;Auto per game&lt;/span&gt; to crop automatically based on the game or &lt;span style=&quot; font-weight:600;&quot;&gt;Custom&lt;/span&gt; to set the number of pixels yourself. The number of pixels is based on the original N64 resolution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Crop image:&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This option allows user to crop black boarders from resulted image. It has two modes:&lt;br/&gt;&lt;br/&gt;* Auto - plugin sets crop automatically using game&apos;s frame scissor.&lt;/p&gt;&lt;p&gt;* Custom - crop using user defined values. User should set number of pixels to crop from original native-res image.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bild zuschneiden:&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Diese Option erlaubt es dem Benutzer schwarze Fensterr&#228;nder zu beschneiden. Es gibt zwei Modi:&lt;br/&gt;&lt;br/&gt;* Auto - das Plugin beschneidet automatisch nach Spielvorgabe.&lt;/p&gt;&lt;p&gt;* Custom - der Rand wird nach Benutzervorgabe beschnitten. Der Benutzer muss die zu beschneidende Pixelanzahl angeben.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Diese Option erlaubt es dem Benutzer schwarze Fensterränder zu beschneiden. Verwende &lt;span style=&quot; font-weight:600;&quot;&gt;Automatisch spielabhängig&lt;/span&gt; um automatisch nach Spielvorgabe zu beschneiden oder  &lt;span style=&quot; font-weight:600;&quot;&gt;Anpassung&lt;/span&gt; um nach Benutzervorgabe zu beschneiden. Der Benutzer muss die zu beschneidende Pixelanzahl angeben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="248"/>
@@ -203,7 +203,7 @@
     <message>
         <location filename="configDialog.ui" line="455"/>
         <source>Anti-aliasing:</source>
-        <translation>Kantenglättung</translation>
+        <translation>Kantenglättung:</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="832"/>
@@ -314,12 +314,12 @@
     <message>
         <location filename="configDialog.ui" line="59"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All the resolutions that your video card/monitor supports should be displayed.&lt;/p&gt;&lt;p&gt;[Recommended:&lt;span style=&quot; font-style:italic;&quot;&gt; Maximum resolution for your monitor unless performance becomes an issue&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Alle von der Grafikkarte/Monitor unterst&#252;tzten Aufl&#246;sungen sollten angezeigt werden.&lt;/p&gt;&lt;p&gt;[Empfohlen:&lt;span style=&quot; font-style:italic;&quot;&gt; Die maximale Aufl&#246;sung des Monitors außer es gibt Geschwindigkeitprobleme&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Alle von der Grafikkarte/Monitor unterstützten Auflösungen sollten angezeigt werden.&lt;/p&gt;&lt;p&gt;[Empfehlung:&lt;span style=&quot; font-style:italic;&quot;&gt; Die maximale Auflösung des Monitors, außer es gibt Geschwindigkeitprobleme&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="107"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option selects the resolution for windowed mode. You also may select &lt;span style=&quot; font-weight:600;&quot;&gt;Custom&lt;/span&gt; and enter your own window size.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;640 x 480, 800 x 600, 1024 x 768, 1280 x 960&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung legt die Auflösung des Fenstermodus fest. Man kann auch &lt;span style=&quot; font-weight:600;&quot;&gt;Anpassung&lt;/span&gt; auswählen und eine eigene Fenstergröße angeben.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;640 x 480, 800 x 600, 1024 x 768, 1280 x 960&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="237"/>
@@ -329,12 +329,12 @@
     <message>
         <location filename="configDialog.ui" line="341"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting adjusts the aspect ratio of the video output. All N64 games support &lt;span style=&quot; font-weight:600;&quot;&gt;4:3&lt;/span&gt;. Some games support &lt;span style=&quot; font-weight:600;&quot;&gt;16:9&lt;/span&gt; within game settings. Use &lt;span style=&quot; font-weight:600;&quot;&gt;Stretch&lt;/span&gt; to fill the screen without pillar or letterboxing.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Try to adjust game to fit&lt;/span&gt; tries to adjust the viewing space to fit without stretching. Many games work well adjusted, but some don&apos;t.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung legt das Seitenverhältnis der Ausgabe fest. Alle N64 Spiele unterstützen &lt;span style=&quot; font-weight:600;&quot;&gt;4:3&lt;/span&gt;. Einige Spiele unterstützen &lt;span style=&quot; font-weight:600;&quot;&gt;16:9&lt;/span&gt; innerhalb der Spieleinstellungen. Verwende &lt;span style=&quot; font-weight:600;&quot;&gt;Strecken&lt;/span&gt; um den kompletten Bildschirm ohne schwarze Ränder anzuzeigen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Versuche das Spiel passend einzustellen&lt;/span&gt; versucht den Betrachtungsraum ohne Strecken anzupassen. Viele Spiele funktionieren gut. Einige nicht.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="362"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aspect ratio:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Seitenverh&#228;ltnis:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Seitenverhältnis:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="369"/>
@@ -410,7 +410,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="951"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The selected language will display after this window is closed and reopened.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Die gewählte Sprache wird übernommen, nachdem das Fenster geschlossen und wieder geöffnet wird.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1060"/>
@@ -421,7 +421,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1100"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;GLideN64 contains settings for the optimal performance of some games. When this option is checked some options on this tab and the frame buffer tab may be overridden.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;GLideN64 enthält Voreinstellungen für einige Spiele um die beste Ausführrungsgeschwindikeit sicher zu stellen. Wenn diese Einstellung ausgewählt ist, werden einige Auswahlmöglichkeiten auf dieser Seite und die Frame-Buffer-Emulation möglicherweise überschrieben.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1103"/>
@@ -431,7 +431,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1137"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The N64 uses a unique method of mip-mapping that&apos;s difficult to reproduce correctly on PCs. When checked, this option emulates N64-accurate mip-mapping. When unchecked, some games have sharper distant textures.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das N64 verwendet eine einzigartige Art des Mip-Mappings, welche nur schwer auf einem PC nachzustellen ist. Wenn diese Einstellung ausgewählt ist wird N64 Mip-Mapping emuliert. Wenn diese Einstellung nicht ausgewählt ist sehen bei einigen Spielen Texturen in der Ferne schärfer aus.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1140"/>
@@ -441,7 +441,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1150"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option emulates effects that use random color input. Checking this option may cause rare performance problems.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung emuliert Effekte, welche zufällige Farbeingaben verwenden. Diese Einstellung kann sporadisch zu Geschwindigkeitsproblemen führen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1153"/>
@@ -451,7 +451,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1163"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In N64 games lighting is calculated per vertex. This option enables Phong shading, which provides smoother and more realistic lighting.&lt;br/&gt;&lt;br/&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Your preference&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das N64 berechnet die Beleuchtung per Vertex. Diese Einstellung aktiviert Phong Shading, welches glatterer und realistischer Beleuchtung erzeugt.&lt;br/&gt;&lt;br/&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Eigene Vorliebe&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1166"/>
@@ -461,22 +461,22 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1173"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use persistent storage for compiled shader programs.&lt;br/&gt;Each game uses a set of combiners. A combiner is an equation that defines how to build output color from various color inputs. GLideN64 translates shaders, and compiles shader programs on the fly. Shaders are large and complex. If the game uses several new combiners, compiling new shaders will take time and result in stuttering. When this option is checked, these shaders are saved so they&apos;re not recompiled the next time you run the game.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verwende einen dauerhaften Speicher für kompilierte Shader Programme.&lt;br/&gt;Jedes Spiel verwendet einen Satz an Combinern. Ein Combiner ist eine Gleichung, welche beschreibt wie aus verschiedenen Farbeingängen eine Ausgangsfarbe erzeugt wird. GLideN64 übersetzt und kompiliert Shader während der Laufzeit. Shader sind groß und komplex.Wenn ein Spiel mehrere neue Combiner verwendet dauert das kompilieren neuer Shader einige Zeit, was zu Stottern führen kann. Wenn diese einstellung ausgewählt ist werden diese Shader gesichert, damit sie beim nächsten Mal nicht neu kompiliert werden müssen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1176"/>
         <source>Store compiled shaders for performance (recommended)</source>
-        <translation>Speichere kompilierte Shader für Geschwindigkeit (empfohlen)</translation>
+        <translation>Speichere kompilierte Shader für Geschwindigkeit (Empfehlung)</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1189"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option sets the output render buffer size. By default, the render buffer is set to the &lt;span style=&quot; font-weight:600;&quot;&gt;Same as output resolution&lt;/span&gt;, but you can set it to the &lt;span style=&quot; font-weight:600;&quot;&gt;Original N64 resolution&lt;/span&gt; or a &lt;span style=&quot; font-weight:600;&quot;&gt;Multiple of N64 resolution&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung legt die Render-Buffer-Größe der Ausgabe fest. Standardmäßig ist die Render-Buffer-Größe &lt;span style=&quot; font-weight:600;&quot;&gt;Wie die Auflösung der Ausgabe&lt;/span&gt;, oder alternativ auch die &lt;span style=&quot; font-weight:600;&quot;&gt;Original N64 Auflösung&lt;/span&gt; oder ein &lt;span style=&quot; font-weight:600;&quot;&gt;Vielfaches der N64 Auflösung&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1210"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Internal resolution:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interne Aufl&#246;sung:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interne Auflösung:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1217"/>
@@ -502,18 +502,18 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1418"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, 2D elements are rendered at the N64s resolution before copying them to output. This usually eliminates display issues with 2D elements, but it can be slow. This option uses heuristics to detect adjacent 2D elements that doesn&apos;t work for every game.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked, unless you have performance problems&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Option ausgewählt ist, werden 2D Elemente in der originalen N64 Auflösung gezeichnet, bevor sie zur Ausgabe gegeben werden. Normalerweise werden durch diese Einstellung Anzeigeprobleme von 2D Elementen beseitigt. Die Ausführungsgeschwindigkeit kann aber beeinträchtigt werden. Diese Einstellung verwendet Heuristik um benachbarte 2D Elemente zu erkennen, welche nicht in jedem Spiel funktionieren.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt, außer es bestehen Geschwindigkeitsprobleme&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1421"/>
         <source>Render 2D elements in N64 resolution (best quality, can be slow)</source>
         <extracomment>2D elements, formerly labelled texrects, are usually used for title screens or HUDs</extracomment>
-        <translation>Gebe 2D Elemente in der originalen N64 Aufl&#246;sung wieder (beste Qualit&#228;t, kann langsam sein)</translation>
+        <translation>Gebe 2D Elemente in der originalen N64 Auflösung wieder (beste Qualität, kann langsam sein)</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1431"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In some games the coordinates for parts of 2D elements are not aligned: there is a half-pixel split between adjacent elements. When rendering at the N64&apos;s original resolution it isn&apos;t visible, but when the image is scaled up it results in black lines. This option attempts to connect these 2D elements.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;For adjacent 2D elements&lt;/span&gt;: Apply the correction only for polygons that need it. Select this option for games that have issues with black lines.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Always&lt;/span&gt;: Apply the correction for every 2D element. Select this option when &lt;span style=&quot; font-weight:600;&quot;&gt;For adjacent 2D elements&lt;/span&gt; doesn&apos;t help.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Never&lt;/span&gt;: Don&apos;t attempt to correct black lines between 2D elements.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Game dependent, mostly Never&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In einigen Spielen sind die Koordinaten von 2D Elemente nicht richtig ausgerichtet. Zwischen zwei benachbarten Elementen besteht eine Lücke von einem halben Pixel. Bei der originalen N64 Auflösung tritt dieses Problem nicht aus. Bei höheren Auflösungen ist aber eine schwarze Linie zwischen den Elementen sichtbar. Diese Einstellung verhindert schwarze Linien zwischen benachbarten 2D Elementen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Für benachbarte 2D Elemente&lt;/span&gt;: Wendet die Korrektur bei Polygonen an, welche sie benötigen. Bei auswählen, welche Probleme mit schwarzen Linien haben.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immer&lt;/span&gt;: Wende Korrektur bei allen 2D Elementen an. Wähle diese Einstellung aus, falls &lt;span style=&quot; font-weight:600;&quot;&gt;Für benachbarte 2D Elemente&lt;/span&gt; nicht hilft.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Niemals&lt;/span&gt;: Keine Korrektur von schwarzen Linien zwischen 2D Elementen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Spielabhängig, in der Regel Niemals&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1452"/>
@@ -547,12 +547,12 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1637"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unchecking this option disables many effects including anti-aliasing, cropping, aspect ratio, N64 resolution factor, N64-style depth compare and more. Don&apos;t uncheck this option unless you have performance issues.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Einstellung nicht ausgewählt ist, sind viele Effekte deaktiviert wie z.B. Kantenglättung, Beschneiden, Seitenverhältnis, N64 Auflösungsfaktor, N64-Style Tiefenvergleich und mehr. Diese Einstellung sollte nur deaktiviert werden, falls es Geschwindigkeitsprobleme gibt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1696"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the auxiliary color buffer is copied to N64 memory right after rendering to it is finished. This option helps to correctly emulate frame buffer effects in some games. This option may noticeably reduce performance.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Usually unchecked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Einstellung ausgewählt ist wird der Hilfs-Farb-Buffer, direkt nachdem er aktualisiert wurde, in den N64 Speicher geschrieben. Diese Einstellung hilft Frame-Buffer-Effekte in einigen Spielen richtig zu emulieren. Sie kann aber deutlich die Leistung reduzieren.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ncht ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1699"/>
@@ -562,7 +562,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1713"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option controls how often GLideN64 updates the main frame buffer.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Vertical interrupt&lt;/span&gt;: Update the buffer as quickly as possible, every vertical interrupt per second (50 for PAL and 60 for NTSC games). This option is the most compatible. Use this mode unless you have performance problems.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;VI origin change&lt;/span&gt;: The VI origin changes corresponding to the game&apos;s actual FPS. N64 games typically run between 20 to 30 FPS so the buffers swap less often than the first mode. This mode does not work for games that use single buffering, which is rare.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Color buffer change&lt;/span&gt;: This option checks to see if the frame buffer has been changed. There are some games where this doesn&apos;t work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Die Einstellung legt fest, wie oft GLideN64 den Haupt-Frame-Buffer aktualisiert.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Vertikaler Interrupt&lt;/span&gt;: Aktualisiert den Buffer so schnell wie möglich, d.h. bei jedem vertikalen Interrupt in der Sekunde (50Hz für PAL und 60Hz für NTSC Spiele). Diese Einstellung hat die höchste Kompatibilität. Verwende diese Einstellung solange es keine Leistungseinbußen gibt.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;VI-Ursprungsänderung&lt;/span&gt;: Die VI-Ursprungsänderung korrespondiert mit den eigentlichen FPS eines Spiels. N64 Spiele laufen in der Regel mit 20 bis 30 FPS. Der Buffer wird nicht so oft wie beim ersten Modus aktualisiert. Dieser Modus funktioniert nicht bei Spielen, welche einen einzigen Buffer verwenden, was selten vorkommt.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Farb-Buffer-Änderung&lt;/span&gt;: Diese Einstellung überprüft, ob sich der Frame-Buffer geändert hat. Bei einigen Spielen funktioniert diese Einstellung nicht.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1734"/>
@@ -572,7 +572,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1781"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some emulators do a poor job of detecting when to read/write frame buffers. You can disable emulator help to let GLideN64 read/write frame buffers itself.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Usually unchecked, but for some games/emulators it may be faster checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Einige Emulatoren erkennen nur schlecht, ob der Frame-Buffer gelesen oder geschrieben wurden. Die Erkennung des Emulators kann deaktiviert werden, damit GLideN64 selbst Frame-Buffer lesen und schreiben kann.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Gewöhnlich nicht ausgewählt, aber manche Spiele laufen mit dieser Einstellung schneller&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1784"/>
@@ -582,7 +582,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the color buffer will be read in chunks. Otherwise, the buffer will be read in its entirety. If a game needs to read the entire buffer, selecting this option may be slow.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Usually unchecked, because the color buffer is usually read entirely&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Einstellung ausgewählt ist, wird der Farb-Buffer in Stücken gelesen. Andernfalls wird der Buffer in einem Rutsch gelesen. Wenn ein Spiel den kompletten Buffer lesen muss, kann diese Einstellung zu Verzögerungen führen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Gewöhnlich nicht ausgewählt, weil der Farb-Buffer in der Regel komplett gelesen wird&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1797"/>
@@ -593,7 +593,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the depth buffer will be read in chunks. Otherwise the buffer will be read in its entirety. If a game needs to read the entire buffer, selecting this option may be slow.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked, because the depth buffer is not often read entirely&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Einstellung ausgewählt ist, wird der Depth-Buffer in Stücken gelesen. Andernfalls wird der Buffer in einem Rutsch gelesen. Wenn ein Spiel den kompletten Buffer lesen muss, kann diese Einstellung zu Verzögerungen führen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt, weil der Depth-Buffer in der Regel nicht komplett gelesen wird&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1807"/>
@@ -604,7 +604,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1825"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In some games GLideN64 can&apos;t detect when the game uses the frame buffer. With these options, you can have GLideN64 copy each frame of your video card&apos;s frame buffer to N64 memory.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Never&lt;/span&gt;: Disable copying buffers from video card.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Synchronous&lt;/span&gt;: Effects are detected for all games, but it can be slow. Use for games where &lt;span style=&quot; font-weight:600;&quot;&gt;Asynchronous&lt;/span&gt; doesn&apos;t work.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Asynchronous&lt;/span&gt;: Effects are detected for most games.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Usually Asynchronous&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bei einigen Spielen kann GLideN64 nicht feststellen, ob der Frame-Buffer verwendet wird. Mit diesen Einstellungen kann festgelegt werde, ob GLideN64 jeden Frame des Grafikkarten-Frame-Buffers in den N64 Speicher kopiert.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Niemals&lt;/span&gt;: Deaktivert das Kopieren des Grafikkarten-Buffers.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Synchron&lt;/span&gt;: Effekte aller Spiele werden erkannt. Die Leistung kann beeinträchtigt werden. Verwende diese Einstellung für alle Spiele, welche mit &lt;span style=&quot; font-weight:600;&quot;&gt;Asynchron&lt;/span&gt; nicht funktionieren.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Asynchron&lt;/span&gt;: Die Effekte der meisten Spiele werden erkannt.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Asynchron&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1846"/>
@@ -614,7 +614,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1875"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The depth buffer is used to emulate some effects (e.g. coronas):&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Never&lt;/span&gt;: Depth buffer is disabled.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;From VRAM&lt;/span&gt;: Your video card&apos;s depth buffer is copied to N64 memory each frame, which can be slow on some games.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;In software&lt;/span&gt;: Generally faster than copying from VRAM, but the result can be imperfect.&lt;/p&gt;&lt;p&gt;[Recommended:&lt;span style=&quot; font-style:italic;&quot;&gt; In software&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Der Depth Buffer wird benötigt um einige Effekte zu emulieren (z.B. Koronas):&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Niemals&lt;/span&gt;: Depth-Buffer ist deaktiviert.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Vom VRAM&lt;/span&gt;: Der Depth-Buffer der Grafikkarte wird bei jedem Fraem in den N64 Speicher kopiert, was bei einigen Spielen zu Verzögerungen führt.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;In Software&lt;/span&gt;: Allgemein schneller als den VRAM zu kopieren. Das Ergebnis kann aber fehlerhaft sein.&lt;/p&gt;&lt;p&gt;[Empfehlung:&lt;span style=&quot; font-style:italic;&quot;&gt; In Software&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1902"/>
@@ -624,7 +624,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1938"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The N64 uses a unique method of calculating depth to the camera. When checked, GlideN64 uses shaders to try to emulate these calculations correctly. &lt;span style=&quot; font-weight:600;&quot;&gt;Experimental!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Sometimes checked, for a few games&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das N64 berechnet auf eine einzigartige Art die Tiefe der Kamera. Wenn ausgewählt versucht GlideN64 mit Shadern die Berechnung richtig zu emulieren. &lt;span style=&quot; font-weight:600;&quot;&gt;Experimentell!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Bei einigen Spielen ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1941"/>
@@ -634,7 +634,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1948"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this option is checked, the frame buffer is rendered directly to the screen. This prevents some graphic problems but may cause slowdowns or visual quality problems.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Usually unchecked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wenn diese Einstellung ausgewählt ist, wird der Frame-Buffer direkt ausgegeben. Dies verhindert einige Grafikprobleme, kann aber zu Verzögerungen und visuellen Problemem führen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;In der Regel nicht ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1951"/>
@@ -649,17 +649,17 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2024"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This filter smooths or sharpens textures. There are four smoothing filters and two sharpening filters. The higher the number, the stronger the effect. Performance may be affected depending on the game and/or your PC.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Your preference&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Filter glätten oder schärfen Texturen. Es gibt vier Filter zum Glätten und zwei Filter zum Schärfen. Um so höher die Nummer, umso stärker der Effekt. Die Geschwindigkeit kann je nach Spiel und/oder PC beeinträchtigt werden.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Eigene Vorliebe&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2061"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;There are 12 distinct filters to select. Depending on which filter, they may cause performance problems.&lt;/p&gt;&lt;p&gt;When &lt;span style=&quot; font-weight:600;&quot;&gt;Store&lt;/span&gt; is selected, textures are saved to the cache as-is. This improves performance in games that load many textures. Uncheck &lt;span style=&quot; font-weight:600;&quot;&gt;Disable for backgrounds&lt;/span&gt; for the best performance.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Your preference&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Es können 12 verschiedene Filter ausgewählt werden. Abhängig vom Filter kann die Ausführungsgeschwindigkeit beeinträchtigt werden.&lt;/p&gt;&lt;p&gt;Wenn &lt;span style=&quot; font-weight:600;&quot;&gt;Abspeichern&lt;/span&gt; ausgewählt ist werden Texturen im Cache gespeichert. Dies steigert die Ausführungsgeschwindigkeit. Deaktiviere &lt;span style=&quot; font-weight:600;&quot;&gt;Ausgeschaltet für Hintergründe&lt;/span&gt; für die beste Ausführungsgeschwindikeit.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Eigene Vorliebe&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2120"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option enables a pre-processing step that reduces posterization issues on enhanced textures.&lt;/p&gt;&lt;p&gt;[Recommended:&lt;span style=&quot; font-style:italic;&quot;&gt; Checked for xBRZ&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung aktiviert eine Vorverarbeitungsstufe, welche Farbtontrennungsprobleme bei hochauflösenden Texturen reduziert.&lt;/p&gt;&lt;p&gt;[Empfehlung:&lt;span style=&quot; font-style:italic;&quot;&gt; Ausgewählt für xBRZ&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2123"/>
@@ -669,7 +669,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2130"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option skips texture enhancements for long, narrow textures that are usually used for backgrounds. This may save texture memory and improve performance.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked, unless Enhancement is set to Store&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung verwirft Texturverbesserungen für lange, schmale Texturen, welche gewöhnlich für Hintergründe verwendet werden. Dies spart Texturspeicher und kann die Ausführungsgeschwindigkeit steigern.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2133"/>
@@ -679,7 +679,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2142"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enhanced and filtered textures can be cached to improve performance. This option adjusts how much memory is dedicated to the texture cache. This can improve performance if there are many requests for the same texture, which is usually the case. Normally 128 MB should be more than enough, but the best option is different for each game. Super Mario 64 may not need more than 32 MB, but Conker&apos;s Bad Fur Day can take advantage of 256 MB+. Adjust accordingly if you are having performance problems. Setting this option to 0 disables the cache.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;PC and game dependent&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Verbesserte und gefilterte Texturen können zwischengespeichert werden, um die Leistung zu erhöhen. Diese Einstellung legt fest wieviel Speicher für den Texture-Cache reserviert wird. Dies kann bei vielen Anfragen die Leistung erhöhen, was normalerweise der Fall ist. Eigentlich sollten 128MB mehr als genug sein. Der beste Wert ist aber spielabhängig. Super Mario 64 reichen z.B. 32 MB. Conker&apos;s Bad Fur Day kann aber noch von 256 MB+ providieren. Beim Wert 0 ist der Cache deaktiviert.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;abhängig von PC und Spiel&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2169"/>
@@ -694,7 +694,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2240"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select path to the folder with texture packs.&lt;br/&gt;Default: Plugin/hires_texture&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pfad für Textur-Packs auswählen.&lt;br/&gt;Standard: Plugin/hires_texture&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2287"/>
@@ -704,7 +704,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2315"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this option is cleared, textures will be loaded as they are when using Rice Video: transparencies either on or off. When this option is selected, GlideN64 will check how the texture&apos;s alpha channel was designed and will select the most appropriate format. This gives texture pack designers freedom to use semi-transparent textures.&lt;/p&gt;&lt;p&gt;Clear this option for older or poorly designed texture packs.&lt;/p&gt;&lt;p&gt;[Recommended:&lt;span style=&quot; font-style:italic;&quot;&gt; Texture pack dependent&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Falls diese Einstellung nicht ausgewählt ist, werden Texturen wie beim Rice-Video-Plugin geladen: Transparenzen sind entweder an oder aus. Wenn diese Einstellung ausgewählt ist untersucht GlideN64 wie der Alpha Channel der Texturen aufgebaut ist und wählt das beste Format aus. Dies gibt dem Ersteller von Textur-Packs die Möglichkeit halbtransparente Texturen zu verwenden.&lt;/p&gt;&lt;p&gt;Diese Einstellung sollte bei alten oder schlecht entworfenen Texture-Packs nicht ausgewählt werden.&lt;/p&gt;&lt;p&gt;[Empfehlung:&lt;span style=&quot; font-style:italic;&quot;&gt; Textur-Pack abhängig&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2318"/>
@@ -714,7 +714,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2325"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option emulates a palette CRC calculation bug in Rice Video. If you have problems loading textures, try checking or unchecking this option.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Mostly unchecked, checked for old texture packs&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung emuliert einen CRC Berechnungsfehler des Rice-Video-Plugins. Wenn Fehler beim Laden von Texturen auftauchen aktiviere oder deaktiviere diese Einstellung.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Nicht ausgewählt, ausgewählt für ältere Textur-Packs&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2328"/>
@@ -724,7 +724,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2338"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option dumps textures on screen to a texture pack folder. You can also reload textures while the game is running to see how they look instantly—big time saver!&lt;/p&gt;&lt;p&gt;Hotkeys:&lt;br/&gt;Use &lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt; to reload textures from the texture pack&lt;br/&gt;Use &lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt; to toggle texture dumping on or off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert aktuell angezeigte Texturen in einem Texture-Pack Verzeichnis. Es k&#246;nnen auch Texturen neu geladen werden während ein Spiel l&#228;uft um direkt zu sehen wie sie aussehen.&lt;/p&gt;&lt;p&gt;Hotkeys:&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt; um Texturen aus Texture-Packs neu zu laden&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt; um Texturen speichern an- und abzuschalten&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert aktuell angezeigte Texturen in einem Texture-Pack Verzeichnis. Es können auch Texturen neu geladen werden während ein Spiel läuft um direkt zu sehen wie sie aussehen.&lt;/p&gt;&lt;p&gt;Hotkeys:&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt; um Texturen aus Texture-Packs neu zu laden&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt; um Texturen speichern an- und abzuschalten&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2341"/>
@@ -734,7 +734,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option saves all previously loaded and enhanced textures to your PC. When the game is next launched, textures don&apos;t have to be recreated, causing smoother performance.&lt;/p&gt;&lt;p&gt;When using texture packs, loading packs will take only a few seconds when the game is launched as opposed to the 5–60 seconds that loading usually takes. However, if you change the texture pack you&apos;ll have to manually delete the texture cache. Saved cache files are saved to a folder called Cache within the plugins folder.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert alle vorher geladenen oder verbesserten Texturen auf dem PC. Wenn das Spiel noch einmal gestartet wird müssen die Texturen nicht neu erstellt werden.&lt;/p&gt;&lt;p&gt;Wenn Texture-Packs verwendet werden dauert das Laden eines Packs nur wenige Sekunden gegen&#252;ber dem normalen Ladevorgang von 5-60 Sekunden. Wird jedoch das Texture Pack ver&#228;ndert, muss der Texture Cache manuell gel&#246;scht werden um die Änderung zu &#252;bernehmen. Cache Dateien werden im Plugin Verzeichnis im Verzeichnis Cache gespeichert.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert alle vorher geladenen oder verbesserten Texturen auf dem PC. Wenn das Spiel noch einmal gestartet wird müssen die Texturen nicht neu erstellt werden.&lt;/p&gt;&lt;p&gt;Wenn Texture-Packs verwendet werden dauert das Laden eines Packs nur wenige Sekunden gegenüber dem normalen Ladevorgang von 5-60 Sekunden. Wird jedoch das Texture Pack verändert, muss der Texture Cache manuell gelöscht werden um die Änderung zu übernehmen. Cache Dateien werden im Plugin Verzeichnis im Verzeichnis Cache gespeichert.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2384"/>
@@ -744,12 +744,12 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2394"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Textures will be compressed so more textures can be held in the cache. The compression ratio varies per texture, but the compression is typically 1/5 of the original size.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texturen werden komprimiert, damit mehr Texturen im Cache gehalten werden können. Die Kompressionsrate variiert je nach Textur, aber ist normalerweise 1/5 der Originalgr&#246;ße.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgew&#228;hlt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texturen werden komprimiert, damit mehr Texturen im Cache gehalten werden können. Die Kompressionsrate variiert je nach Textur, aber ist normalerweise 1/5 der Originalgröße.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2404"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option halves the space used by textures in the texture cache and video card memory to improve performance. When reducing the color, GLideN64 tries to perserve the original quality as much as possible. On most textures it&apos;s hardly noticeable, but some textures, like skies, can look noticeably worse.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Unchecked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung halbiert den Speicherbedarf von Texturen im Texture-Cache und VRAM um die Leistung zu steigern. Wenn die Farbtiefe reduziert wird versucht GLideN64 die originale Qualit&#228;t so gut wie m&#246;glich zu erhalten. Bei den meisten Texturen ist es kaum wahrnehmbar, aber einige Texturen, wie z.B. f&#252;r den Himmel, k&#246;nnen schlechter aussehen.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;Nicht ausgew&#228;hlt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung halbiert den Speicherbedarf von Texturen im Texture-Cache und VRAM um die Leistung zu steigern. Wenn die Farbtiefe reduziert wird versucht GLideN64 die originale Qualität so gut wie möglich zu erhalten. Bei den meisten Texturen ist es kaum wahrnehmbar, aber einige Texturen, wie z.B. für den Himmel, können schlechter aussehen.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Nicht ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2407"/>
@@ -764,7 +764,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2482"/>
         <source>Blending:</source>
-        <translation>Vermischung/Blending</translation>
+        <translation>Vermischung/Blending:</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2499"/>
@@ -774,7 +774,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2846"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some N64 games use gamma correction to brighten the image. When the frame buffer is enabled, gamma correction is applied automatically for all games that use it on the N64. You can use your own gamma correction instead with this option. The default level, used on the N64, is 2.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Unchecked; 2.00&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Einige N64 Spiele verwenden Gammakorrektur um das Bild aufzuhellen. Wenn Frame-Buffer-Emulation aktiviert ist wird Gammakorrektur automatisch bei allen Spielen angewandt, welche Gammakorrektur auf dem N64 verwenden. Alternativ kann über diese Einstellung der Gammakorrekturwert selbst ausgewählt werden. Der Standardwert des N64 ist 2.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Nicht ausgewählt; 2.00&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2849"/>
@@ -784,12 +784,12 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2861"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecting this option overrides gamma correction specified by the game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wird diese Einstellung ausgew&#228;hlt wird die durch das Spiel festgelegte Gammakorrektur &#252;berschrieben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wird diese Einstellung ausgewählt, wird die durch das Spiel festgelegte Gammakorrektur überschrieben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2882"/>
         <source>Correction level:</source>
-        <translation>Korrekturwert</translation>
+        <translation>Korrekturwert:</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2986"/>
@@ -861,7 +861,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
         <location filename="configDialog.ui" line="3602"/>
         <location filename="configDialog.ui" line="3621"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This font is used for all on-screen messages. Not all fonts can be used. If messages aren&apos;t displayed, try a different font.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Schrift wird f&#252;r alle Bildschirmmeldungen verwendet. Nicht alle Schriften k&#246;nnen verwendet werden. Wenn Meldungen nicht dargestellt werden, probiere eine andere Schrift.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Schrift wird für alle Bildschirmmeldungen verwendet. Nicht alle Schriften können verwendet werden. Wenn Meldungen nicht dargestellt werden, probiere eine andere Schrift aus.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="3570"/>

--- a/translations/gliden64_de.ts
+++ b/translations/gliden64_de.ts
@@ -183,7 +183,7 @@
         <location filename="configDialog.ui" line="213"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can use this option to crop black borders. Use &lt;span style=&quot; font-weight:600;&quot;&gt;Auto per game&lt;/span&gt; to crop automatically based on the game or &lt;span style=&quot; font-weight:600;&quot;&gt;Custom&lt;/span&gt; to set the number of pixels yourself. The number of pixels is based on the original N64 resolution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <oldsource>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Crop image:&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This option allows user to crop black boarders from resulted image. It has two modes:&lt;br/&gt;&lt;br/&gt;* Auto - plugin sets crop automatically using game&apos;s frame scissor.&lt;/p&gt;&lt;p&gt;* Custom - crop using user defined values. User should set number of pixels to crop from original native-res image.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</oldsource>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bild zuschneiden:&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Diese Option erlaubt es dem Benutzer schwarze Fensterr&auml;nder zu beschneiden. Es gibt zwei Modi:&lt;br/&gt;&lt;br/&gt;* Auto - das Plugin beschneidet automatisch nach Spielvorgabe.&lt;/p&gt;&lt;p&gt;* Custom - der Rand wird nach Benutzervorgabe beschnitten. Der Benutzer muss die zu beschneidende Pixelanzahl angeben.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bild zuschneiden:&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Diese Option erlaubt es dem Benutzer schwarze Fensterr&#228;nder zu beschneiden. Es gibt zwei Modi:&lt;br/&gt;&lt;br/&gt;* Auto - das Plugin beschneidet automatisch nach Spielvorgabe.&lt;/p&gt;&lt;p&gt;* Custom - der Rand wird nach Benutzervorgabe beschnitten. Der Benutzer muss die zu beschneidende Pixelanzahl angeben.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="248"/>
@@ -314,7 +314,7 @@
     <message>
         <location filename="configDialog.ui" line="59"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All the resolutions that your video card/monitor supports should be displayed.&lt;/p&gt;&lt;p&gt;[Recommended:&lt;span style=&quot; font-style:italic;&quot;&gt; Maximum resolution for your monitor unless performance becomes an issue&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Alle von der Grafikkarte/Monitor unterst&uuml;tzten Aufl&ouml;sungen sollten angezeigt werden.&lt;/p&gt;&lt;p&gt;[Empfohlen:&lt;span style=&quot; font-style:italic;&quot;&gt; Die maximale Aufl&ouml;sung des Monitors außer es gibt Geschwindigkeitprobleme&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Alle von der Grafikkarte/Monitor unterst&#252;tzten Aufl&#246;sungen sollten angezeigt werden.&lt;/p&gt;&lt;p&gt;[Empfohlen:&lt;span style=&quot; font-style:italic;&quot;&gt; Die maximale Aufl&#246;sung des Monitors außer es gibt Geschwindigkeitprobleme&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="107"/>
@@ -334,7 +334,7 @@
     <message>
         <location filename="configDialog.ui" line="362"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aspect ratio:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Seitenverh&auml;ltnis:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Seitenverh&#228;ltnis:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="369"/>
@@ -476,7 +476,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="1210"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Internal resolution:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interne Aufl&ouml;sung:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Interne Aufl&#246;sung:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1217"/>
@@ -508,7 +508,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
         <location filename="configDialog.ui" line="1421"/>
         <source>Render 2D elements in N64 resolution (best quality, can be slow)</source>
         <extracomment>2D elements, formerly labelled texrects, are usually used for title screens or HUDs</extracomment>
-        <translation>Gebe 2D Elemente in der originalen N64 Aufl&ouml;sung wieder (beste Qualit&auml;t, kann langsam sein)</translation>
+        <translation>Gebe 2D Elemente in der originalen N64 Aufl&#246;sung wieder (beste Qualit&#228;t, kann langsam sein)</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="1431"/>
@@ -724,7 +724,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2338"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option dumps textures on screen to a texture pack folder. You can also reload textures while the game is running to see how they look instantly—big time saver!&lt;/p&gt;&lt;p&gt;Hotkeys:&lt;br/&gt;Use &lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt; to reload textures from the texture pack&lt;br/&gt;Use &lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt; to toggle texture dumping on or off&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert aktuell angezeigte Texturen in einem Texture-Pack Verzeichnis. Es k&ouml;nnen auch Texturen neu geladen werden während ein Spiel l&auml;uft um direkt zu sehen wie sie aussehen.&lt;/p&gt;&lt;p&gt;Hotkeys:&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt; um Texturen aus Texture-Packs neu zu laden&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt; um Texturen speichern an- und abzuschalten&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert aktuell angezeigte Texturen in einem Texture-Pack Verzeichnis. Es k&#246;nnen auch Texturen neu geladen werden während ein Spiel l&#228;uft um direkt zu sehen wie sie aussehen.&lt;/p&gt;&lt;p&gt;Hotkeys:&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;R&lt;/span&gt; um Texturen aus Texture-Packs neu zu laden&lt;br/&gt;Benutze &lt;span style=&quot; font-weight:600;&quot;&gt;D&lt;/span&gt; um Texturen speichern an- und abzuschalten&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2341"/>
@@ -734,7 +734,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option saves all previously loaded and enhanced textures to your PC. When the game is next launched, textures don&apos;t have to be recreated, causing smoother performance.&lt;/p&gt;&lt;p&gt;When using texture packs, loading packs will take only a few seconds when the game is launched as opposed to the 5–60 seconds that loading usually takes. However, if you change the texture pack you&apos;ll have to manually delete the texture cache. Saved cache files are saved to a folder called Cache within the plugins folder.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert alle vorher geladenen oder verbesserten Texturen auf dem PC. Wenn das Spiel noch einmal gestartet wird müssen die Texturen nicht neu erstellt werden.&lt;/p&gt;&lt;p&gt;Wenn Texture-Packs verwendet werden dauert das Laden eines Packs nur wenige Sekunden gegen&uuml;ber dem normalen Ladevorgang von 5-60 Sekunden. Wird jedoch das Texture Pack ver&auml;ndert, muss der Texture Cache manuell gel&ouml;scht werden um die Änderung zu &uuml;bernehmen. Cache Dateien werden im Plugin Verzeichnis im Verzeichnis Cache gespeichert.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung speichert alle vorher geladenen oder verbesserten Texturen auf dem PC. Wenn das Spiel noch einmal gestartet wird müssen die Texturen nicht neu erstellt werden.&lt;/p&gt;&lt;p&gt;Wenn Texture-Packs verwendet werden dauert das Laden eines Packs nur wenige Sekunden gegen&#252;ber dem normalen Ladevorgang von 5-60 Sekunden. Wird jedoch das Texture Pack ver&#228;ndert, muss der Texture Cache manuell gel&#246;scht werden um die Änderung zu &#252;bernehmen. Cache Dateien werden im Plugin Verzeichnis im Verzeichnis Cache gespeichert.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgewählt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2384"/>
@@ -744,12 +744,12 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2394"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Textures will be compressed so more textures can be held in the cache. The compression ratio varies per texture, but the compression is typically 1/5 of the original size.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texturen werden komprimiert, damit mehr Texturen im Cache gehalten werden können. Die Kompressionsrate variiert je nach Textur, aber ist normalerweise 1/5 der Originalgr&ouml;ße.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgew&auml;hlt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Texturen werden komprimiert, damit mehr Texturen im Cache gehalten werden können. Die Kompressionsrate variiert je nach Textur, aber ist normalerweise 1/5 der Originalgr&#246;ße.&lt;/p&gt;&lt;p&gt;[Empfehlung: &lt;span style=&quot; font-style:italic;&quot;&gt;Ausgew&#228;hlt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2404"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option halves the space used by textures in the texture cache and video card memory to improve performance. When reducing the color, GLideN64 tries to perserve the original quality as much as possible. On most textures it&apos;s hardly noticeable, but some textures, like skies, can look noticeably worse.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Unchecked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung halbiert den Speicherbedarf von Texturen im Texture-Cache und VRAM um die Leistung zu steigern. Wenn die Farbtiefe reduziert wird versucht GLideN64 die originale Qualit&auml;t so gut wie m&ouml;glich zu erhalten. Bei den meisten Texturen ist es kaum wahrnehmbar, aber einige Texturen, wie z.B. f&uuml;r den Himmel, k&ouml;nnen schlechter aussehen.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;Nicht ausgew&auml;hlt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Einstellung halbiert den Speicherbedarf von Texturen im Texture-Cache und VRAM um die Leistung zu steigern. Wenn die Farbtiefe reduziert wird versucht GLideN64 die originale Qualit&#228;t so gut wie m&#246;glich zu erhalten. Bei den meisten Texturen ist es kaum wahrnehmbar, aber einige Texturen, wie z.B. f&#252;r den Himmel, k&#246;nnen schlechter aussehen.&lt;/p&gt;&lt;p&gt;[Empfohlen: &lt;span style=&quot; font-style:italic;&quot;&gt;Nicht ausgew&#228;hlt&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2407"/>
@@ -784,7 +784,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
     <message>
         <location filename="configDialog.ui" line="2861"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selecting this option overrides gamma correction specified by the game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wird diese Einstellung ausgew&auml;hlt wird die durch das Spiel festgelegte Gammakorrektur &uuml;berschrieben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wird diese Einstellung ausgew&#228;hlt wird die durch das Spiel festgelegte Gammakorrektur &#252;berschrieben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="2882"/>
@@ -861,7 +861,7 @@ The highest in a sequence of numbers. In this case, 16.</extracomment>
         <location filename="configDialog.ui" line="3602"/>
         <location filename="configDialog.ui" line="3621"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This font is used for all on-screen messages. Not all fonts can be used. If messages aren&apos;t displayed, try a different font.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Schrift wird f&uuml;r alle Bildschirmmeldungen verwendet. Nicht alle Schriften k&ouml;nnen verwendet werden. Wenn Meldungen nicht dargestellt werden, probiere eine andere Schrift.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Diese Schrift wird f&#252;r alle Bildschirmmeldungen verwendet. Nicht alle Schriften k&#246;nnen verwendet werden. Wenn Meldungen nicht dargestellt werden, probiere eine andere Schrift.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="configDialog.ui" line="3570"/>


### PR DESCRIPTION
Replace html special sign notation with xml notation.

@gonetz 
Please take a look if there is no error now.

XML validator says there is no error anymore.