### PR TITLE
Add ResizeVideoOutput to MupenPlusPluginAPI

### DIFF
--- a/src/MupenPlusPluginAPI.cpp
+++ b/src/MupenPlusPluginAPI.cpp
@@ -43,5 +43,10 @@ EXPORT void CALL SetRenderingCallback(void (*callback)(int))
 {
 	api().SetRenderingCallback(callback);
 }
+	
+EXPORT void CALL ResizeVideoOutput(int width, int height)
+{
+	api().ResizeVideoOutput(width, height);
+}
 
 } // extern "C"


### PR DESCRIPTION
This was missing from the API, this allows the window to be resized in mupen64plus