### PR TITLE
Fix flickering when rdram to color buffer is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Roms/
 *.user
 projects/msvc15/*db
 projects/msvc15/GeneratedFiles
+projects/msvc15/libGLideNHQ.dir
 projects/msvc12/*db
 projects/msvc12/GeneratedFiles
 src/Revision.h

--- a/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -251,7 +251,7 @@ void RDRAMtoColorBuffer::copyFromRDRAM(u32 _address, bool _bCFB)
 		}
 	}
 
-	if (bUseAlpha) {
+	if (bUseAlpha && config.frameBufferEmulation.copyToRDRAM == Config::ctDisable) {
 		u32 totalBytes = (width * height) << m_pCurBuffer->m_size >> 1;
 		if (address + totalBytes > RDRAMSize + 1)
 			totalBytes = RDRAMSize + 1 - address;


### PR DESCRIPTION
 I think clearing RDRAM only makes sense if we are not copying color buffer to RDRAM ourselves.

Without this, if copy color to RDRAM happens at 60 VI/s and copy color buffer to RDRAM happens at a lower rate, we get flickering in the screen. For example Mario Artist - Paint Studio.