### PR TITLE
CMake: fix 'UNIX build requires MUPENPLUSAPI' message

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,9 +134,9 @@ if(MUPENPLUSAPI)
   )
   set(GLideN64_DLL_NAME mupen64plus-video-GLideN64)
 else(MUPENPLUSAPI)
-  if(NOT UNIX)
-	message(ERROR "UNIX build requires MUPENPLUSAPI!")
-  endif(NOT UNIX)
+  if(UNIX)
+    message(FATAL_ERROR "UNIX build requires MUPENPLUSAPI!")
+  endif(UNIX)
   set(GLideN64_SOURCES_WIN
 	ZilmarPluginAPI.cpp
 	windows/Config_windows.cpp


### PR DESCRIPTION
Since GitHub wasn't updating #1530 for some reason.