### PR TITLE
Add secondary shader keys to reduce in shader logic

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -284,7 +284,10 @@ void CombinerInfo::update()
 
 void CombinerInfo::setCombine(u64 _mux )
 {
-	const CombinerKey key(_mux);
+	CombinerKey key(_mux);
+	key.setBiLerp0(gDP.otherMode.bi_lerp0);
+	key.setBiLerp1(gDP.otherMode.bi_lerp1);
+
 	if (m_pCurrent != nullptr && m_pCurrent->getKey() == key) {
 		m_bChanged = false;
 		return;

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -7,6 +7,23 @@
 CombinerKey::CombinerKey(u64 _mux, bool _setModeBits)
 {
 	m_key.mux = _mux;
+	m_secondaryFlags.mux = 0;
+	if (!_setModeBits)
+		return;
+
+	// High byte of muxs0 is zero. We can use it for addtional combiner flags:
+	// [0 - 0] polygon type: 0 - triangle, 1 - rect
+	// [1 - 2] cycle type
+	u32 flags = CombinerInfo::get().isRectMode() ? 1U : 0U;
+	flags |= (gDP.otherMode.cycleType << 1);
+
+	m_key.muxs0 |= (flags << 24);
+}
+
+CombinerKey::CombinerKey(u64 _mux, u64 secondaryParams, bool _setModeBits)
+{
+	m_key.mux = _mux;
+	m_secondaryFlags.mux = secondaryParams;
 	if (!_setModeBits)
 		return;
 
@@ -22,26 +39,30 @@ CombinerKey::CombinerKey(u64 _mux, bool _setModeBits)
 CombinerKey::CombinerKey(const CombinerKey & _other)
 {
 	m_key.mux = _other.m_key.mux;
+	m_secondaryFlags = _other.m_secondaryFlags;
 }
 
 void CombinerKey::operator=(u64 _mux)
 {
 	m_key.mux = _mux;
+	m_secondaryFlags.mux = 0;
 }
 
 void CombinerKey::operator=(const CombinerKey & _other)
 {
 	m_key.mux = _other.m_key.mux;
+	m_secondaryFlags = _other.m_secondaryFlags;
 }
 
 bool CombinerKey::operator==(const CombinerKey & _other) const
 {
-	return m_key.mux == _other.m_key.mux;
+	return m_key.mux == _other.m_key.mux && m_secondaryFlags.mux == _other.m_secondaryFlags.mux;
 }
 
 bool CombinerKey::operator<(const CombinerKey & _other) const
 {
-	return m_key.mux < _other.m_key.mux;
+	return (m_key.mux < _other.m_key.mux) ||
+		(m_key.mux == _other.m_key.mux && m_secondaryFlags.mux < _other.m_secondaryFlags.mux);
 }
 
 u32 CombinerKey::getCycleType() const
@@ -54,6 +75,17 @@ bool CombinerKey::isRectKey() const
 	return ((m_key.muxs0 >> 24) & 1) != 0;
 }
 
+void CombinerKey::setBiLerp0(unsigned int _bilerp0)
+{
+	m_secondaryFlags.bi_lerp0 = _bilerp0;
+}
+
+void CombinerKey::setBiLerp1(unsigned int _bilerp1)
+{
+	m_secondaryFlags.bi_lerp1 = _bilerp1;
+}
+
 void CombinerKey::read(std::istream & _is) {
 	_is.read((char*)&m_key.mux, sizeof(m_key.mux));
+	_is.read((char*)&m_secondaryFlags.mux, sizeof(m_secondaryFlags.mux));
 }

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -3,11 +3,27 @@
 #include "gDP.h"
 
 class CombinerKey {
+
+	struct SecondaryShaderParams
+	{
+		union
+		{
+			struct
+			{
+				unsigned	bi_lerp0 : 1;
+				unsigned	bi_lerp1 : 1;
+			};
+
+			u64				mux;
+		};
+	};
+
 public:
 	CombinerKey() {
 		m_key.mux = 0;
 	}
 	explicit CombinerKey(u64 _mux, bool _setModeBits = true);
+	explicit CombinerKey(u64 _mux, u64 _secondaryFlags, bool _setModeBits = true);
 	CombinerKey(const CombinerKey & _other);
 
 	void operator=(u64 _mux);
@@ -22,8 +38,15 @@ public:
 
 	u64 getMux() const { return m_key.mux; }
 
+	u64 getSecondaryParams() const { return m_secondaryFlags.mux; }
+
+	void setBiLerp0(unsigned int _bilerp0);
+
+	void setBiLerp1(unsigned int _bilerp1);
+
 	void read(std::istream & _is);
 
 private:
 	gDPCombine m_key;
+	SecondaryShaderParams m_secondaryFlags;
 };

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -932,7 +932,6 @@ public:
 		if (!_glinfo.isGLES2) {
 			m_part =
 				"uniform lowp ivec2 uTextureFormat;									\n"
-				"uniform lowp ivec2 uBiLerp;										\n"
 				"uniform lowp ivec2 uTextureConvert;								\n"
 				"uniform mediump ivec4 uConvertParams;								\n"
 				"uniform lowp int uTextureFilterMode;								\n"
@@ -1014,7 +1013,6 @@ public:
 		} else {
 			m_part =
 				"uniform lowp ivec2 uTextureFormat;									\n"
-				"uniform lowp ivec2 uBiLerp;										\n"
 				"uniform lowp ivec2 uTextureConvert;								\n"
 				"uniform mediump ivec4 uConvertParams;								\n"
 				"uniform lowp int uTextureFilterMode;								\n"
@@ -1161,77 +1159,110 @@ public:
 class ShaderFragmentReadTex0 : public ShaderPart
 {
 public:
-	ShaderFragmentReadTex0(const opengl::GLInfo & _glinfo)
+	ShaderFragmentReadTex0(const opengl::GLInfo & _glinfo) : m_glinfo(_glinfo)
 	{
-		if (_glinfo.isGLES2) {
-			m_part =
-				"  nCurrentTile = 0; \n"
-				"  lowp vec4 readtex0;																\n"
-				"  if (uBiLerp[0] != 0)																\n"
-				"    readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);		\n"
-				"  else																				\n"
-				"    readtex0 = YUV_Convert(uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0);	\n"
-				;
-		} else {
+
+	}
+
+	void write(std::stringstream & shader) const override
+	{
+		std::string shaderPart;
+
+		if (m_glinfo.isGLES2) {
+			shaderPart = "  nCurrentTile = 0; \n";
+			if (gDP.otherMode.bi_lerp0 != 0) {
+				shaderPart += "  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);		\n";
+			}
+			else {
+				shaderPart += "  lowp vec4 readtex0 = YUV_Convert(uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0);	\n";
+			}
+
+		}
+		else {
 			if (config.video.multisampling > 0) {
-				m_part =
+				shaderPart =
 					"  lowp vec4 readtex0;																	\n"
-					"  if (uMSTexEnabled[0] == 0) {															\n"
-					"    if (uBiLerp[0] != 0)																\n"
-					"      READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n"
-					"    else																				\n"
-					"      YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)	\n"
-					"  } else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);\n"
-					;
-			} else {
-				m_part =
-					"  lowp vec4 readtex0;																\n"
-					"  if (uBiLerp[0] != 0)																\n"
-					"    READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n"
-					"  else																				\n"
-					"    YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)\n"
-					;
+					"  if (uMSTexEnabled[0] == 0) {															\n";
+
+				if (gDP.otherMode.bi_lerp0 != 0) {
+					shaderPart += "    READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n";
+				}
+				else {
+					shaderPart += "    YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)	\n";
+				}
+				shaderPart += "  } else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);\n";
+			}
+			else {
+				shaderPart = "  lowp vec4 readtex0;																	\n";
+				if (gDP.otherMode.bi_lerp0 != 0) {
+					shaderPart += "  READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n";
+				}
+				else {
+					shaderPart += "  YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)\n";
+				}
 			}
 		}
+
+		shader << shaderPart;
 	}
+
+	const opengl::GLInfo& m_glinfo;
 };
 
 class ShaderFragmentReadTex1 : public ShaderPart
 {
 public:
-	ShaderFragmentReadTex1(const opengl::GLInfo & _glinfo)
+	ShaderFragmentReadTex1(const opengl::GLInfo & _glinfo) : m_glinfo(_glinfo)
 	{
-		if (_glinfo.isGLES2) {
-			m_part =
-				"  nCurrentTile = 1; \n"
-				"  lowp vec4 readtex1;																\n"
-				"  if (uBiLerp[1] != 0)																\n"
-				"    readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);		\n"
-				"  else																				\n"
-				"    readtex1 = YUV_Convert(uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0);	\n"
-				;
-		} else {
+
+	}
+
+	void write(std::stringstream & shader) const override
+	{
+		std::string shaderPart;
+
+		if (m_glinfo.isGLES2) {
+			shaderPart = "  nCurrentTile = 1; \n";
+
+			if (gDP.otherMode.bi_lerp1 != 0) {
+				shaderPart += "  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);		\n";
+			}
+			else {
+				shaderPart += "  lowp vec4 readtex1 = YUV_Convert(uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0);	\n";
+			}
+
+		}
+		else {
 			if (config.video.multisampling > 0) {
-				m_part =
+				shaderPart =
 					"  lowp vec4 readtex1; \n"
-					"  if (uMSTexEnabled[1] == 0) {															\n"
-					"    if (uBiLerp[1] != 0)																\n"
-					"      READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n"
-					"    else																				\n"
-					"      YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)	\n"
-					"  } else readtex1 = readTexMS(uMSTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);\n"
-					;
-			} else {
-				m_part =
-					"  lowp vec4 readtex1; \n"
-					"  if (uBiLerp[1] != 0)																\n"
-					"    READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n"
-					"  else																				\n"
-					"    YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)\n"
-					;
+					"  if (uMSTexEnabled[1] == 0) {															\n";
+
+				if (gDP.otherMode.bi_lerp1 != 0) {
+					shaderPart += "    READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n";
+				}
+				else {
+					shaderPart += "    YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)	\n";
+				}
+
+				shaderPart += "  } else readtex1 = readTexMS(uMSTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);\n";
+			}
+			else {
+				shaderPart = "  lowp vec4 readtex1; \n";
+
+				if (gDP.otherMode.bi_lerp1 != 0) {
+					shaderPart += "  READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n";
+				}
+				else {
+					shaderPart += "  YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)\n";
+				}
 			}
 		}
+
+		shader << shaderPart;
 	}
+
+	const opengl::GLInfo& m_glinfo;
 };
 
 class ShaderFragmentCallN64Depth : public ShaderPart

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramImpl.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramImpl.cpp
@@ -93,15 +93,21 @@ bool CombinerProgramImpl::getBinaryForm(std::vector<char> & _buffer)
 		return false;
 
 	u64 key = m_key.getMux();
+	u64 secondaryParams = m_key.getSecondaryParams();
+
 	int inputs(m_inputs);
 
-	int totalSize = sizeof(key)+sizeof(inputs)+sizeof(binaryFormat)+
+	int totalSize = sizeof(key)+sizeof(secondaryParams)+sizeof(inputs)+sizeof(binaryFormat)+
 		sizeof(binaryLength)+binaryLength;
 	_buffer.resize(totalSize);
 
 	char* keyData = reinterpret_cast<char*>(&key);
 	std::copy_n(keyData, sizeof(key), _buffer.data());
 	int offset = sizeof(key);
+
+	char* secondaryParamData = reinterpret_cast<char*>(&secondaryParams);
+	std::copy_n(secondaryParamData, sizeof(secondaryParams), _buffer.data());
+	offset += sizeof(secondaryParams);
 
 	char* inputData = reinterpret_cast<char*>(&inputs);
 	std::copy_n(inputData, sizeof(inputs), _buffer.data() + offset);

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -456,7 +456,6 @@ public:
 	UTextureFetchMode(GLuint _program) {
 		LocateUniform(uTextureFilterMode);
 		LocateUniform(uTextureFormat);
-		LocateUniform(uBiLerp);
 		LocateUniform(uTextureConvert);
 		LocateUniform(uConvertParams);
 	}
@@ -467,7 +466,6 @@ public:
 		if ((gSP.objRendermode&G_OBJRM_BILERP) != 0)
 			textureFilter |= 2;
 		uTextureFilterMode.set(textureFilter, _force);
-		uBiLerp.set(gDP.otherMode.bi_lerp0, gDP.otherMode.bi_lerp1, _force);
 		uTextureFormat.set(gSP.textureTile[0]->format, gSP.textureTile[1]->format, _force);
 		uTextureConvert.set(0, gDP.otherMode.convert_one, _force);
 		if (gDP.otherMode.bi_lerp0 == 0 || gDP.otherMode.bi_lerp1 == 0)
@@ -477,7 +475,6 @@ public:
 private:
 	iUniform uTextureFilterMode;
 	iv2Uniform uTextureFormat;
-	iv2Uniform uBiLerp;
 	iv2Uniform uTextureConvert;
 	i4Uniform uConvertParams;
 };

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -74,8 +74,10 @@ bool ShaderStorage::_saveCombinerKeys(const graphics::Combiners & _combiners) co
 	std::vector<char> allShaderData;
 	std::vector<u64> keysData;
 	keysData.reserve(szCombiners);
-	for (auto cur = _combiners.begin(); cur != _combiners.end(); ++cur)
+	for (auto cur = _combiners.begin(); cur != _combiners.end(); ++cur) {
 		keysData.push_back(cur->first.getMux());
+		keysData.push_back(cur->first.getSecondaryParams());
+	}
 
 	std::sort(keysData.begin(), keysData.end());
 	keysOut << "0x" << std::hex << std::setfill('0') << std::setw(8) << m_keysFormatVersion << "\n";
@@ -147,7 +149,6 @@ bool ShaderStorage::saveShadersStorage(const graphics::Combiners & _combiners) c
 
 	u32 totalWritten = 0;
 	std::vector<char> allShaderData;
-	std::vector<u64> keysData;
 
 	const f32 percent = szCombiners / 100.0f;
 	const f32 step = 100.0f / szCombiners;
@@ -246,9 +247,13 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 	f32 progress = 0.0f;
 	f32 percents = percent;
 	u64 key;
+	u64 secondaryParams;
+
 	for (u32 i = 0; i < szCombiners; ++i) {
 		fin >> std::hex >> key;
-		graphics::CombinerProgram * pCombiner = Combiner_Compile(CombinerKey(key, false));
+		fin >> std::hex >> secondaryParams;
+
+		graphics::CombinerProgram * pCombiner = Combiner_Compile(CombinerKey(key, secondaryParams, false));
 		pCombiner->update(true);
 		_combiners[pCombiner->getKey()] = pCombiner;
 		progress += step;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -111,7 +111,7 @@ bool ShaderStorage::saveShadersStorage(const graphics::Combiners & _combiners) c
 		// Created shaders are obsolete due to changes in config, but we saved combiners keys.
 		return true;
 
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (!CombinerInfo::get().isShaderCacheSupported())
 		// Shaders storage is not supported, but we saved combiners keys.
 		return true;
 
@@ -267,7 +267,7 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 	if (opengl::Utils::isGLError())
 		return false;
 
-	if (gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (CombinerInfo::get().isShaderCacheSupported())
 		// Restore shaders storage
 		return saveShadersStorage(_combiners);
 
@@ -277,7 +277,7 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 
 bool ShaderStorage::loadShadersStorage(graphics::Combiners & _combiners)
 {
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (!CombinerInfo::get().isShaderCacheSupported())
 		// Shaders storage is not supported, load from combiners keys.
 		return _loadFromCombinerKeys(_combiners);
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x17U;
+		const u32 m_formatVersion = 0x18U;
 		const u32 m_keysFormatVersion = 0x03;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;


### PR DESCRIPTION
This is a test fix for https://github.com/gonetz/GLideN64/issues/1665

This approach can be taken to remove additional logic from shaders.

Shader storage hasn't been tested with this yet, so it may not work.