### PR TITLE
Fix memory corruption in Banjo-Tooie

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -152,7 +152,7 @@ bool ColorBufferToRDRAM::_prepareCopy(u32 _startAddress)
 
 	if(m_pTexture == nullptr ||
 		m_pTexture->realWidth != _getRealWidth(pBuffer->m_width) ||
-		m_pTexture->realHeight != VI_GetMaxBufferHeight(m_lastBufferWidth))
+		m_pTexture->realHeight != VI_GetMaxBufferHeight(_getRealWidth(pBuffer->m_width)))
 	{
 		_destroyFBTexure();
 

--- a/src/Graphics/ColorBufferReader.h
+++ b/src/Graphics/ColorBufferReader.h
@@ -32,7 +32,7 @@ protected:
 
 private:
 	const u8* _convertFloatTextureBuffer(const u8* _gpuData, u32 _width, u32 _height, u32 _heightOffset, u32 _stride);
-	const u8* _convertIntegerTextureBuffer(const u8* _gpuData, u32 _width, u32 _height,u32 _heightOffset, u32 _stride);
+	const u8* _convertIntegerTextureBuffer(const u8* _gpuData, u32 _width, u32 _height,u32 _heightOffset, u32 _stride, u32 _colorsPerPixel);
 	virtual const u8 * _readPixels(const ReadColorBufferParams& _params, u32& _heightOffset, u32& _stride) = 0;
 };
 

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -626,10 +626,14 @@ void gDPLoadTLUT( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt )
 		DebugMsg(DEBUG_NORMAL | DEBUG_ERROR, "gDPLoadTLUT wrong tile tmem addr: tile[%d].tmem=%04x;\n", tile, gDP.tiles[tile].tmem);
 		return;
 	}
-	const u16 count = (u16)((gDP.tiles[tile].lrs - gDP.tiles[tile].uls + 1) * (gDP.tiles[tile].lrt - gDP.tiles[tile].ult + 1));
+	u16 count = (u16)((gDP.tiles[tile].lrs - gDP.tiles[tile].uls + 1) * (gDP.tiles[tile].lrt - gDP.tiles[tile].ult + 1));
 	u32 address = gDP.textureImage.address + gDP.tiles[tile].ult * gDP.textureImage.bpl + (gDP.tiles[tile].uls << gDP.textureImage.size >> 1);
 	u16 pal = (u16)((gDP.tiles[tile].tmem - 256) >> 4);
 	u16 *dest = (u16*)&TMEM[gDP.tiles[tile].tmem];
+	
+	// Workaround for possible game/emulator bug (see bug #1250)
+	if (pal != 0)
+		count = 16;
 
 	int i = 0;
 	while (i < count) {


### PR DESCRIPTION
This fixes memory corruption in Banjo-Tooie in the case of the attached save state for mupen64plus

[grogged.zip](https://github.com/gonetz/GLideN64/files/1219533/grogged.zip)

Just walk forward to reproduce the issue.
