### PR TITLE
Add COMMON_LDFLAGS to Android makefiles

### DIFF
--- a/src/GLideNHQ/mupen64plus-video-glidenhq.mk
+++ b/src/GLideNHQ/mupen64plus-video-glidenhq.mk
@@ -43,6 +43,7 @@ LOCAL_CFLAGS :=         \
     #-DSDL_NO_COMPAT     \
 
 LOCAL_CPPFLAGS := $(COMMON_CPPFLAGS) -std=c++11 -fexceptions
+LOCAL_LDFLAGS := $(COMMON_LDFLAGS)
 LOCAL_LDLIBS := -llog
 
 include $(BUILD_SHARED_LIBRARY)

--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -123,7 +123,7 @@ MY_LOCAL_CFLAGS :=      \
 
 MY_LOCAL_CPPFLAGS := $(COMMON_CPPFLAGS) -std=c++11 -g
 
-MY_LOCAL_LDFLAGS := -Wl,-version-script,$(LOCAL_PATH)/$(SRCDIR)/mupenplus/video_api_export.ver
+MY_LOCAL_LDFLAGS := $(COMMON_LDFLAGS) -Wl,-version-script,$(LOCAL_PATH)/$(SRCDIR)/mupenplus/video_api_export.ver
 
 MY_LOCAL_LDLIBS := -llog -latomic -lEGL
 

--- a/src/osal/mupen64plus-video-osal.mk
+++ b/src/osal/mupen64plus-video-osal.mk
@@ -23,5 +23,6 @@ LOCAL_CFLAGS :=         \
     #-DSDL_NO_COMPAT     \
 
 LOCAL_CPPFLAGS := $(COMMON_CPPFLAGS) -std=c++11 -g -fexceptions
+LOCAL_LDFLAGS := $(COMMON_LDFLAGS)
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Just a minor change that happened in mupen64plus-ae (https://github.com/mupen64plus-ae/mupen64plus-ae/pull/637)