### PR TITLE
Raspberry Pi: fix vendor library names & add override

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 option(EGL "Set to ON if targeting an EGL device" ${EGL})
 option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})
 option(MUPENPLUSAPI "Set to ON for Mupen64Plus plugin" ${MUPENPLUSAPI})
+option(MESA "Set to ON to disable Raspberry Pi autodetection" ${MESA})
 
 project( GLideN64 )
 
@@ -103,10 +104,11 @@ set(GLideN64_SOURCES
 )
 
 #check if we're running on Raspberry Pi
-if(EXISTS "/opt/vc/include/bcm_host.h")
+if(EXISTS "/opt/vc/include/bcm_host.h" AND NOT MESA)
   message("bcm_host.h found")
   set(BCMHOST ON)
   set(EGL ON)
+  set(EGL_LIB -lbrcmEGL)
   add_definitions(
     -DVC
   )
@@ -120,7 +122,9 @@ if(EXISTS "/opt/vc/include/bcm_host.h")
     "/opt/vc/lib"
     "/opt/vc/lib/GL"
   )
-endif(EXISTS "/opt/vc/include/bcm_host.h")
+else(EXISTS "/opt/vc/include/bcm_host.h" AND NOT MESA)
+  set(EGL_LIB -lEGL)
+endif(EXISTS "/opt/vc/include/bcm_host.h" AND NOT MESA)
 
 if(MUPENPLUSAPI)
   add_definitions(
@@ -288,8 +292,8 @@ endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
 if(EGL)
   add_definitions(
     -DEGL
-   )
-   SET(OPENGL_LIBRARIES -lEGL)
+  )
+  SET(OPENGL_LIBRARIES ${EGL_LIB})
 else(EGL)
   find_package(OpenGL REQUIRED)
   include_directories(${OpenGL_INCLUDE_DIRS})

--- a/src/Graphics/OpenGLContext/GLFunctions.cpp
+++ b/src/Graphics/OpenGLContext/GLFunctions.cpp
@@ -189,7 +189,7 @@ PFNGLFLUSHMAPPEDBUFFERRANGEPROC g_glFlushMappedBufferRange;
 void initGLFunctions()
 {
 #ifdef VC
-	void *gles2so = dlopen("/opt/vc/lib/libGLESv2.so", RTLD_NOW);
+	void *gles2so = dlopen("/opt/vc/lib/libbrcmGLESv2.so", RTLD_NOW);
 #endif
 #ifdef OS_WINDOWS
 	GL_GET_PROC_ADR(PFNGLACTIVETEXTUREPROC, glActiveTexture);


### PR DESCRIPTION
* Use new libbrcmEGL/libbrcmGLESv2 names
* Allow RPI autodetection override via -DMESA=On (for VC4 driver)