### PR TITLE
Neon asm optimization

### DIFF
--- a/src/3DMath.cpp
+++ b/src/3DMath.cpp
@@ -13,6 +13,13 @@ void MultMatrix(float m0[4][4], float m1[4][4], float dest[4][4])
 	}
 }
 
+void MultMatrix2(float m0[4][4], float m1[4][4])
+{
+	float dst[4][4];
+	MultMatrix(m0, m1, dst);
+	memcpy( m0, dst, sizeof(float) * 16 );
+}
+
 void TransformVectorNormalize(float vec[3], float mtx[4][4])
 {
 	float vres[3];

--- a/src/3DMath.h
+++ b/src/3DMath.h
@@ -3,18 +3,12 @@
 #include <memory.h>
 #include <string.h>
 
-void MultMatrix( float m0[4][4], float m1[4][4], float dest[4][4]);
+void MultMatrix(float m0[4][4], float m1[4][4], float dest[4][4]);
+void MultMatrix2(float m0[4][4], float m1[4][4]);
 void TransformVectorNormalize(float vec[3], float mtx[4][4]);
 void InverseTransformVectorNormalize(float src[3], float dst[3], float mtx[4][4]);
 void Normalize(float v[3]);
 float DotProduct(const float v0[3], const float v1[3]);
-
-inline void MultMatrix2(float m0[4][4], float m1[4][4])
-{
-	float dst[4][4];
-	MultMatrix(m0, m1, dst);
-	memcpy( m0, dst, sizeof(float) * 16 );
-}
 
 inline void CopyMatrix( float m0[4][4], float m1[4][4] )
 {

--- a/src/3DMathNeon.cpp
+++ b/src/3DMathNeon.cpp
@@ -38,6 +38,11 @@ void MultMatrix( float m0[4][4], float m1[4][4], float dest[4][4])
     );
 }
 
+void MultMatrix2(float m0[4][4], float m1[4][4])
+{
+    MultMatrix(m0, m1, m0);
+}
+
 void TransformVectorNormalize(float vec[3], float mtx[4][4])
 {
     asm volatile (

--- a/src/3DMathNeon.cpp
+++ b/src/3DMathNeon.cpp
@@ -5,20 +5,16 @@
 void MultMatrix( float m0[4][4], float m1[4][4], float dest[4][4])
 {
     asm volatile (
-    "vld1.32         {d0, d1}, [%1]!         \n\t"    //q0 = m1
-    "vld1.32         {d2, d3}, [%1]!         \n\t"    //q1 = m1+4
-    "vld1.32         {d4, d5}, [%1]!         \n\t"    //q2 = m1+8
-    "vld1.32         {d6, d7}, [%1]          \n\t"    //q3 = m1+12
-    "vld1.32         {d16, d17}, [%0]!       \n\t"    //q8 = m0
-    "vld1.32         {d18, d19}, [%0]!       \n\t"    //q9 = m0+4
-    "vld1.32         {d20, d21}, [%0]!       \n\t"    //q10 = m0+8
-    "vld1.32         {d22, d23}, [%0]        \n\t"    //q11 = m0+12
+    "vld1.32         {d0-d3}, [%1]!          \n\t"    //q0 & q1 = m1
+    "vld1.32         {d16-d19}, [%0]!        \n\t"    //q8 & q9 = m0
 
     "vmul.f32        q12, q8, d0[0]          \n\t"    //q12 = q8 * d0[0]
+    "vld1.32         {d4-d7}, [%1]           \n\t"    //q2 & q3= m1+8
     "vmul.f32        q13, q8, d2[0]          \n\t"    //q13 = q8 * d2[0]
     "vmul.f32        q14, q8, d4[0]          \n\t"    //q14 = q8 * d4[0]
     "vmul.f32        q15, q8, d6[0]          \n\t"    //q15 = q8 * d6[0]
     "vmla.f32        q12, q9, d0[1]          \n\t"    //q12 = q9 * d0[1]
+    "vld1.32         {d20-d23}, [%0]         \n\t"    //q10 & q11 = m0+8
     "vmla.f32        q13, q9, d2[1]          \n\t"    //q13 = q9 * d2[1]
     "vmla.f32        q14, q9, d4[1]          \n\t"    //q14 = q9 * d4[1]
     "vmla.f32        q15, q9, d6[1]          \n\t"    //q15 = q9 * d6[1]
@@ -31,10 +27,8 @@ void MultMatrix( float m0[4][4], float m1[4][4], float dest[4][4])
     "vmla.f32        q14, q11, d5[1]         \n\t"    //q14 = q11 * d4[1]
     "vmla.f32        q15, q11, d7[1]         \n\t"    //q15 = q11 * d6[1]
 
-    "vst1.32         {d24, d25}, [%2]!       \n\t"    //d = q12
-    "vst1.32         {d26, d27}, [%2]!       \n\t"    //d+4 = q13
-    "vst1.32         {d28, d29}, [%2]!       \n\t"    //d+8 = q14
-    "vst1.32         {d30, d31}, [%2]        \n\t"    //d+12 = q15
+    "vst1.32         {d24-d27}, [%2]!        \n\t"    //d = q12 & q13
+    "vst1.32         {d28-d31}, [%2]         \n\t"    //d+8 = q14 & q15 
 
     :"+r"(m0), "+r"(m1), "+r"(dest):
     : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
@@ -49,11 +43,10 @@ void TransformVectorNormalize(float vec[3], float mtx[4][4])
     asm volatile (
     "vld1.32         {d0}, [%1]              \n\t"    //q0 =  v
     "flds            s2, [%1, #8]            \n\t"    //q0 =  v
-    "vld1.32         {d18, d19}, [%0]!       \n\t"    //q9 =  m
-    "vld1.32         {d20, d21}, [%0]!       \n\t"    //q10 = m+4
-    "vld1.32         {d22, d23}, [%0]        \n\t"    //q11 = m+8
-
+    
+    "vld1.32         {d18-d21}, [%0]!        \n\t"    //q9 =  m
     "vmul.f32        q2, q9, d0[0]           \n\t"    //q2 =  q9*d0[0]
+    "vld1.32         {d22, d23}, [%0]        \n\t"    //q11 = m+8
     "vmla.f32        q2, q10, d0[1]          \n\t"    //q2 += q11*d0[1]
     "vmla.f32        q2, q11, d1[0]          \n\t"    //q2 += q11*d1[0]
 
@@ -72,8 +65,8 @@ void TransformVectorNormalize(float vec[3], float mtx[4][4])
 
     "vmul.f32        q2, q2, d0[0]           \n\t"    //q2= q2*d0[0]
 
-    "vst1.32         {d4}, [%1]              \n\t"    //d4
-    "fsts            s10, [%1, #8]           \n\t"    //Q4 = m+12
+    "vst1.32         {d4}, [%1]              \n\t"    //vec = d4
+    "fsts            s10, [%1, #8]           \n\t"    //vec += d5[0]
     : "+r"(mtx), "+r"(vec) :
     : "d0","d1","d2","d3","d18","d19","d20","d21","d22", "d23", "memory"
     );
@@ -81,51 +74,37 @@ void TransformVectorNormalize(float vec[3], float mtx[4][4])
 
 void InverseTransformVectorNormalize(float src[3], float dst[3], float mtx[4][4])
 {
-    if(!(std::isnan(src[0]) && std::isnan(src[1]) && std::isnan(src[2]))){
-        asm volatile (
-        "vld1.32         {d0}, [%1]              \n\t"    //q0 = v
-        "flds            s2, [%1, #8]            \n\t"    //q0 = v
-        "vld1.32         {d18, d19}, [%0]!       \n\t"    //q9 = m
-        "vld1.32         {d20, d21}, [%0]!       \n\t"    //q10 = m+4
-        "vld1.32         {d22, d23}, [%0]        \n\t"    //q11 = m+8
+    asm volatile (
+    "vld1.32        {d0}, [%1]!                   \n\t"    //d0 = src[0] & src[1]
+    "vld1.32        {d1[0]}, [%1]                 \n\t"    //d1[0] = src[2]
+    
+    "vld4.32        {d18, d20, d22, d24}, [%0]!   \n\t"
+    "vld4.32        {d19, d21, d23, d25}, [%0]    \n\t"
+    "vmul.f32       q2, q9, d0[0]                 \n\t"    //q2 =  q9*d0[0]
+    "vmla.f32       q2, q10, d0[1]                \n\t"    //q2 += q1*d0[1]
+    "vmla.f32       q2, q11, d1[0]                \n\t"    //q2 += q2*d1[0]*/
 
-        "vmul.f32        q2, q0, q9              \n\t"
-        "vmul.f32        q3, q0, q10             \n\t"
-        "vmul.f32        q4, q0, q11             \n\t"
-        "vpadd.f32       d4, d4, d5              \n\t"
-        "vpadd.f32       d4, d4, d4              \n\t"    //d4[0] = sum of q2
-        "vpadd.f32       d8, d8, d9              \n\t"
-        "vpadd.f32       d5, d8, d8              \n\t"    //d5[0] = sum of q4
-        "vpadd.f32       d6, d6, d7              \n\t"
-        "vpadd.f32       d10, d6, d6             \n\t"
-        "vmov.f32        s9, s20                 \n\t"    //d4[1] = sum of q3
+    "vmul.f32       d0, d4, d4                    \n\t"    //d0 =  d4*d4
+    "vpadd.f32      d0, d0, d0                    \n\t"    //d0 =  d[0] + d[1]
+    "vmla.f32       d0, d5, d5                    \n\t"    //d0 += d5*d5
 
-        "vmul.f32        d0, d4, d4              \n\t"    //d0 = d4*d4
-        "vpadd.f32       d0, d0, d0              \n\t"    //d0 = d0[0] + d0[1]
-        "vmla.f32        d0, d5, d5              \n\t"    //d0 += d5*d5
+    "vmov.f32       d1, d0                        \n\t"    //d1 = d0
+    "vrsqrte.f32    d0, d0                        \n\t"    //d0 = ~ 1.0 / sqrt(d0)
+    "vmul.f32       d2, d0, d1                    \n\t"    //d2 = d0 * d1
+    "vrsqrts.f32    d3, d2, d0                    \n\t"    //d3 = (3 - d0 * d2) / 2
+    "vmul.f32       d0, d0, d3                    \n\t"    //d0 = d0 * d3
+    "vmul.f32       d2, d0, d1                    \n\t"    //d2 = d0 * d1
+    "vrsqrts.f32    d3, d2, d0                    \n\t"    //d3 = (3 - d0 * d3) / 2
+    "vmul.f32       d0, d0, d3                    \n\t"    //d0 = d0 * d3
 
-        "vmov.f32        d1, d0                  \n\t"    //d1 = d0
-        "vrsqrte.f32     d0, d0                  \n\t"    //d0 = ~ 1.0 / sqrt(d0)
-        "vmul.f32        d2, d0, d1              \n\t"    //d2 = d0 * d1
-        "vrsqrts.f32     d3, d2, d0              \n\t"    //d3 = (3 - d0 * d2) / 2
-        "vmul.f32        d0, d0, d3              \n\t"    //d0 = d0 * d3
-        "vmul.f32        d2, d0, d1              \n\t"    //d2 = d0 * d1
-        "vrsqrts.f32     d3, d2, d0              \n\t"    //d3 = (3 - d0 * d3) / 2
-        "vmul.f32        d0, d0, d3              \n\t"    //d0 = d0 * d3
+    "vmul.f32       q2, q2, d0[0]                 \n\t"    //q2 = q2*d0[0]
 
-        "vmul.f32        q2, q2, d0[0]           \n\t"    //d0= d2*d4
-
-        "vst1.32         {d4}, [%2]              \n\t"    //d2
-        "fsts            s10, [%2, #8]           \n\t"    //Q4 = m+12
-        : "+r"(mtx), "+r"(src), "+r"(dst) :
-        : "d0","d1","d2","d3","d4","d5","d6","d7","d8","d9","d10","d18","d19",
-        "d20","d21","d22", "d23", "memory"
-        );
-    }else{
-        dst[0] = NAN;
-        dst[1] = NAN;
-        dst[2] = NAN;
-    }
+    "vst1.32        {d4}, [%2]!                   \n\t"    //dst = d4
+    "vst1.32        {d5[0]}, [%2]                 \n\t"    //dst += d5[0]
+    : "+r"(mtx), "+r"(src), "+r"(dst) :
+    : "d0","d1","d2","d3","d4","d5","d6","d7","d8","d9","d10","d18","d19",
+    "d20","d21","d22","d23","d24","d25", "memory"
+    );
 }
 
 void Normalize(float v[3])

--- a/src/gSPNeon.cpp
+++ b/src/gSPNeon.cpp
@@ -38,10 +38,8 @@ void gSPTransformVertex4NEON(u32 v, float mtx[4][4])
     "vld1.32         {d6, d7}, [%1]          \n\t"    //q3 = {x,y,z,w}
     "sub             %1, %1, %3              \n\t"    //q0 = {x,y,z,w}
 
-    "vld1.32         {d18, d19}, [%0]!       \n\t"    //q9 = m
-    "vld1.32         {d20, d21}, [%0]!       \n\t"    //q10 = m
-    "vld1.32         {d22, d23}, [%0]!       \n\t"    //q11 = m
-    "vld1.32         {d24, d25}, [%0]        \n\t"    //q12 = m
+    "vld1.32         {d18-d21}, [%0]!        \n\t"    //q9 & q10 = m
+    "vld1.32         {d22-d25}, [%0]         \n\t"    //q11 & q12 = m+8
 
     "vmov.f32        q13, q12                \n\t"    //q13 = q12
     "vmov.f32        q14, q12                \n\t"    //q14 = q12


### PR DESCRIPTION
-rewrite InverseTransformVectorNormalize. Load array deinterleaved (lvd4) so we can reuse TransformVectorNormalize. Fixes whatever reason texture flickering in SM64 on a PI as well. https://github.com/gonetz/GLideN64/issues/1297. Pi problems with enabled framebuffer persist. 
-reorder instructions to get best throughput
-use vld1.32 and vst1.32 to load and store four d registers at once
-add MultMatrix2 neon version without memcpy