### PR TITLE
Don't unset DP_STATUS_FREEZE

### DIFF
--- a/src/RDP.cpp
+++ b/src/RDP.cpp
@@ -554,7 +554,7 @@ inline u32 READ_RDP_DATA(u32 address)
 void RDP_ProcessRDPList()
 {
 	if (ConfigOpen || dwnd().isResizeWindow()) {
-		dp_status &= ~0x0002;
+		//dp_status &= ~0x0002;
 		dp_start = dp_current = dp_end;
 		gDPFullSync();
 		return;
@@ -562,7 +562,7 @@ void RDP_ProcessRDPList()
 
 	const u32 length = dp_end - dp_current;
 
-	dp_status &= ~0x0002;
+	//dp_status &= ~0x0002;
 
 	if (dp_end <= dp_current) return;
 


### PR DESCRIPTION
See the discussion here: https://github.com/ata4/angrylion-rdp-plus/pull/41

The emulator should be handling setting/unsetting this bit, not the GFX plugin