### PR TITLE
Enable IPO/LTO for release build in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.6)
 
+if ((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))
+  cmake_policy(SET CMP0069 NEW)
+endif()
+
 option(EGL "Set to ON if targeting an EGL device" ${EGL})
 option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})
 option(MUPENPLUSAPI "Set to ON for Mupen64Plus plugin" ${MUPENPLUSAPI})
@@ -305,11 +309,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQ
     message("Found compiler version " ${G++_VERSION})
     message(SEND_ERROR "You need at least Clang 3.3 to compile GLideN64!")
   endif()
-#  SET(GCC_CPP11_COMPILE_FLAGS "-std=c++0x -static-libgcc")
-  SET(GCC_CPP11_COMPILE_FLAGS "-std=c++0x")
+  SET(GCC_CPP11_COMPILE_FLAGS "-std=c++11")
   SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_CPP11_COMPILE_FLAGS}" )
   SET(GCC_STATIC_LINK_FLAGS "-static-libgcc")
-  SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_STATIC_LINK_FLAGS}" )
+  SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} ${GCC_STATIC_LINK_FLAGS}" )
 endif()
 
 add_library( ${GLideN64_DLL_NAME} SHARED ${GLideN64_SOURCES})
@@ -339,6 +342,15 @@ if( CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 if( CMAKE_BUILD_TYPE STREQUAL "Release")
+  if ((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT result)
+    if(result)
+      message("Interprocedural optimizations enabled")
+      set_property(TARGET ${GLideN64_DLL_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
+  endif()
+
   SET_TARGET_PROPERTIES(
 	${GLideN64_DLL_NAME}
 	PROPERTIES

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -27,7 +27,7 @@ void GLInfo::init() {
 	LOG(LOG_VERBOSE, "OpenGL vendor: %s\n", glGetString(GL_VENDOR));
 	const GLubyte * strRenderer = glGetString(GL_RENDERER);
 
-	if (std::regex_match((const char*)strRenderer, std::regex("Adreno.*5\\d\\d") ))
+	if (std::regex_match(std::string((const char*)strRenderer), std::regex("Adreno.*5\\d\\d") ))
 		renderer = Renderer::Adreno500;
 	else if (strstr((const char*)strRenderer, "Adreno") != nullptr)
 		renderer = Renderer::Adreno;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <cwchar>
 #include "Log.h"
 #include "PluginAPI.h"
 #include "wst.h"

--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -1,9 +1,6 @@
 #ifndef COMMONPLUGINAPI_H
 #define COMMONPLUGINAPI_H
 
-#include <thread>
-#include <condition_variable>
-
 #ifdef MUPENPLUSAPI
 #include "m64p_plugin.h"
 #else
@@ -11,6 +8,11 @@
 #include "ZilmarGFX_1_3.h"
 #include "FrameBufferInfoAPI.h"
 #define RSPTHREAD
+#endif
+
+#ifdef RSPTHREAD
+#include <thread>
+#include <condition_variable>
 #endif
 
 class APICommand;

--- a/src/T3DUX.cpp
+++ b/src/T3DUX.cpp
@@ -8,7 +8,7 @@
 
 /******************T3DUX microcode*************************/
 
-struct T3DGlobState
+struct T3DUXGlobState
 {
 	u16 pad0;
 	u16 perspNorm;
@@ -28,7 +28,7 @@ struct T3DGlobState
 	u32 rdpCmds;
 };
 
-struct T3DState
+struct T3DUXState
 {
 	u32 renderState;	/* render state */
 
@@ -48,7 +48,7 @@ struct T3DState
 };
 
 
-struct T3DTriN
+struct T3DUXTriN
 {
 	u8	flag, v2, v1, v0; /* flag is which one for flat shade */
 	u8	pal, v2tex, v1tex, v0tex; /* indexes in texture coords list */
@@ -91,7 +91,7 @@ static
 void T3DUX_LoadGlobState(u32 pgstate)
 {
 	const u32 addr = RSP_SegmentToPhysical(pgstate);
-	T3DGlobState *gstate = (T3DGlobState*)&RDRAM[addr];
+	T3DUXGlobState *gstate = (T3DUXGlobState*)&RDRAM[addr];
 	const u32 w0 = gstate->othermode0;
 	const u32 w1 = gstate->othermode1;
 	gDPSetOtherMode( _SHIFTR( w0, 0, 24 ),	// mode0
@@ -108,7 +108,7 @@ void T3DUX_LoadGlobState(u32 pgstate)
 static
 void T3DUX_LoadObject(u32 pstate, u32 pvtx, u32 ptri, u32 pcol)
 {
-	T3DState *ostate = (T3DState*)&RDRAM[RSP_SegmentToPhysical(pstate)];
+	T3DUXState *ostate = (T3DUXState*)&RDRAM[RSP_SegmentToPhysical(pstate)];
 	// TODO: fix me
 	const u32 tile = 0;
 	gSP.texture.tile = tile;
@@ -123,7 +123,7 @@ void T3DUX_LoadObject(u32 pstate, u32 pvtx, u32 ptri, u32 pcol)
 					 w1 );					// mode1
 
 	if ((ostate->matrixFlag & 1) == 0) //load matrix
-		gSPForceMatrix(pstate + sizeof(T3DState));
+		gSPForceMatrix(pstate + sizeof(T3DUXState));
 
 	gSPClearGeometryMode(G_LIGHTING | G_FOG);
 	gSPSetGeometryMode(ostate->renderState | G_SHADING_SMOOTH | G_SHADE | G_ZBUFFER | G_CULL_BACK);
@@ -138,7 +138,7 @@ void T3DUX_LoadObject(u32 pstate, u32 pvtx, u32 ptri, u32 pcol)
 
 	GraphicsDrawer & drawer = dwnd().getDrawer();
 	const u32 coladdr = RSP_SegmentToPhysical(pcol);
-	const T3DTriN * tri = (const T3DTriN*)&RDRAM[RSP_SegmentToPhysical(ptri)];
+	const T3DUXTriN * tri = (const T3DUXTriN*)&RDRAM[RSP_SegmentToPhysical(ptri)];
 	u8 pal = _SHIFTR(t32uxSetTileW1, 20, 4);
 	t32uxSetTileW1 &= 0xFF0FFFFF;
 	const bool flatShading = (ostate->geommode & 0x0F) == 0;


### PR DESCRIPTION
The goal here is to be able to pass the ```-flto``` flag to cmake, which turns on Link Time Optimizations, although other flags could be passed as well.

This works for me, although I had to pass std::regex_match a std::string instead of a char array. I also had to rename some of the variables in T3DUX.cpp, since with -flto, it looks at the code as a whole, instead of each source file separately, and some of the variables in T3DUX.cpp conflict with T3D.cpp

Besides that there is just some minor cleanup/fixes in the CMake file (c++0x to c++11, CMAKE_EXE_LINKER_FLAGS to CMAKE_SHARED_LINKER_FLAGS)

Tested and working in Windows via MinGW and Linux via GCC