### PR TITLE
Optimize 3point shader

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -1478,15 +1478,11 @@ public:
 					"#define TEX_OFFSET(off) texture2D(tex, texCoord - (off)/texSize)			\n"
 					"lowp vec4 filter3point(in sampler2D tex, in mediump vec2 texCoord)			\n"
 					"{																			\n"
-#ifndef VC
-					"  mediump vec2 texSize = uTextureSize[nCurrentTile];						\n"
-#else
 					"  mediump vec2 texSize;													\n"
 					"  if (nCurrentTile == 0)													\n"
 					"    texSize = uTextureSize[0];												\n"
 					"  else																		\n"
 					"    texSize = uTextureSize[1];												\n"
-#endif
 					"  mediump vec2 offset = fract(texCoord*texSize - vec2(0.5));	\n"
 					"  offset -= step(1.0, offset.x + offset.y);								\n"
 					"  lowp vec4 c0 = TEX_OFFSET(offset);										\n"


### PR DESCRIPTION
We recently discovered that variable indexing can be extremely resource intensive. This #ifdef was added for the same reason. Given what we've discovered, I believe it's probably best to use the if/else version