### PR TITLE
Refactor gSP.lights and gSP.lookat

### DIFF
--- a/src/3DMath.cpp
+++ b/src/3DMath.cpp
@@ -88,16 +88,16 @@ End:
 #endif // WIN32_ASM
 }
 
-void InverseTransformVectorNormalize2x(float src0[3], float src1[3], float dst0[3], float dst1[3], float mtx[4][4] )
+void InverseTransformVectorNormalize2x(float src[2][3], float dst[2][3], float mtx[4][4] )
 {
-	InverseTransformVectorNormalize(src0, dst0, mtx);
-	InverseTransformVectorNormalize(src1, dst1, mtx);
+	InverseTransformVectorNormalize((float(*))src[0], (float(*))dst[0], mtx);
+	InverseTransformVectorNormalize((float(*))src[1], (float(*))dst[1], mtx);
 }
 
-void InverseTransformVectorNormalize4x(float src0[3], float src1[3],float src2[3], float src3[3], float dst0[3], float dst1[3], float dst2[3], float dst3[3], float mtx[4][4] )
+void InverseTransformVectorNormalize4x(float src[4][3], float dst[4][3], float mtx[4][4] )
 {
-	InverseTransformVectorNormalize(src0, dst0, mtx);
-	InverseTransformVectorNormalize(src1, dst1, mtx);
-	InverseTransformVectorNormalize(src2, dst2, mtx);
-	InverseTransformVectorNormalize(src3, dst3, mtx);
+	InverseTransformVectorNormalize((float(*))src[0], (float(*))dst[0], mtx);
+	InverseTransformVectorNormalize((float(*))src[1], (float(*))dst[1], mtx);
+	InverseTransformVectorNormalize((float(*))src[2], (float(*))dst[2], mtx);
+	InverseTransformVectorNormalize((float(*))src[3], (float(*))dst[3], mtx);
 }

--- a/src/3DMath.h
+++ b/src/3DMath.h
@@ -7,8 +7,8 @@ void MultMatrix(float m0[4][4], float m1[4][4], float dest[4][4]);
 void MultMatrix2(float m0[4][4], float m1[4][4]);
 void TransformVectorNormalize(float vec[3], float mtx[4][4]);
 void InverseTransformVectorNormalize(float src[3], float dst[3], float mtx[4][4]);
-void InverseTransformVectorNormalize2x(float src0[3], float src1[3], float dst0[3], float dst1[3], float mtx[4][4] );
-void InverseTransformVectorNormalize4x(float src0[3], float src1[3],float src2[3], float src3[3], float dst0[3], float dst1[3], float dst2[3], float dst3[3], float mtx[4][4] );
+void InverseTransformVectorNormalize2x(float src[2][3], float dst[2][3], float mtx[4][4] );
+void InverseTransformVectorNormalize4x(float src[4][3], float dst[4][3], float mtx[4][4] );
 void Normalize(float v[3]);
 float DotProduct(const float v0[3], const float v1[3]);
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -765,8 +765,8 @@ public:
 	void update(bool _force) override
 	{
 		for (s32 i = 0; i <= gSP.numLights; ++i) {
-			uLightDirection[i].set(&gSP.lights[i].ix, _force);
-			uLightColor[i].set(&gSP.lights[i].r, _force);
+			uLightDirection[i].set(gSP.lights.i_xyz[i], _force);
+			uLightColor[i].set(gSP.lights.rgb[i], _force);
 		}
 	}
 

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -135,7 +135,7 @@ void RSP_SetDefaultState()
 	gDP.loadTile = &gDP.tiles[7];
 	gSP.textureTile[0] = &gDP.tiles[0];
 	gSP.textureTile[1] = &gDP.tiles[1];
-	gSP.lookat[0].y = gSP.lookat[1].x = 1.0f;
+	gSP.lookat.xyz[0][Y] = gSP.lookat.xyz[1][X] = 1.0f;
 	gSP.lookatEnable = true;
 
 	gSP.objMatrix.A = 1.0f;

--- a/src/ZSort.cpp
+++ b/src/ZSort.cpp
@@ -245,27 +245,27 @@ void ZSort_XFMLight( u32 _w0, u32 _w1 )
 */
 
 
-	gSP.lights[gSP.numLights].r = (f32)(((u8*)DMEM)[(addr+0)^3]) * 0.0039215689f;
-	gSP.lights[gSP.numLights].g = (f32)(((u8*)DMEM)[(addr+1)^3]) * 0.0039215689f;
-	gSP.lights[gSP.numLights].b = (f32)(((u8*)DMEM)[(addr+2)^3]) * 0.0039215689f;
+	gSP.lights.rgb[gSP.numLights][R] = (f32)(((u8*)DMEM)[(addr+0)^3]) * 0.0039215689f;
+	gSP.lights.rgb[gSP.numLights][G] = (f32)(((u8*)DMEM)[(addr+1)^3]) * 0.0039215689f;
+	gSP.lights.rgb[gSP.numLights][B] = (f32)(((u8*)DMEM)[(addr+2)^3]) * 0.0039215689f;
 	addr += 8;
 	u32 i;
 	for (i = 0; i < gSP.numLights; ++i)
 	{
-		gSP.lights[i].r = (f32)(((u8*)DMEM)[(addr+0)^3]) * 0.0039215689f;
-		gSP.lights[i].g = (f32)(((u8*)DMEM)[(addr+1)^3]) * 0.0039215689f;
-		gSP.lights[i].b = (f32)(((u8*)DMEM)[(addr+2)^3]) * 0.0039215689f;
-		gSP.lights[i].x = (f32)(((s8*)DMEM)[(addr+8)^3]);
-		gSP.lights[i].y = (f32)(((s8*)DMEM)[(addr+9)^3]);
-		gSP.lights[i].z = (f32)(((s8*)DMEM)[(addr+10)^3]);
+		gSP.lights.rgb[i][R] = (f32)(((u8*)DMEM)[(addr+0)^3]) * 0.0039215689f;
+		gSP.lights.rgb[i][G] = (f32)(((u8*)DMEM)[(addr+1)^3]) * 0.0039215689f;
+		gSP.lights.rgb[i][B] = (f32)(((u8*)DMEM)[(addr+2)^3]) * 0.0039215689f;
+		gSP.lights.xyz[i][X] = (f32)(((s8*)DMEM)[(addr+8)^3]);
+		gSP.lights.xyz[i][Y] = (f32)(((s8*)DMEM)[(addr+9)^3]);
+		gSP.lights.xyz[i][Z] = (f32)(((s8*)DMEM)[(addr+10)^3]);
 		addr += 24;
 	}
 	for (i = 0; i < 2; i++)
 	{
-		gSP.lookat[i].x = (f32)(((s8*)DMEM)[(addr+8)^3]);
-		gSP.lookat[i].y = (f32)(((s8*)DMEM)[(addr+9)^3]);
-		gSP.lookat[i].z = (f32)(((s8*)DMEM)[(addr+10)^3]);
-		gSP.lookatEnable = (i == 0) || (i == 1 && gSP.lookat[i].x != 0 && gSP.lookat[i].y != 0);
+		gSP.lookat.xyz[i][X] = (f32)(((s8*)DMEM)[(addr+8)^3]);
+		gSP.lookat.xyz[i][Y] = (f32)(((s8*)DMEM)[(addr+9)^3]);
+		gSP.lookat.xyz[i][Z] = (f32)(((s8*)DMEM)[(addr+10)^3]);
+		gSP.lookatEnable = (i == 0) || (i == 1 && gSP.lookat.xyz[i][X] != 0 && gSP.lookat.xyz[i][Y] != 0);
 		addr += 24;
 	}
 }
@@ -300,8 +300,8 @@ void ZSort_Lighting( u32 _w0, u32 _w1 )
 		TransformVectorNormalize(fLightDir, gSP.matrix.projection);
 		f32 x, y;
 		if (gSP.lookatEnable) {
-			x = DotProduct(&gSP.lookat[0].x, fLightDir);
-			y = DotProduct(&gSP.lookat[1].x, fLightDir);
+			x = DotProduct(gSP.lookat.xyz[0], fLightDir);
+			y = DotProduct(gSP.lookat.xyz[1], fLightDir);
 		} else {
 			x = fLightDir[0];
 			y = fLightDir[1];

--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -897,20 +897,18 @@ void gSPLookAt( u32 _l, u32 _n )
 static
 void gSPUpdateLightVectors()
 {
-	s32 count = gSP.numLights;
-	while (count >= 4) {
-		InverseTransformVectorNormalize4x(gSP.lights.xyz[count-1], gSP.lights.xyz[count-2], gSP.lights.xyz[count-3], gSP.lights.xyz[count-4],
-									gSP.lights.i_xyz[count-1], gSP.lights.i_xyz[count-2], gSP.lights.i_xyz[count-3], gSP.lights.i_xyz[count-4],
-									gSP.matrix.modelView[gSP.matrix.modelViewi]);
+	s32 count = gSP.numLights-1;
+	while (count >= 3) {
+		InverseTransformVectorNormalize4x(&gSP.lights.xyz[count-3],&gSP.lights.i_xyz[count-3], 
+					gSP.matrix.modelView[gSP.matrix.modelViewi]);
 		count -= 4;
 	}
-	if (count >= 2){
-		InverseTransformVectorNormalize2x(gSP.lights.xyz[count - 1], gSP.lights.xyz[count - 2],
-									gSP.lights.i_xyz[count - 1], gSP.lights.i_xyz[count - 2],
-									gSP.matrix.modelView[gSP.matrix.modelViewi]);
+	if (count >= 1){
+		InverseTransformVectorNormalize2x(&gSP.lights.xyz[count-1], &gSP.lights.i_xyz[count-1],
+					gSP.matrix.modelView[gSP.matrix.modelViewi]);
 		count -= 2;
 	}
-	if (count == 1)
+	if (count == 0)
 		InverseTransformVectorNormalize(gSP.lights.xyz[0], gSP.lights.i_xyz[0], gSP.matrix.modelView[gSP.matrix.modelViewi]);
 	gSP.changed ^= CHANGED_LIGHT;
 	gSP.changed |= CHANGED_HW_LIGHT;
@@ -920,9 +918,8 @@ static
 void gSPUpdateLookatVectors()
 {
 	if (gSP.lookatEnable) {
-		InverseTransformVectorNormalize2x(gSP.lookat.xyz[0], gSP.lookat.xyz[1],
-									gSP.lookat.i_xyz[0], gSP.lookat.i_xyz[1],
-									gSP.matrix.modelView[gSP.matrix.modelViewi]);
+		InverseTransformVectorNormalize2x(&gSP.lookat.xyz[0], &gSP.lookat.i_xyz[0],
+					gSP.matrix.modelView[gSP.matrix.modelViewi]);
 	}
 	gSP.changed ^= CHANGED_LOOKAT;
 }

--- a/src/gSP.h
+++ b/src/gSP.h
@@ -30,6 +30,9 @@
 #define MODIFY_RGBA	0xFF000000
 #define MODIFY_ALL	0xFFFFFFFF
 
+enum Component { R, G, B };
+enum Axis { X ,Y, Z, W };
+
 struct SPVertex
 {
 	f32 x, y, z, w;
@@ -41,15 +44,6 @@ struct SPVertex
 	u8 HWLight;
 	u8 clip;
 	s16 flag;
-};
-
-struct SPLight
-{
-	f32 r, g, b;
-	f32 x, y, z;
-	f32 ix, iy, iz;
-	f32 posx, posy, posz, posw;
-	f32 ca, la, qa;
 };
 
 struct gSPInfo
@@ -76,8 +70,24 @@ struct gSPInfo
 	u32 vertexColorBase;
 	u32 vertexi;
 
-	SPLight lights[12];
-	SPLight lookat[2];
+	struct
+	{
+		f32 rgb[12][3];
+		f32 xyz[12][3];
+		f32 i_xyz[12][3];
+		f32 pos_xyzw[12][4];
+		f32 ca[12], la[12], qa[12];
+	} lights;
+
+	struct
+	{
+		f32 rgb[2][3];
+		f32 xyz[2][3];
+		f32 i_xyz[2][3];
+		f32 pos_xyzw[2][4];
+		f32 ca[2], la[2], qa[2];
+	} lookat;
+	
 	s32 numLights;
 	bool lookatEnable;
 


### PR DESCRIPTION
I refactored gSP.lights and gSP.lookat as described here:
https://github.com/gonetz/GLideN64/issues/1447

I also rewrote InverseTransformVectorNormalize 2x and 4x so they can benefit from the new structure. 
Rewritten versions are faster:
2x, opt level -O2
old 0,42 runtime of c function
new 0,36 runtime of c function

4x, opt level  -O2
old 0,30 runtime of c function
new 0,23 runtime of c function

Tested with and without -DVEC4_OPT and -DNEON_OPT.