### PR TITLE
Update Paper Mario/Mario Story

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -79,6 +79,14 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Mario Golf (E)(J)(U)
 frameBufferEmulation\copyDepthToRDRAM=0
 
+[MARIO%20STORY]
+Good_Name=Mario Story (J)
+frameBufferEmulation\copyToRDRAM=1
+
+[PAPER%20MARIO]
+Good_Name=Paper Mario (E)(U)
+frameBufferEmulation\copyToRDRAM=1
+
 [PENNY%20RACERS]
 Good_Name=Penny Racers (E)(U)
 frameBufferEmulation\copyToRDRAM=0


### PR DESCRIPTION
According to https://github.com/gonetz/GLideN64/issues/1026#issuecomment-291628122 Paper Mario needs synchronous RDRAM copies.