### PR TITLE
Add support for SP_STATUS_REG and RDRAM_SIZE in mupen64plus API

### DIFF
--- a/src/MupenPlusPluginAPI.cpp
+++ b/src/MupenPlusPluginAPI.cpp
@@ -1,10 +1,15 @@
 #include "PluginAPI.h"
 #include "Types.h"
+#include "mupenplus/GLideN64_mupenplus.h"
+#include "N64.h"
 
 extern "C" {
 
 EXPORT int CALL RomOpen(void)
 {
+	if (rdram_size != nullptr)
+		RDRAMSize = *rdram_size - 1;
+
 	api().RomOpen();
 	return 1;
 }
@@ -43,7 +48,7 @@ EXPORT void CALL SetRenderingCallback(void (*callback)(int))
 {
 	api().SetRenderingCallback(callback);
 }
-	
+
 EXPORT void CALL ResizeVideoOutput(int width, int height)
 {
 	api().ResizeVideoOutput(width, height);

--- a/src/N64.cpp
+++ b/src/N64.cpp
@@ -6,7 +6,7 @@ u8 *IMEM;
 u64 TMEM[512];
 u8 *RDRAM;
 
-u32 RDRAMSize;
+u32 RDRAMSize = 0;
 
 N64Regs REG;
 

--- a/src/N64.h
+++ b/src/N64.h
@@ -32,6 +32,8 @@ struct N64Regs
 	u32 *VI_V_BURST;
 	u32 *VI_X_SCALE;
 	u32 *VI_Y_SCALE;
+
+	u32 *SP_STATUS;
 };
 
 extern N64Regs REG;

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -219,24 +219,26 @@ void setDepthClearColor()
 
 void RSP_Init()
 {
+	if (RDRAMSize == 0) {
 #ifdef OS_WINDOWS
-	// Calculate RDRAM size by intentionally causing an access violation
-	u32 test;
-	try
-	{
-		test = RDRAM[0x007FFFFF] + 1;
-	}
-	catch (...)
-	{
-		test = 0;
-	}
-	if (test > 0)
-		RDRAMSize = 0x7FFFFF;
-	else
-		RDRAMSize = 0x3FFFFF;
+		// Calculate RDRAM size by intentionally causing an access violation
+		u32 test;
+		try
+		{
+			test = RDRAM[0x007FFFFF] + 1;
+		}
+		catch (...)
+		{
+			test = 0;
+		}
+		if (test > 0)
+			RDRAMSize = 0x7FFFFF;
+		else
+			RDRAMSize = 0x3FFFFF;
 #else // OS_WINDOWS
-	RDRAMSize = 1024 * 1024 * 8 - 1;
+		RDRAMSize = 1024 * 1024 * 8 - 1;
 #endif // OS_WINDOWS
+	}
 
 	RSP.uc_start = RSP.uc_dstart = 0;
 	RSP.bLLE = false;

--- a/src/common/CommonAPIImpl_common.cpp
+++ b/src/common/CommonAPIImpl_common.cpp
@@ -253,6 +253,8 @@ void PluginAPI::_initiateGFX(const GFX_INFO & _gfxInfo) const {
 	REG.VI_Y_SCALE = _gfxInfo.VI_Y_SCALE_REG;
 
 	CheckInterrupts = _gfxInfo.CheckInterrupts;
+
+	REG.SP_STATUS = nullptr;
 }
 
 void PluginAPI::ChangeWindow()

--- a/src/inc/m64p_plugin.h
+++ b/src/inc/m64p_plugin.h
@@ -103,6 +103,19 @@ typedef struct {
     unsigned int * VI_Y_SCALE_REG;
 
     void (*CheckInterrupts)(void);
+
+    /* The GFX_INFO.version parameter was added in version 2.5.1 of the core.
+       Plugins should ensure the core is at least this version before
+       attempting to read GFX_INFO.version. */
+    unsigned int version;
+    /* SP_STATUS_REG and RDRAM_SIZE were added in version 2 of GFX_INFO.version.
+       Plugins should only attempt to read these values if GFX_INFO.version is at least 2. */
+
+    /* The RSP plugin should set (HALT | BROKE | TASKDONE) *before* calling ProcessDList.
+       It should not modify SP_STATUS_REG after ProcessDList has returned.
+       This will allow the GFX plugin to unset these bits if it needs. */
+    unsigned int * SP_STATUS_REG;
+    const unsigned int * RDRAM_SIZE;
 } GFX_INFO;
 
 typedef struct {

--- a/src/mupenplus/CommonAPIImpl_mupenplus.cpp
+++ b/src/mupenplus/CommonAPIImpl_mupenplus.cpp
@@ -15,6 +15,16 @@ int PluginAPI::InitiateGFX(const GFX_INFO & _gfxInfo)
 {
 	_initiateGFX(_gfxInfo);
 
+	int core_version;
+	unsigned int gfx_info_version = 1;
+	CoreGetVersion(NULL, &core_version, NULL, NULL, NULL);
+	if (core_version >= 0x020501)
+		gfx_info_version = _gfxInfo.version;
+	if (gfx_info_version >= 2) {
+		REG.SP_STATUS = _gfxInfo.SP_STATUS_REG;
+		rdram_size = _gfxInfo.RDRAM_SIZE;
+	}
+
 	return TRUE;
 }
 

--- a/src/mupenplus/GLideN64_mupenplus.h
+++ b/src/mupenplus/GLideN64_mupenplus.h
@@ -1,6 +1,7 @@
 #ifndef GLIDEN64_MUPENPLUS_H
 #define GLIDEN64_MUPENPLUS_H
 
+#include "m64p_common.h"
 #include "m64p_config.h"
 #include "m64p_vidext.h"
 
@@ -46,6 +47,10 @@ extern ptr_VidExt_GL_GetProcAddress     CoreVideo_GL_GetProcAddress;
 extern ptr_VidExt_GL_SetAttribute       CoreVideo_GL_SetAttribute;
 extern ptr_VidExt_GL_GetAttribute       CoreVideo_GL_GetAttribute;
 extern ptr_VidExt_GL_SwapBuffers        CoreVideo_GL_SwapBuffers;
+
+extern ptr_PluginGetVersion             CoreGetVersion;
+
+extern const unsigned int* rdram_size;
 
 extern void(*renderCallback)(int);
 

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -44,6 +44,10 @@ ptr_VidExt_GL_SetAttribute       CoreVideo_GL_SetAttribute = nullptr;
 ptr_VidExt_GL_GetAttribute       CoreVideo_GL_GetAttribute = nullptr;
 ptr_VidExt_GL_SwapBuffers        CoreVideo_GL_SwapBuffers = nullptr;
 
+ptr_PluginGetVersion             CoreGetVersion = nullptr;
+
+const unsigned int* rdram_size = nullptr;
+
 void(*renderCallback)(int) = nullptr;
 
 m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle)
@@ -81,6 +85,8 @@ m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle)
 	CoreVideo_GL_SetAttribute = (ptr_VidExt_GL_SetAttribute) DLSYM(_CoreLibHandle, "VidExt_GL_SetAttribute");
 	CoreVideo_GL_GetAttribute = (ptr_VidExt_GL_GetAttribute) DLSYM(_CoreLibHandle, "VidExt_GL_GetAttribute");
 	CoreVideo_GL_SwapBuffers = (ptr_VidExt_GL_SwapBuffers) DLSYM(_CoreLibHandle, "VidExt_GL_SwapBuffers");
+
+	CoreGetVersion = (ptr_PluginGetVersion) DLSYM(_CoreLibHandle, "PluginGetVersion");
 
 	if (Config_SetDefault()) {
 		config.version = ConfigGetParamInt(g_configVideoGliden64, "configVersion");


### PR DESCRIPTION
The mupen64plus API recently gained support for passing SP_STATUS_REG and the RDRAM's size to the GFX plugin.

This (SP_STATUS) should hopefully be enough to properly implement the ucodes for WDC, Stunt Racer, and Gauntlet Legends.

Right now, the RSP plugins set the ```HALT | BROKE | TASKDONE``` bits of SP_STATUS after ProcessDList returns. I am going to modify the RSP plugin to set ```HALT | BROKE | TASKDONE``` before ProcessDList is called, and then the GFX plugin can unset those bits if it needs.

@Gillou68310 @olivieryuyu

EDIT: As should be obvious, GLideN64 will need to make sure SP_STATUS isn't ```nullptr``` before trying to use it when those ucodes are implemented