### PR TITLE
Fix GL_ARB_compute_shader statement

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -208,9 +208,6 @@ public:
 				ss << "#extension GL_ARB_shader_image_load_store : enable" << std::endl
 					<< "#extension GL_ARB_shading_language_420pack : enable" << std::endl;
 			}
-			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 43) {
-				ss << "#extension GL_ARB_compute_shader : enable" << std::endl;
-			}
 			ss << "# define IN in" << std::endl << "# define OUT out" << std::endl;
 			m_part = ss.str();
 		}
@@ -442,9 +439,6 @@ public:
 			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 42) {
 				ss << "#extension GL_ARB_shader_image_load_store : enable" << std::endl
 					<< "#extension GL_ARB_shading_language_420pack : enable" << std::endl;
-			}
-			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 43) {
-				ss << "#extension GL_ARB_compute_shader : enable" << std::endl;
 			}
 			ss << "# define IN in" << std::endl
 				<< "# define OUT out" << std::endl
@@ -1602,6 +1596,8 @@ public:
 				"  return true;											\n"
 				"}														\n"
 			;
+			if (!_glinfo.isGLESX && _glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 43)
+				m_part = "#extension GL_ARB_compute_shader : enable	\n" + m_part;
 		}
 	}
 };
@@ -1630,6 +1626,8 @@ public:
 				"  return true;											\n"
 				"}														\n"
 			;
+			if (!_glinfo.isGLESX && _glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 43)
+				m_part = "#extension GL_ARB_compute_shader : enable	\n" + m_part;
 		}
 	}
 };


### PR DESCRIPTION
Sorry I got the last commit wrong, you can't have ```#extension GL_ARB_compute_shader : enable``` at the beginning of normal shaders, it gives errors about having user-defined input variables. I somehow dodged this problem when I tested before, perhaps it was shader storage.

Anyway I've tested this with shader storage disabled on my Nvidia machine, and this works (tested with TWINE). However, I do still notice the issue in https://github.com/gonetz/GLideN64/issues/1418. This commit just fixes shader compilation, I was getting a completely black screen before this fix.