### PR TITLE
UI: Language drop down displays languages in foreign languages

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -314,7 +314,8 @@ void ConfigDialog::setIniPath(const QString & _strIniPath)
 		const bool bCurrent = locale == currentTranslation;
 		locale.truncate(locale.lastIndexOf('.')); // "TranslationExample_de"
 		locale.remove(0, locale.indexOf('_') + 1); // "de"
-		QString language = QLocale::languageToString(QLocale(locale).language());
+		QString language = QLocale(locale).nativeLanguageName();
+		language = language.left(1).toUpper() + language.remove(0, 1);
 		if (bCurrent) {
 			listIndex = i + 1;
 		}


### PR DESCRIPTION
Having them display always in English doesn't make sense for someone looking for their language. A simple change:

![image](https://user-images.githubusercontent.com/9537912/27112060-b0c98424-5071-11e7-9a03-29a42caf22e3.png)
