### PR TITLE
zero fill gDPTile in RDRAMtoColorBuffer

### DIFF
--- a/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -286,8 +286,7 @@ void RDRAMtoColorBuffer::copyFromRDRAM(u32 _address, bool _bCFB)
 	m_pTexture->offsetT = 0.0f;
 	textureCache().activateTexture(0, m_pTexture);
 
-	gDPTile tile0;
-	tile0.fuls = tile0.fult = 0.0f;
+	gDPTile tile0 = {0};
 	gDPTile * pTile0 = gSP.textureTile[0];
 	gSP.textureTile[0] = &tile0;
 


### PR DESCRIPTION
Fixes https://github.com/gonetz/GLideN64/issues/1498

Creating ```gDPTile tile0;``` without zeroing it out allows the structure to be filled with garbage. It seems that some compilers/platforms zero it out by default, but you can't expect that.