### PR TITLE
Disable LOD emulation on GLES2 devices that can't support it

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -415,8 +415,10 @@ public:
 	{
 		if (_glinfo.isGLES2) {
 			m_part = "#version 100 \n";
-			m_part += "#extension GL_EXT_shader_texture_lod : enable \n";
-			m_part += "#extension GL_OES_standard_derivatives : enable \n";
+			if (config.generalEmulation.enableLOD) {
+				m_part += "#extension GL_EXT_shader_texture_lod : enable \n";
+				m_part += "#extension GL_OES_standard_derivatives : enable \n";
+			}
 			m_part +=
 				"#if (__VERSION__ > 120)		\n"
 				"# define IN in					\n"

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -75,4 +75,10 @@ void GLInfo::init() {
 		LOG(LOG_WARNING, "Async color buffer copies are not supported on GLES2\n");
 	}
 #endif
+	if (isGLES2 && config.generalEmulation.enableLOD) {
+		if (!Utils::isExtensionSupported(*this, "GL_EXT_shader_texture_lod") || !Utils::isExtensionSupported(*this, "GL_OES_standard_derivatives")) {
+			config.generalEmulation.enableLOD = 0;
+			LOG(LOG_WARNING, "LOD emulation not possible on this device\n");
+		}
+	}
 }


### PR DESCRIPTION
LOD emulation on GLES2 depends on GL_EXT_shader_texture_lod and GL_OES_standard_derivatives. 

Unfortunately not every device supports these extensions, like the Raspberry Pi.

This disables LOD if either of those extensions are not supported. @fzurita perhaps you could review this. It should be pretty harmless.

Fixes the issue with GoldenEye on the Raspberry Pi noted in https://github.com/gonetz/GLideN64/issues/1428