### PR TITLE
Init mupen64plus config at PluginStartup

### DIFF
--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -18,18 +18,19 @@ Config config;
 static
 const u32 uMegabyte = 1024U*1024U;
 
-static m64p_handle g_configVideoGeneral = nullptr;
-static m64p_handle g_configVideoGliden64 = nullptr;
+m64p_handle g_configVideoGeneral = nullptr;
+m64p_handle g_configVideoGliden64 = nullptr;
 
-static
 bool Config_SetDefault()
 {
 	if (ConfigOpenSection("Video-General", &g_configVideoGeneral) != M64ERR_SUCCESS) {
 		LOG(LOG_ERROR, "Unable to open Video-General configuration section");
+		g_configVideoGeneral = nullptr;
 		return false;
 	}
 	if (ConfigOpenSection("Video-GLideN64", &g_configVideoGliden64) != M64ERR_SUCCESS) {
 		LOG(LOG_ERROR, "Unable to open GLideN64 configuration section");
+		g_configVideoGliden64 = nullptr;
 		return false;
 	}
 
@@ -309,23 +310,8 @@ void Config_LoadCustomConfig()
 
 void Config_LoadConfig()
 {
-	const u32 hacks = config.generalEmulation.hacks;
-
-	if (!Config_SetDefault()) {
-		config.generalEmulation.hacks = hacks;
+	if (g_configVideoGeneral == nullptr || g_configVideoGliden64 == nullptr)
 		return;
-	}
-
-	config.version = ConfigGetParamInt(g_configVideoGliden64, "configVersion");
-	if (config.version != CONFIG_VERSION_CURRENT) {
-		m64p_error res = ConfigDeleteSection("Video-GLideN64");
-		assert(res == M64ERR_SUCCESS);
-		ConfigSaveFile();
-		if (!Config_SetDefault()) {
-			config.generalEmulation.hacks = hacks;
-			return;
-		}
-	}
 
 	config.video.fullscreen = ConfigGetParamBool(g_configVideoGeneral, "Fullscreen");
 	config.video.windowedWidth = ConfigGetParamInt(g_configVideoGeneral, "ScreenWidth");
@@ -429,5 +415,4 @@ void Config_LoadConfig()
 
 	if (config.generalEmulation.enableCustomSettings)
 		Config_LoadCustomConfig();
-	config.generalEmulation.hacks = hacks;
 }

--- a/src/mupenplus/GLideN64_mupenplus.h
+++ b/src/mupenplus/GLideN64_mupenplus.h
@@ -49,4 +49,8 @@ extern ptr_VidExt_GL_SwapBuffers        CoreVideo_GL_SwapBuffers;
 
 extern void(*renderCallback)(int);
 
+extern m64p_handle g_configVideoGeneral;
+extern m64p_handle g_configVideoGliden64;
+bool Config_SetDefault();
+
 #endif // GLIDEN64_MUPENPLUS_H

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -1,6 +1,7 @@
 #include "GLideN64_mupenplus.h"
 #include "../PluginAPI.h"
 #include "../GLideN64.h"
+#include "../Config.h"
 #include <DisplayWindow.h>
 
 #ifdef OS_WINDOWS
@@ -81,6 +82,14 @@ m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle)
 	CoreVideo_GL_GetAttribute = (ptr_VidExt_GL_GetAttribute) DLSYM(_CoreLibHandle, "VidExt_GL_GetAttribute");
 	CoreVideo_GL_SwapBuffers = (ptr_VidExt_GL_SwapBuffers) DLSYM(_CoreLibHandle, "VidExt_GL_SwapBuffers");
 
+	if (Config_SetDefault()) {
+		config.version = ConfigGetParamInt(g_configVideoGliden64, "configVersion");
+		if (config.version != CONFIG_VERSION_CURRENT) {
+			ConfigDeleteSection("Video-GLideN64");
+			ConfigSaveFile();
+			Config_SetDefault();
+		}
+	}
 	return M64ERR_SUCCESS;
 }
 


### PR DESCRIPTION
Right now, the configuration isn't populated until RomOpen. This means that the configuration isn't populated until the first game is played. Most mupen64plus plugins (all that I know of), set the config defaults at PluginStartup. This way, in a GUI frontend, the configuration can be populated before a user plays their first game.