### PR TITLE
Fix sprite sizes

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -2275,12 +2275,8 @@ struct ObjCoordinates
 
 		ulx = frameX;
 		uly = frameY;
-		lrx = frameX + min(imageW/scaleW, frameW) - 1.0f;
-		lry = frameY + min(imageH/scaleH, frameH) - 1.0f;
-		if (gDP.otherMode.cycleType == G_CYC_COPY) {
-			lrx += 1.0f;
-			lry += 1.0f;;
-		}
+		lrx = frameX + min(imageW/scaleW, frameW);
+		lry = frameY + min(imageH/scaleH, frameH);
 
 		uls = imageX;
 		ult = imageY;

--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -2280,8 +2280,8 @@ struct ObjCoordinates
 
 		uls = imageX;
 		ult = imageY;
-		lrs = uls + (lrx - ulx) * scaleW;
-		lrt = ult + (lry - uly) * scaleH;
+		lrs = uls + (lrx - ulx -1) * scaleW;
+		lrt = ult + (lry - uly -1) * scaleH;
 		if (gDP.otherMode.cycleType != G_CYC_COPY) {
 			if ((gSP.objRendermode&G_OBJRM_SHRINKSIZE_1) != 0) {
 				lrs -= 1.0f / scaleW;


### PR DESCRIPTION
HLE sprite sizes were 1pixel smaller than LLE sprite sizes when not in copy mode.
Fixes https://github.com/gonetz/GLideN64/issues/936

Edit: I made a mistake while testing yesterday. A second commit was necessary.