### PR TITLE
ColorBufferReader Performance Improvements

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp
@@ -26,8 +26,8 @@ void ColorBufferReaderWithBufferStorage::_initBuffers()
 	for (int index = 0; index < _numPBO; ++index) {
 		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[index]));
 		m_fence[index] = 0;
-		glBufferStorage(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, nullptr, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT);
-		m_PBOData[index] = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, m_pTexture->textureBytes, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT);
+		glBufferStorage(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, nullptr, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+		m_PBOData[index] = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, m_pTexture->textureBytes, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
 	}
 
 	m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle::null);
@@ -59,18 +59,17 @@ u8 * ColorBufferReaderWithBufferStorage::readPixels(s32 _x0, s32 _y0, u32 _width
 	m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[m_curIndex]));
 	glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
 
-	//Setup a fence sync object so that we know when glReadPixels completes
-	glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT);
-	m_fence[m_curIndex] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-
 	if (!_sync) {
+		//Setup a fence sync object so that we know when glReadPixels completes
+		m_fence[m_curIndex] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 		m_curIndex = (m_curIndex + 1) % _numPBO;
-	}
-
-	//Wait for glReadPixels to complete for the currently selected PBO
-	if (m_fence[m_curIndex] != 0) {
-		glClientWaitSync(m_fence[m_curIndex], 0, 1e8);
-		glDeleteSync(m_fence[m_curIndex]);
+		//Wait for glReadPixels to complete for the currently selected PBO
+		if (m_fence[m_curIndex] != 0) {
+			glClientWaitSync(m_fence[m_curIndex], 0, 1e8);
+			glDeleteSync(m_fence[m_curIndex]);
+		}
+	} else {
+		glFinish();
 	}
 
 	GLubyte* pixelData = reinterpret_cast<GLubyte*>(m_PBOData[m_curIndex]);

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp
@@ -33,7 +33,7 @@ void ColorBufferReaderWithPixelBuffer::_initBuffers()
 
 	// Initialize Pixel Buffer Objects
 	for (u32 i = 0; i < _numPBO; ++i) {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[i]);
+		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[i]));
 		glBufferData(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, nullptr, GL_DYNAMIC_READ);
 	}
 	m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle::null);
@@ -58,11 +58,11 @@ u8 * ColorBufferReaderWithPixelBuffer::readPixels(s32 _x0, s32 _y0, u32 _width, 
 	if (!_sync) {
 		m_curIndex ^= 1;
 		const u32 nextIndex = m_curIndex ^ 1;
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[m_curIndex]);
+		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[m_curIndex]));
 		glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[nextIndex]);
+		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[nextIndex]));
 	} else {
-		glBindBuffer(GL_PIXEL_PACK_BUFFER, m_PBO[_numPBO - 1]);
+		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[_numPBO -1]));
 		glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
 	}
 

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -303,7 +303,7 @@ graphics::PixelReadBuffer * ContextImpl::createPixelReadBuffer(size_t _sizeInByt
 
 graphics::ColorBufferReader * ContextImpl::createColorBufferReader(CachedTexture * _pTexture)
 {
-	if (m_glInfo.bufferStorage)
+	if (m_glInfo.bufferStorage && m_glInfo.renderer != Renderer::Intel)
 		return new ColorBufferReaderWithBufferStorage(_pTexture, m_cachedFunctions->getCachedBindBuffer());
 
 	if (!m_glInfo.isGLES2)

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -29,6 +29,8 @@ void GLInfo::init() {
 		renderer = Renderer::Adreno;
 	else if (strstr((const char*)strRenderer, "VideoCore IV") != nullptr)
 		renderer = Renderer::VideoCore;
+	else if (strstr((const char*)strRenderer, "Intel") != nullptr)
+		renderer = Renderer::Intel;
 	LOG(LOG_VERBOSE, "OpenGL renderer: %s\n", strRenderer);
 
 	int numericVersion = majorVersion * 10 + minorVersion;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -6,6 +6,7 @@ namespace opengl {
 enum class Renderer {
 	Adreno,
 	VideoCore,
+	Intel,
 	Other
 };
 


### PR DESCRIPTION
I tested Sync mode with both implementations (ColorBufferReaderWithBufferStorage and ColorBufferReaderWithPixelBuffer), and I got 170 VI/S in Luigi's Raceway with both methods. This was on Windows with an Nvidia card.

Given that some desktop users have experienced performance regressions with ColorBufferReaderWithBufferStorage (see https://github.com/gonetz/GLideN64/issues/1312), I think it's probably best to just use that method for GLES devices.