### PR TITLE
Have mupen64plus maintain resolution in fullscreen mode

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -177,25 +177,14 @@ bool ColorBufferToRDRAM::_prepareCopy(u32 _startAddress)
 	}
 
 	if (m_pCurFrameBuffer->m_scale != 1.0f) {
-		u32 x0 = 0;
-		u32 width;
-		if (config.frameBufferEmulation.nativeResFactor == 0) {
-			const u32 screenWidth = wnd.getWidth();
-			width = screenWidth;
-			if (wnd.isAdjustScreen()) {
-				width = static_cast<u32>(screenWidth*wnd.getAdjustScale());
-				x0 = (screenWidth - width) / 2;
-			}
-		} else {
-			width = m_pCurFrameBuffer->m_pTexture->realWidth;
-		}
+		u32 width = m_pCurFrameBuffer->m_pTexture->realWidth;
 		u32 height = (u32)(bufferHeight * m_pCurFrameBuffer->m_scale);
 
 		CachedTexture * pInputTexture = m_pCurFrameBuffer->m_pTexture;
 		GraphicsDrawer::BlitOrCopyRectParams blitParams;
-		blitParams.srcX0 = x0;
+		blitParams.srcX0 = 0;
 		blitParams.srcY0 = 0;
-		blitParams.srcX1 = x0 + width;
+		blitParams.srcX1 = width;
 		blitParams.srcY1 = height;
 		blitParams.srcWidth = pInputTexture->realWidth;
 		blitParams.srcHeight = pInputTexture->realHeight;

--- a/src/DisplayWindow.cpp
+++ b/src/DisplayWindow.cpp
@@ -87,8 +87,21 @@ void DisplayWindow::updateScale()
 {
 	if (VI.width == 0 || VI.height == 0)
 		return;
-	m_scaleX = m_width / (float)VI.width;
-	m_scaleY = m_height / (float)VI.height;
+	u32 width, height;
+#ifdef MUPENPLUSAPI
+	if (m_bFullscreen)
+	{
+		width = config.video.windowedWidth;
+		height = config.video.windowedHeight;
+	}
+	else
+#endif
+	{
+		width = m_width;
+		height = m_height;
+	}
+	m_scaleX = width / (float)VI.width;
+	m_scaleY = height / (float)VI.height;
 }
 
 void DisplayWindow::_setBufferSize()

--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -78,6 +78,8 @@ bool DisplayWindowMupen64plus::_start()
 	m_screenHeight = config.video.windowedHeight;
 	_getDisplaySize();
 	_setBufferSize();
+	config.video.windowedWidth = m_width;
+	config.video.windowedHeight = m_height;
 
 	printf("(II) Setting video mode %dx%d...\n", m_screenWidth, m_screenHeight);
 	const m64p_video_flags flags = M64VIDEOFLAG_SUPPORT_RESIZING;
@@ -128,7 +130,6 @@ bool DisplayWindowMupen64plus::_resizeWindow()
 {
 	_setAttributes();
 
-	m_bFullscreen = false;
 	m_width = m_screenWidth = m_resizeWidth;
 	m_height = m_screenHeight = m_resizeHeight;
 	if (CoreVideo_ResizeWindow(m_screenWidth, m_screenHeight) != M64ERR_SUCCESS) {
@@ -145,6 +146,7 @@ bool DisplayWindowMupen64plus::_resizeWindow()
 
 void DisplayWindowMupen64plus::_changeWindow()
 {
+	m_bFullscreen = !m_bFullscreen;
 	CoreVideo_ToggleFullScreen();
 }
 


### PR DESCRIPTION
This is mostly a suggestion/hope for some discussion.

Right now the default is to start at 640x480, windowed mode.

I get complaints from people sometimes that "performance is bad", and what is happening is that they put it into fullscreen, and thus it starts rendering at their monitor resolution, which might be quite high.

I think this would be a better default for most people, making the graphics look decent by default, while also allowing people to use fullscreen without having to mess with any settings to get decent performance.