### PR TITLE
Fix chuck copy start address

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -308,10 +308,16 @@ void ColorBufferToRDRAM::copyToRDRAM(u32 _address, bool _sync)
 
 void ColorBufferToRDRAM::copyChunkToRDRAM(u32 _address)
 {
-	if (!_prepareCopy(_address))
+	FrameBuffer * pBuffer = frameBufferList().findBuffer(_address);
+	u32 startAddr = _address & ~0xfff;
+	u32 endAddr = startAddr + 0x1000;
+
+	if (startAddr < pBuffer->m_startAddress)
+		startAddr = pBuffer->m_startAddress;
+
+	if (!_prepareCopy(startAddr))
 		return;
-	const u32 addr = _address & ~0xfff;
-	_copy(addr, addr + 0x1000, true);
+	_copy(startAddr, endAddr, true);
 }
 
 

--- a/src/BufferCopy/DepthBufferToRDRAM.cpp
+++ b/src/BufferCopy/DepthBufferToRDRAM.cpp
@@ -296,9 +296,19 @@ bool DepthBufferToRDRAM::copyChunkToRDRAM(u32 _address)
 	if (!m_pbuf)
 		return false;
 
-	if (!_prepareCopy(_address, true))
+	FrameBuffer *pBuffer = frameBufferList().findBuffer(_address);
+	FrameBuffer *pDepthFrameBuffer = frameBufferList().findBuffer(pBuffer->m_pDepthBuffer->m_address);
+	if (pDepthFrameBuffer != nullptr)
+		pBuffer = pDepthFrameBuffer;
+
+	u32 startAddr = _address & ~0xfff;
+	u32 endAddr = startAddr + 0x1000;
+
+	if (startAddr < pBuffer->m_pDepthBuffer->m_address)
+		startAddr = pBuffer->m_pDepthBuffer->m_address;
+
+	if (!_prepareCopy(startAddr, true))
 		return false;
 
-	const u32 addr = _address & ~0xfff;
-	return _copy(addr, addr + 0x1000);
+	return _copy(startAddr, endAddr);
 }


### PR DESCRIPTION
This is a PR into the fbinfo_fixes branch.

This fixes the freezing in Prof. Oak's check. However, the images still look wrong in the thumbnail (when you look at an individual image they look correct, but the thumbnails are wrong, however the check still works).

The requested start address might be before the actual start of the framebuffer, so this accounts for that possibility.