### PR TITLE
Don't use hires textures with zero dimensions

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -764,7 +764,9 @@ bool TextureCache::_loadHiresBackground(CachedTexture *_pTexture)
 						tile_height, (unsigned short)(gSP.bgImage.format << 8 | gSP.bgImage.size),
 						bpl, paladdr);
 	GHQTexInfo ghqTexInfo;
-	if (txfilter_hirestex(_pTexture->crc, ricecrc, palette, &ghqTexInfo)) {
+	// TODO: fix problem with zero texture dimensions on GLideNHQ side.
+	if (txfilter_hirestex(_pTexture->crc, ricecrc, palette, &ghqTexInfo) &&
+			ghqTexInfo.width != 0 && ghqTexInfo.height != 0) {
 		ghqTexInfo.format = gfxContext.convertInternalTextureFormat(ghqTexInfo.format);
 		Context::InitTextureParams params;
 		params.handle = _pTexture->name;
@@ -950,7 +952,9 @@ bool TextureCache::_loadHiresTexture(u32 _tile, CachedTexture *_pTexture, u64 & 
 
 	_ricecrc = txfilter_checksum(addr, tile_width, tile_height, (unsigned short)(_pTexture->format << 8 | _pTexture->size), bpl, paladdr);
 	GHQTexInfo ghqTexInfo;
-	if (txfilter_hirestex(_pTexture->crc, _ricecrc, palette, &ghqTexInfo)) {
+	// TODO: fix problem with zero texture dimensions on GLideNHQ side.
+	if (txfilter_hirestex(_pTexture->crc, _ricecrc, palette, &ghqTexInfo) &&
+		ghqTexInfo.width != 0 && ghqTexInfo.height != 0) {
 		ghqTexInfo.format = gfxContext.convertInternalTextureFormat(ghqTexInfo.format);
 		Context::InitTextureParams params;
 		params.handle = _pTexture->name;


### PR DESCRIPTION
Fixes crash reported here: https://github.com/gonetz/GLideN64/issues/1478

It doesn't find the root cause though.