### PR TITLE
Rename opengl_ColorBufferReaderWithBUfferStorage.h/cpp

### DIFF
--- a/projects/msvc12/GLideN64.vcxproj
+++ b/projects/msvc12/GLideN64.vcxproj
@@ -308,7 +308,7 @@
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_Attributes.cpp" />
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_BufferManipulationObjectFactory.cpp" />
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_CachedFunctions.cpp" />
-    <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStorage.cpp" />
+    <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStore.cpp" />
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithPixelBuffer.cpp" />
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithReadPixels.cpp" />
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ContextImpl.cpp" />
@@ -444,7 +444,7 @@
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_Attributes.h" />
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_BufferManipulationObjectFactory.h" />
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_CachedFunctions.h" />
-    <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStorage.h" />
+    <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStore.h" />
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithPixelBuffer.h" />
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithReadPixels.h" />
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ContextImpl.h" />

--- a/projects/msvc12/GLideN64.vcxproj.filters
+++ b/projects/msvc12/GLideN64.vcxproj.filters
@@ -323,7 +323,7 @@
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithPixelBuffer.cpp">
       <Filter>Source Files\Graphics\OpenGL</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStorage.cpp">
+    <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStore.cpp">
       <Filter>Source Files\Graphics\OpenGL</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_BufferedDrawer.cpp">
@@ -625,7 +625,7 @@
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithPixelBuffer.h">
       <Filter>Header Files\Graphics\OpenGL</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStorage.h">
+    <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_ColorBufferReaderWithBufferStore.h">
       <Filter>Header Files\Graphics\OpenGL</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Graphics\OpenGLContext\opengl_BufferedDrawer.h">

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ set(GLideN64_SOURCES
   Graphics/OpenGLContext/opengl_BufferedDrawer.cpp
   Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
   Graphics/OpenGLContext/opengl_CachedFunctions.cpp
-  Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp
+  Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStore.cpp
   Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp
   Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.cpp
   Graphics/OpenGLContext/opengl_ContextImpl.cpp

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -327,7 +327,7 @@ class UDitherMode : public UniformGroup
 {
 public:
 	UDitherMode(GLuint _program, bool _usesNoise)
-	: m_usesNoise(m_usesNoise)
+	: m_usesNoise(_usesNoise)
 	{
 		LocateUniform(uAlphaCompareMode);
 		LocateUniform(uAlphaDitherMode);

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStore.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStore.cpp
@@ -1,22 +1,22 @@
 #include <Graphics/Context.h>
-#include "opengl_ColorBufferReaderWithBufferStorage.h"
+#include "opengl_ColorBufferReaderWithBufferStore.h"
 
 using namespace graphics;
 using namespace opengl;
 
-ColorBufferReaderWithBufferStorage::ColorBufferReaderWithBufferStorage(CachedTexture * _pTexture,
+ColorBufferReaderWithBufferStore::ColorBufferReaderWithBufferStore(CachedTexture * _pTexture,
 	CachedBindBuffer * _bindBuffer)
 	: ColorBufferReader(_pTexture), m_bindBuffer(_bindBuffer)
 {
 	_initBuffers();
 }
 
-ColorBufferReaderWithBufferStorage::~ColorBufferReaderWithBufferStorage()
+ColorBufferReaderWithBufferStore::~ColorBufferReaderWithBufferStore()
 {
 	_destroyBuffers();
 }
 
-void ColorBufferReaderWithBufferStorage::_initBuffers()
+void ColorBufferReaderWithBufferStore::_initBuffers()
 {
 	// Generate Pixel Buffer Objects
 	glGenBuffers(_numPBO, m_PBO);
@@ -33,7 +33,7 @@ void ColorBufferReaderWithBufferStorage::_initBuffers()
 	m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle::null);
 }
 
-void ColorBufferReaderWithBufferStorage::_destroyBuffers()
+void ColorBufferReaderWithBufferStore::_destroyBuffers()
 {
 	glDeleteBuffers(_numPBO, m_PBO);
 
@@ -41,7 +41,7 @@ void ColorBufferReaderWithBufferStorage::_destroyBuffers()
 		m_PBO[index] = 0;
 }
 
-u8 * ColorBufferReaderWithBufferStorage::readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync)
+u8 * ColorBufferReaderWithBufferStore::readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync)
 {
 	const FramebufferTextureFormats & fbTexFormat = gfxContext.getFramebufferTextureFormats();
 	GLenum colorFormat, colorType, colorFormatBytes;
@@ -88,7 +88,7 @@ u8 * ColorBufferReaderWithBufferStorage::readPixels(s32 _x0, s32 _y0, u32 _width
 	return pixelDataAlloc;
 }
 
-void ColorBufferReaderWithBufferStorage::cleanUp()
+void ColorBufferReaderWithBufferStore::cleanUp()
 {
 	m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle::null);
 }

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStore.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStore.h
@@ -5,13 +5,13 @@
 
 namespace opengl {
 
-	class ColorBufferReaderWithBufferStorage :
+	class ColorBufferReaderWithBufferStore :
 		public graphics::ColorBufferReader
 	{
 	public:
-		ColorBufferReaderWithBufferStorage(CachedTexture * _pTexture,
+		ColorBufferReaderWithBufferStore(CachedTexture * _pTexture,
 			CachedBindBuffer * _bindBuffer);
-		virtual ~ColorBufferReaderWithBufferStorage();
+		virtual ~ColorBufferReaderWithBufferStore();
 
 		u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) override;
 		void cleanUp() override;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -6,7 +6,7 @@
 #include "opengl_BufferedDrawer.h"
 #include "opengl_UnbufferedDrawer.h"
 #include "opengl_ColorBufferReaderWithPixelBuffer.h"
-#include "opengl_ColorBufferReaderWithBufferStorage.h"
+#include "opengl_ColorBufferReaderWithBufferStore.h"
 #include "opengl_ColorBufferReaderWithEGLImage.h"
 #include "opengl_ColorBufferReaderWithReadPixels.h"
 #include "opengl_Utils.h"
@@ -299,7 +299,7 @@ graphics::PixelReadBuffer * ContextImpl::createPixelReadBuffer(size_t _sizeInByt
 graphics::ColorBufferReader * ContextImpl::createColorBufferReader(CachedTexture * _pTexture)
 {
 	if (m_glInfo.bufferStorage)
-		return new ColorBufferReaderWithBufferStorage(_pTexture, m_cachedFunctions->getCachedBindBuffer());
+		return new ColorBufferReaderWithBufferStore(_pTexture, m_cachedFunctions->getCachedBindBuffer());
 
 	if (!m_glInfo.isGLES2)
 		return new ColorBufferReaderWithPixelBuffer(_pTexture, m_cachedFunctions->getCachedBindBuffer());

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -86,10 +86,10 @@ MY_LOCAL_SRC_FILES :=                               \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_BufferedDrawer.cpp                     \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp    \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_CachedFunctions.cpp                    \
-    $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp   \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.cpp    \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp      \
+    $(SRCDIR)/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStore.cpp   \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_ContextImpl.cpp                        \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_GLInfo.cpp                             \
     $(SRCDIR)/Graphics/OpenGLContext/opengl_Parameters.cpp                         \


### PR DESCRIPTION
This allow compilation with clang in Anroid Studio with Windows. This file
name was too long for some reason.

There are more fixes coming as I find them, so I wouldn't close this pull request yet.