### PR TITLE
Add missing GLSL extension

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -208,6 +208,9 @@ public:
 				ss << "#extension GL_ARB_shader_image_load_store : enable" << std::endl
 					<< "#extension GL_ARB_shading_language_420pack : enable" << std::endl;
 			}
+			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 43) {
+				ss << "#extension GL_ARB_compute_shader : enable" << std::endl;
+			}
 			ss << "# define IN in" << std::endl << "# define OUT out" << std::endl;
 			m_part = ss.str();
 		}
@@ -439,6 +442,9 @@ public:
 			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 42) {
 				ss << "#extension GL_ARB_shader_image_load_store : enable" << std::endl
 					<< "#extension GL_ARB_shading_language_420pack : enable" << std::endl;
+			}
+			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 43) {
+				ss << "#extension GL_ARB_compute_shader : enable" << std::endl;
 			}
 			ss << "# define IN in" << std::endl
 				<< "# define OUT out" << std::endl


### PR DESCRIPTION
Sorry, I missed this one. This is required if the GL context is less than 4.3, but compute shaders/image textures are supported.

The error message I was getting on Windows/Nvidia when using N64 Depth Compare:

```
shader_compile error: 0(139) : error C7532: global function memoryBarrierImage requires "#version 430" or later
0(139) : error C0000: ... or #extension GL_ARB_compute_shader : enable
```