### PR TITLE
Hacky fix for RPi depth issues

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -261,6 +261,11 @@ void ContextImpl::deleteFramebuffer(graphics::ObjectHandle _name)
 
 void ContextImpl::bindFramebuffer(graphics::BufferTargetParam _target, graphics::ObjectHandle _name)
 {
+	if (m_glInfo.renderer == Renderer::VideoCore) {
+		CachedDepthMask * depthMask = m_cachedFunctions->getCachedDepthMask();
+		depthMask->setDepthMask(true);
+		glClear(GL_DEPTH_BUFFER_BIT);
+	}
 	m_cachedFunctions->getCachedBindFramebuffer()->bind(_target, _name);
 }
 

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -27,6 +27,8 @@ void GLInfo::init() {
 	const GLubyte * strRenderer = glGetString(GL_RENDERER);
 	if (strstr((const char*)strRenderer, "Adreno") != nullptr)
 		renderer = Renderer::Adreno;
+	else if (strstr((const char*)strRenderer, "VideoCore IV") != nullptr)
+		renderer = Renderer::VideoCore;
 	LOG(LOG_VERBOSE, "OpenGL renderer: %s\n", strRenderer);
 
 	int numericVersion = majorVersion * 10 + minorVersion;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -5,6 +5,7 @@ namespace opengl {
 
 enum class Renderer {
 	Adreno,
+	VideoCore,
 	Other
 };
 


### PR DESCRIPTION
This re-implements the fix that existed before the refactoring. This fixes (although it's probably not perfect), the serious depth issues that the Raspberry Pi has with Framebuffer Emulation