### PR TITLE
Floating point color buffer reader support

### DIFF
--- a/projects/msvc12/GLideN64.vcxproj
+++ b/projects/msvc12/GLideN64.vcxproj
@@ -290,6 +290,7 @@
     <ClCompile Include="..\..\src\GBI.cpp" />
     <ClCompile Include="..\..\src\gDP.cpp" />
     <ClCompile Include="..\..\src\GLideN64.cpp" />
+    <ClCompile Include="..\..\src\Graphics\ColorBufferReader.cpp" />
     <ClCompile Include="..\..\src\Graphics\CombinerProgram.cpp" />
     <ClCompile Include="..\..\src\Graphics\Context.cpp" />
     <ClCompile Include="..\..\src\Graphics\ObjectHandle.cpp" />

--- a/projects/msvc12/GLideN64.vcxproj.filters
+++ b/projects/msvc12/GLideN64.vcxproj.filters
@@ -296,6 +296,9 @@
     <ClCompile Include="..\..\src\Graphics\OpenGLContext\opengl_Utils.cpp">
       <Filter>Source Files\Graphics\OpenGL</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Graphics\ColorBufferReader.cpp">
+      <Filter>Source Files\Graphics</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\Graphics\CombinerProgram.cpp">
       <Filter>Source Files\Graphics</Filter>
     </ClCompile>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ set(GLideN64_SOURCES
   DepthBufferRender/DepthBufferRender.cpp
   common/CommonAPIImpl_common.cpp
   Graphics/Context.cpp
+  Graphics/ColorBufferReader.cpp
   Graphics/CombinerProgram.cpp
   Graphics/ObjectHandle.cpp
   Graphics/OpenGLContext/GLFunctions.cpp

--- a/src/Graphics/ColorBufferReader.cpp
+++ b/src/Graphics/ColorBufferReader.cpp
@@ -1,0 +1,89 @@
+
+#include "ColorBufferReader.h"
+#include "FramebufferTextureFormats.h"
+#include "Context.h"
+#include "Parameters.h"
+#include <algorithm>
+#include <cstring>
+
+namespace graphics {
+
+	ColorBufferReader::ColorBufferReader(CachedTexture * _pTexture)
+		: m_pTexture(_pTexture)
+	{
+		m_pixelData.resize(m_pTexture->textureBytes);
+		m_tempPixelData.resize(m_pTexture->textureBytes);
+	}
+
+	const u8* ColorBufferReader::_convertFloatTextureBuffer(const u8* _gpuData, u32 _width, u32 _height,
+		u32 _heightOffset, u32 _stride)
+	{
+		std::copy_n(_gpuData, m_tempPixelData.size(), m_tempPixelData.data());
+		u8* pixelDataAlloc = m_pixelData.data();
+		float* pixelData = reinterpret_cast<float*>(m_tempPixelData.data());
+		const u32 colorsPerPixel = 4;
+		const u32 widthPixels = _width * colorsPerPixel;
+		const u32 stridePixels = _stride * colorsPerPixel;
+
+		for (u32 index = 0; index < _height; ++index) {
+			for (u32 widthIndex = 0; widthIndex < widthPixels; ++widthIndex) {
+				u8& dest = *(pixelDataAlloc + index*widthPixels + widthIndex);
+				float& src = *(pixelData + (index+_heightOffset)*stridePixels + widthIndex);
+				dest = static_cast<u8>(src*255.0);
+			}
+		}
+
+		return pixelDataAlloc;
+	}
+
+	const u8* ColorBufferReader::_convertIntegerTextureBuffer(const u8* _gpuData, u32 _width, u32 _height,
+		u32 _heightOffset, u32 _stride)
+	{
+		const u32 colorsPerPixel = 4;
+		const u32 widthBytes = _width * colorsPerPixel;
+		const u32 strideBytes = _stride * colorsPerPixel;
+
+		u8* pixelDataAlloc = m_pixelData.data();
+		for (u32 lnIndex = 0; lnIndex < _height; ++lnIndex) {
+			memcpy(pixelDataAlloc + lnIndex*widthBytes, _gpuData + ((lnIndex+_heightOffset)*strideBytes), widthBytes);
+		}
+
+		return pixelDataAlloc;
+	}
+
+
+	const u8 * ColorBufferReader::readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync)
+	{
+		const FramebufferTextureFormats & fbTexFormat = gfxContext.getFramebufferTextureFormats();
+
+		ReadColorBufferParams params;
+		params.x0 = _x0;
+		params.y0 = _y0;
+		params.width = _width;
+		params.height = _height;
+		params.sync = _sync;
+
+		if (_size > G_IM_SIZ_8b) {
+			params.colorFormat = fbTexFormat.colorFormat;
+			params.colorType = fbTexFormat.colorType;
+			params.colorFormatBytes = fbTexFormat.colorFormatBytes;
+		} else {
+			params.colorFormat = fbTexFormat.monochromeFormat;
+			params.colorType = fbTexFormat.monochromeType;
+			params.colorFormatBytes = fbTexFormat.monochromeFormatBytes;
+		}
+
+		u32 heightOffset = 0;
+		u32 stride = 0;
+		const u8* pixelData = _readPixels(params, heightOffset, stride);
+
+		if (pixelData == nullptr)
+			return nullptr;
+
+		if(params.colorType == datatype::FLOAT) {
+			return _convertFloatTextureBuffer(pixelData, params.width, params.height, heightOffset, stride);
+		} else {
+			return _convertIntegerTextureBuffer(pixelData, params.width, params.height, heightOffset, stride);
+		}
+	}
+}

--- a/src/Graphics/ColorBufferReader.h
+++ b/src/Graphics/ColorBufferReader.h
@@ -8,18 +8,32 @@ namespace graphics {
 class ColorBufferReader
 {
 public:
-	ColorBufferReader(CachedTexture * _pTexture)
-		: m_pTexture(_pTexture) {
-		m_pixelData.resize(m_pTexture->textureBytes);
-	}
-	virtual ~ColorBufferReader() {}
+	ColorBufferReader(CachedTexture * _pTexture);
+	virtual ~ColorBufferReader() = default;
 
-	virtual u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) = 0;
+	virtual const u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync);
 	virtual void cleanUp() = 0;
 
 protected:
+	struct ReadColorBufferParams {
+		s32 x0;
+		s32 y0;
+		u32 width;
+		u32 height;
+		bool sync;
+		ColorFormatParam colorFormat;
+		DatatypeParam colorType;
+		u32 colorFormatBytes;
+	};
+
 	CachedTexture * m_pTexture;
 	std::vector<u8> m_pixelData;
+	std::vector<u8> m_tempPixelData;
+
+private:
+	const u8* _convertFloatTextureBuffer(const u8* _gpuData, u32 _width, u32 _height, u32 _heightOffset, u32 _stride);
+	const u8* _convertIntegerTextureBuffer(const u8* _gpuData, u32 _width, u32 _height,u32 _heightOffset, u32 _stride);
+	virtual const u8 * _readPixels(const ReadColorBufferParams& _params, u32& _heightOffset, u32& _stride) = 0;
 };
 
 }

--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -469,7 +469,8 @@ struct FramebufferTextureFormatsGLES3 : public graphics::FramebufferTextureForma
 		return _glinfo.isGLESX && !_glinfo.isGLES2;
 	}
 
-	FramebufferTextureFormatsGLES3()
+	FramebufferTextureFormatsGLES3(const GLInfo & _glinfo):
+		m_glinfo(_glinfo)
 	{
 		init();
 	}
@@ -477,10 +478,17 @@ struct FramebufferTextureFormatsGLES3 : public graphics::FramebufferTextureForma
 protected:
 	void init() override
 	{
-		colorInternalFormat = GL_RGBA8;
-		colorFormat = GL_RGBA;
-		colorType = GL_UNSIGNED_BYTE;
-		colorFormatBytes = 4;
+		if (m_glinfo.renderer == Renderer::Adreno500) {
+			colorInternalFormat = GL_RGBA32F;
+			colorFormat = GL_RGBA;
+			colorType = GL_FLOAT;
+			colorFormatBytes = 16;
+		} else {
+			colorInternalFormat = GL_RGBA8;
+			colorFormat = GL_RGBA;
+			colorType = GL_UNSIGNED_BYTE;
+			colorFormatBytes = 4;
+		}
 
 		monochromeInternalFormat = GL_R8;
 		monochromeFormat = GL_RED;
@@ -507,6 +515,8 @@ protected:
 		noiseType = GL_UNSIGNED_BYTE;
 		noiseFormatBytes = 1;
 	}
+
+	const GLInfo & m_glinfo;
 };
 
 struct FramebufferTextureFormatsOpenGL : public graphics::FramebufferTextureFormats
@@ -629,7 +639,7 @@ graphics::FramebufferTextureFormats * BufferManipulationObjectFactory::getFrameb
 		return new FramebufferTextureFormatsOpenGL;
 
 	if (FramebufferTextureFormatsGLES3::Check(m_glInfo))
-		return new FramebufferTextureFormatsGLES3;
+		return new FramebufferTextureFormatsGLES3(m_glInfo);
 
 	if (FramebufferTextureFormatsGLES2::Check(m_glInfo))
 		return new FramebufferTextureFormatsGLES2(m_glInfo);

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.h
@@ -2,6 +2,7 @@
 
 #include <Graphics/ColorBufferReader.h>
 #include "opengl_CachedFunctions.h"
+#include <Graphics/Parameter.h>
 
 namespace opengl {
 
@@ -13,7 +14,8 @@ namespace opengl {
 			CachedBindBuffer * _bindBuffer);
 		virtual ~ColorBufferReaderWithBufferStorage();
 
-		u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) override;
+		const u8 * _readPixels(const ReadColorBufferParams& _params, u32& _heightOffset, u32& _stride) override;
+
 		void cleanUp() override;
 
 	private:

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.h
@@ -19,7 +19,8 @@ public:
 								  CachedBindTexture * _bindTexture);
 	~ColorBufferReaderWithEGLImage();
 
-	u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) override;
+	const u8 * _readPixels(const ReadColorBufferParams& _params, u32& _heightOffset, u32& _stride) override;
+
 	void cleanUp() override;
 
 private:
@@ -29,6 +30,7 @@ private:
 	GraphicBuffer m_window{};
 	EGLImageKHR m_image;
 	PFNGLEGLIMAGETARGETTEXTURE2DOESPROC m_glEGLImageTargetTexture2DOES;
+	bool m_bufferLocked;
 };
 
 }

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.cpp
@@ -39,45 +39,30 @@ void ColorBufferReaderWithPixelBuffer::_initBuffers()
 	m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle::null);
 }
 
-u8 * ColorBufferReaderWithPixelBuffer::readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync)
+const u8 * ColorBufferReaderWithPixelBuffer::_readPixels(const ReadColorBufferParams& _params, u32& _heightOffset,
+	u32& _stride)
 {
-	const graphics::FramebufferTextureFormats & fbTexFormat = gfxContext.getFramebufferTextureFormats();
-	GLenum colorFormat, colorType, colorFormatBytes;
-	if (_size > G_IM_SIZ_8b) {
-		colorFormat = GLenum(fbTexFormat.colorFormat);
-		colorType = GLenum(fbTexFormat.colorType);
-		colorFormatBytes = GLenum(fbTexFormat.colorFormatBytes);
-	} else {
-		colorFormat = GLenum(fbTexFormat.monochromeFormat);
-		colorType = GLenum(fbTexFormat.monochromeType);
-		colorFormatBytes = GLenum(fbTexFormat.monochromeFormatBytes);
-	}
+	GLenum format = GLenum(_params.colorFormat);
+	GLenum type = GLenum(_params.colorType);
 
 	// If Sync, read pixels from the buffer, copy them to RDRAM.
 	// If not Sync, read pixels from the buffer, copy pixels from the previous buffer to RDRAM.
-	if (!_sync) {
+	if (!_params.sync) {
 		m_curIndex ^= 1;
 		const u32 nextIndex = m_curIndex ^ 1;
 		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[m_curIndex]));
-		glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
+		glReadPixels(_params.x0, _params.y0, m_pTexture->realWidth, _params.height, format, type, 0);
 		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[nextIndex]));
 	} else {
 		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[_numPBO -1]));
-		glReadPixels(_x0, _y0, m_pTexture->realWidth, _height, colorFormat, colorType, 0);
+		glReadPixels(_params.x0, _params.y0, m_pTexture->realWidth, _params.height, format, type, 0);
 	}
 
-	GLubyte* pixelData = (GLubyte*)glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, m_pTexture->realWidth * _height * colorFormatBytes, GL_MAP_READ_BIT);
-	if (pixelData == nullptr)
-		return nullptr;
+	_heightOffset = 0;
+	_stride = m_pTexture->realWidth;
 
-	int widthBytes = _width*colorFormatBytes;
-	int strideBytes = m_pTexture->realWidth * colorFormatBytes;
-
-	u8 * pixelDataAlloc = m_pixelData.data();
-	for (unsigned int lnIndex = 0; lnIndex < _height; ++lnIndex) {
-		memcpy(pixelDataAlloc + lnIndex*widthBytes, pixelData + (lnIndex*strideBytes), widthBytes);
-	}
-	return pixelDataAlloc;
+	return reinterpret_cast<u8*>(glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0,
+		m_pTexture->realWidth * _params.height * _params.colorFormatBytes, GL_MAP_READ_BIT));
 }
 
 void ColorBufferReaderWithPixelBuffer::cleanUp()

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithPixelBuffer.h
@@ -12,7 +12,7 @@ public:
 			CachedBindBuffer * _bindBuffer);
 	~ColorBufferReaderWithPixelBuffer();
 
-	u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) override;
+	const u8 * _readPixels(const ReadColorBufferParams& _params, u32& _heightOffset, u32& _stride) override;
 	void cleanUp() override;
 
 private:

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithReadPixels.h
@@ -11,7 +11,7 @@ public:
 	ColorBufferReaderWithReadPixels(CachedTexture * _pTexture);
 	~ColorBufferReaderWithReadPixels() = default;
 
-	u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync) override;
+	const u8 * _readPixels(const ReadColorBufferParams& _params, u32& _heightOffset, u32& _stride) override;
 	void cleanUp() override;
 };
 

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -2,6 +2,7 @@
 #include <Config.h>
 #include "opengl_Utils.h"
 #include "opengl_GLInfo.h"
+#include <regex>
 #ifdef EGL
 #include <EGL/egl.h>
 #endif
@@ -25,7 +26,10 @@ void GLInfo::init() {
 
 	LOG(LOG_VERBOSE, "OpenGL vendor: %s\n", glGetString(GL_VENDOR));
 	const GLubyte * strRenderer = glGetString(GL_RENDERER);
-	if (strstr((const char*)strRenderer, "Adreno") != nullptr)
+
+	if (std::regex_match((const char*)strRenderer, std::regex("Adreno.*5\\d\\d") ))
+		renderer = Renderer::Adreno500;
+	else if (strstr((const char*)strRenderer, "Adreno") != nullptr)
 		renderer = Renderer::Adreno;
 	else if (strstr((const char*)strRenderer, "VideoCore IV") != nullptr)
 		renderer = Renderer::VideoCore;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -4,6 +4,7 @@
 namespace opengl {
 
 enum class Renderer {
+	Adreno500,
 	Adreno,
 	VideoCore,
 	Intel,

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -78,6 +78,7 @@ MY_LOCAL_SRC_FILES :=                               \
     $(SRCDIR)/BufferCopy/DepthBufferToRDRAM.cpp     \
     $(SRCDIR)/BufferCopy/RDRAMtoColorBuffer.cpp     \
     $(SRCDIR)/Graphics/Context.cpp                  \
+    $(SRCDIR)/Graphics/ColorBufferReader.cpp        \
     $(SRCDIR)/Graphics/CombinerProgram.cpp          \
     $(SRCDIR)/Graphics/ObjectHandle.cpp             \
     $(SRCDIR)/Graphics/OpenGLContext/GLFunctions.cpp                               \


### PR DESCRIPTION
This is much faster when using devices with Adreno 500 series GPUs.

I still need to add support in RDRAMtoColorBuffer and TexrectDrawer. But it's good to get it out there early just in case you notice something wrong.

Edit: Nothing to do in TextrectDrawer. Nothing is copied from/to GPU memory directly.