### PR TITLE
Remove majora hack when interlaced mode changes.

### DIFF
--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -84,7 +84,7 @@ void VI_UpdateSize()
 	FrameBufferList & fbList = frameBufferList();
 	FrameBuffer * pBuffer = fbList.findBuffer(VI.lastOrigin);
 	DepthBuffer * pDepthBuffer = pBuffer != nullptr ? pBuffer->m_pDepthBuffer : nullptr;
-	if (config.frameBufferEmulation.enable && ((config.generalEmulation.hacks & hack_ZeldaMM) == 0) &&
+	if (config.frameBufferEmulation.enable &&
 		((interlacedPrev != VI.interlaced) ||
 		(VI.width > 0 && VI.width != VI.widthPrev) ||
 		(!VI.interlaced && pDepthBuffer != nullptr && pDepthBuffer->m_width != VI.width)


### PR DESCRIPTION
The hack is currently breaking the bomber's notebook. Specifically, when we are attaching depth buffers to color buffers, the texture sizes are not matching up which is causing GL errors and graphical issues (at least in GLES 3.0).

Here is a save state, just push start then the A button, then B to exit the notebook to see the issues:

[bombers_notebook.zip](https://github.com/gonetz/GLideN64/files/1346107/bombers_notebook.zip)
