### PR TITLE
Copy 4k block in FBInfo Chunk copies

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -310,7 +310,8 @@ void ColorBufferToRDRAM::copyChunkToRDRAM(u32 _address)
 {
 	if (!_prepareCopy(_address))
 		return;
-	_copy(_address, _address + 0x1000, true);
+	const u32 addr = _address & ~0xfff;
+	_copy(addr, addr + 0x1000, true);
 }
 
 

--- a/src/BufferCopy/DepthBufferToRDRAM.cpp
+++ b/src/BufferCopy/DepthBufferToRDRAM.cpp
@@ -299,6 +299,6 @@ bool DepthBufferToRDRAM::copyChunkToRDRAM(u32 _address)
 	if (!_prepareCopy(_address, true))
 		return false;
 
-	const u32 endAddress = _address + 0x1000;
-	return _copy(_address, endAddress);
+	const u32 addr = _address & ~0xfff;
+	return _copy(addr, addr + 0x1000);
 }


### PR DESCRIPTION
The spec says:
```
DLL should copy 4KB block content back to RDRAM frame buffer.
Emulator should not call this function again if other memory is read within the same 4KB range
```

Unfortunately the wording is a bit ambiguous. However, I read "4k block" as a 4k aligned block of memory, not ```address + 0x1000```

This is how mupen64 works, and mupen64plus as well. They are the only emulators that actually implement this 4k block checking (1964 never implemented it, it calls FBRead for each read). I think we should stick to this standard, since checking 4k blocks is much easier (can use bit shifting), rather than checking "address + 0x1000", which can't be checked using bit shifting.

I haven't looked too closely in the _copy() function, but it should be making sure that startAddress and endAddress are actually inside the FB, and trim the copy if they aren't. (with this change, startAddress might be outside the FB now)