### PR TITLE
Updated link to the WIP Builds 3 thread instead...

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ GLideN64
 
 A new generation, open-source graphics plugin for N64 emulators.
 
-Find WIP builds [here](https://github.com/gonetz/GLideN64/issues/1364). WIP
+Find WIP builds [here](https://github.com/gonetz/GLideN64/issues/1574). WIP
 builds have the latest features and fixes, and are generally stable, but may
 introduce bugs and have incomplete translations.


### PR DESCRIPTION
of the old WIP Builds 2 thread.

Don't want users to be directed to outdated and closed WIP build thread!