### PR TITLE
UI: Fix duplicate fullscreen refresh rates

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -90,7 +90,6 @@ void ConfigDialog::_init()
 	fillFullscreenResolutionsList(fullscreenModesList, fullscreenMode, fullscreenRatesList, fullscreenRate);
 	ui->fullScreenResolutionComboBox->insertItems(0, fullscreenModesList);
 	ui->fullScreenResolutionComboBox->setCurrentIndex(fullscreenMode);
-	ui->fullScreenRefreshRateComboBox->insertItems(0, fullscreenRatesList);
 	ui->fullScreenRefreshRateComboBox->setCurrentIndex(fullscreenRate);
 
 	ui->aliasingSlider->setValue(powof(config.video.multisampling));


### PR DESCRIPTION
`ui->fullScreenResolutionComboBox->setCurrentIndex(fullscreenMode);` within `ConfigDialog::_init()` fills the refresh rate list so it's filled twice.