### PR TITLE
Fix Pokemon Snap border flicker

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -5,6 +5,7 @@
 #include "WriteToRDRAM.h"
 
 #include <FrameBuffer.h>
+#include <FrameBufferInfo.h>
 #include <Config.h>
 #include <N64.h>
 #include <VI.h>
@@ -243,7 +244,7 @@ u32 ColorBufferToRDRAM::_RGBAtoRGBA32(u32 _c) {
 void ColorBufferToRDRAM::_copy(u32 _startAddress, u32 _endAddress, bool _sync)
 {
 	const u32 stride = m_pCurFrameBuffer->m_width << m_pCurFrameBuffer->m_size >> 1;
-	const u32 max_height = std::min((u32)VI_GetMaxBufferHeight(m_pCurFrameBuffer->m_width), cutHeight(_startAddress, m_pCurFrameBuffer->m_height, stride));
+	const u32 max_height = min((u32)VI_GetMaxBufferHeight(m_pCurFrameBuffer->m_width), cutHeight(_startAddress, m_pCurFrameBuffer->m_height, stride));
 
 	u32 numPixels = (_endAddress - _startAddress) >> (m_pCurFrameBuffer->m_size - 1);
 	if (numPixels / m_pCurFrameBuffer->m_width > max_height) {
@@ -255,7 +256,7 @@ void ColorBufferToRDRAM::_copy(u32 _startAddress, u32 _endAddress, bool _sync)
 	const s32 x0 = 0;
 	const s32 y0 = max_height - (_endAddress - m_pCurFrameBuffer->m_startAddress) / stride;
 	const u32 y1 = max_height - (_startAddress - m_pCurFrameBuffer->m_startAddress) / stride;
-	const u32 height = std::min(max_height, 1u + y1 - y0);
+	const u32 height = min(max_height, 1u + y1 - y0);
 
 	const u8* pPixels = m_bufferReader->readPixels(x0, y0, width, height, m_pCurFrameBuffer->m_size, _sync);
 	frameBufferList().setCurrentDrawBuffer();
@@ -265,16 +266,31 @@ void ColorBufferToRDRAM::_copy(u32 _startAddress, u32 _endAddress, bool _sync)
 	if (m_pCurFrameBuffer->m_size == G_IM_SIZ_32b) {
 		u32 *ptr_src = (u32*)pPixels;
 		u32 *ptr_dst = (u32*)(RDRAM + _startAddress);
+
+		if (!FBInfo::fbInfo.isSupported() && config.frameBufferEmulation.copyFromRDRAM != 0) {
+			memset(ptr_dst, 0, numPixels * 4);
+		}
+
 		writeToRdram<u32, u32>(ptr_src, ptr_dst, &ColorBufferToRDRAM::_RGBAtoRGBA32, 0, 0, width, height, numPixels, _startAddress, m_pCurFrameBuffer->m_startAddress, m_pCurFrameBuffer->m_size);
 	}
 	else if (m_pCurFrameBuffer->m_size == G_IM_SIZ_16b) {
 		u32 *ptr_src = (u32*)pPixels;
 		u16 *ptr_dst = (u16*)(RDRAM + _startAddress);
+
+		if (!FBInfo::fbInfo.isSupported() && config.frameBufferEmulation.copyFromRDRAM != 0) {
+			memset(ptr_dst, 0, numPixels * 2);
+		}
+
 		writeToRdram<u32, u16>(ptr_src, ptr_dst, &ColorBufferToRDRAM::_RGBAtoRGBA16, 0, 1, width, height, numPixels, _startAddress, m_pCurFrameBuffer->m_startAddress, m_pCurFrameBuffer->m_size);
 	}
 	else if (m_pCurFrameBuffer->m_size == G_IM_SIZ_8b) {
 		u8 *ptr_src = (u8*)pPixels;
 		u8 *ptr_dst = RDRAM + _startAddress;
+
+		if (!FBInfo::fbInfo.isSupported() && config.frameBufferEmulation.copyFromRDRAM != 0) {
+			memset(ptr_dst, 0, numPixels);
+		}
+
 		writeToRdram<u8, u8>(ptr_src, ptr_dst, &ColorBufferToRDRAM::_RGBAtoR8, 0, 3, width, height, numPixels, _startAddress, m_pCurFrameBuffer->m_startAddress, m_pCurFrameBuffer->m_size);
 	}
 


### PR DESCRIPTION
This flicker happens while zooming in to take  a picture while RDRAM to color buffer and color buffer to RDRAM are both enabled.

Also, for some reason I had to switch ```std::min``` to ```min``` after I included FrameBufferInfo.h