### PR TITLE
Further reduce shader logic

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -325,6 +325,12 @@ void CombinerInfo::setSecondaryParams(CombinerKey& _key)
 
 	//Render target
 	_key.setRenderTarget(gDP.colorImage.address == gDP.depthImageAddress ? gDP.otherMode.depthCompare + 1 : 0);
+
+	//Texture filter mode
+	unsigned int textureFilter = gDP.otherMode.textureFilter;
+	if ((gSP.objRendermode&G_OBJRM_BILERP) != 0)
+		textureFilter |= 2;
+	_key.setTextureFilter(textureFilter);
 }
 
 void CombinerInfo::setCombine(u64 _mux )

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -310,7 +310,18 @@ void CombinerInfo::setSecondaryParams(CombinerKey& _key)
 	}
 	_key.setCvgXAlpha(gDP.otherMode.cvgXAlpha);
 
+	//Alpha compare
 	_key.setAlphaCompareMode(gDP.otherMode.cycleType < G_CYC_COPY ? gDP.otherMode.alphaCompare : 0);
+
+	//Dither modes
+	if (gDP.otherMode.cycleType < G_CYC_COPY) {
+		_key.setAlphaDither(gDP.otherMode.alphaDither);
+		_key.setColorDither(gDP.otherMode.colorDither);
+	}
+	else {
+		_key.setAlphaDither(0);
+		_key.setColorDither(0);
+	}
 }
 
 void CombinerInfo::setCombine(u64 _mux )

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -322,6 +322,9 @@ void CombinerInfo::setSecondaryParams(CombinerKey& _key)
 		_key.setAlphaDither(0);
 		_key.setColorDither(0);
 	}
+
+	//Render target
+	_key.setRenderTarget(gDP.colorImage.address == gDP.depthImageAddress ? gDP.otherMode.depthCompare + 1 : 0);
 }
 
 void CombinerInfo::setCombine(u64 _mux )

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -284,7 +284,10 @@ void CombinerInfo::update()
 
 void CombinerInfo::setCombine(u64 _mux )
 {
-	const CombinerKey key(_mux);
+	CombinerKey key(_mux);
+	key.setBiLerp0(gDP.otherMode.bi_lerp0);
+	key.setBiLerp1(gDP.otherMode.bi_lerp1);
+
 	if (m_pCurrent != nullptr && m_pCurrent->getKey() == key) {
 		m_bChanged = false;
 		return;

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -289,27 +289,27 @@ void CombinerInfo::setSecondaryParams(CombinerKey& _key)
 	_key.setBiLerp1(gDP.otherMode.bi_lerp1);
 
 	//Alpha test
-	int enableAlphaTest = 0;
-
 	if (gDP.otherMode.cycleType == G_CYC_FILL) {
-		enableAlphaTest = 0;
+		_key.setEnableAlphaTest(0);
 	}
 	else if (gDP.otherMode.cycleType == G_CYC_COPY) {
 		if (gDP.otherMode.alphaCompare & G_AC_THRESHOLD) {
-			enableAlphaTest = 1;
+			_key.setAlphaCvgSel(0);
+			_key.setEnableAlphaTest(1);
 		}
 		else {
-			enableAlphaTest = 0;
+			_key.setEnableAlphaTest(0);
 		}
 	}
 	else if ((gDP.otherMode.alphaCompare & G_AC_THRESHOLD) != 0) {
-		enableAlphaTest = 1;
+		_key.setEnableAlphaTest(1);
+		_key.setAlphaCvgSel(gDP.otherMode.alphaCvgSel);
 	}
 	else {
-		enableAlphaTest = 0;
+		_key.setEnableAlphaTest(0);
 	}
+	_key.setCvgXAlpha(gDP.otherMode.cvgXAlpha);
 
-	_key.setEnableAlphaTest(enableAlphaTest);
 	_key.setAlphaCompareMode(gDP.otherMode.cycleType < G_CYC_COPY ? gDP.otherMode.alphaCompare : 0);
 }
 

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -282,12 +282,43 @@ void CombinerInfo::update()
 //	}
 }
 
+void CombinerInfo::setSecondaryParams(CombinerKey& _key)
+{
+	//Bilinear filtering
+	_key.setBiLerp0(gDP.otherMode.bi_lerp0);
+	_key.setBiLerp1(gDP.otherMode.bi_lerp1);
+
+	//Alpha test
+	int enableAlphaTest = 0;
+
+	if (gDP.otherMode.cycleType == G_CYC_FILL) {
+		enableAlphaTest = 0;
+	}
+	else if (gDP.otherMode.cycleType == G_CYC_COPY) {
+		if (gDP.otherMode.alphaCompare & G_AC_THRESHOLD) {
+			enableAlphaTest = 1;
+		}
+		else {
+			enableAlphaTest = 0;
+		}
+	}
+	else if ((gDP.otherMode.alphaCompare & G_AC_THRESHOLD) != 0) {
+		enableAlphaTest = 1;
+	}
+	else {
+		enableAlphaTest = 0;
+	}
+
+	_key.setEnableAlphaTest(enableAlphaTest);
+}
+
 void CombinerInfo::setCombine(u64 _mux )
 {
+	//Generate key
 	CombinerKey key(_mux);
-	key.setBiLerp0(gDP.otherMode.bi_lerp0);
-	key.setBiLerp1(gDP.otherMode.bi_lerp1);
+	setSecondaryParams(key);
 
+	//Search for the key
 	if (m_pCurrent != nullptr && m_pCurrent->getKey() == key) {
 		m_bChanged = false;
 		return;

--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -310,6 +310,7 @@ void CombinerInfo::setSecondaryParams(CombinerKey& _key)
 	}
 
 	_key.setEnableAlphaTest(enableAlphaTest);
+	_key.setAlphaCompareMode(gDP.otherMode.cycleType < G_CYC_COPY ? gDP.otherMode.alphaCompare : 0);
 }
 
 void CombinerInfo::setCombine(u64 _mux )

--- a/src/Combiner.h
+++ b/src/Combiner.h
@@ -122,6 +122,7 @@ public:
 	void init();
 	void destroy();
 	void update();
+	void setSecondaryParams(CombinerKey& _key);
 	void setCombine(u64 _mux);
 	void updateParameters();
 

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -85,6 +85,26 @@ void CombinerKey::setBiLerp1(unsigned int _bilerp1)
 	m_secondaryFlags.bi_lerp1 = _bilerp1;
 }
 
+void CombinerKey::setEnableAlphaTest(unsigned int _enableAlphaTest)
+{
+	m_secondaryFlags.enableAlphaTest = _enableAlphaTest;
+}
+
+unsigned int CombinerKey::getBiLerp0(void)
+{
+	return m_secondaryFlags.bi_lerp0;
+}
+
+unsigned int CombinerKey::getBiLerp1(void)
+{
+	return m_secondaryFlags.bi_lerp1;
+}
+
+unsigned int CombinerKey::getEnableAlphaTest(void)
+{
+	return m_secondaryFlags.enableAlphaTest;
+}
+
 void CombinerKey::read(std::istream & _is) {
 	_is.read((char*)&m_key.mux, sizeof(m_key.mux));
 	_is.read((char*)&m_secondaryFlags.mux, sizeof(m_secondaryFlags.mux));

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -7,6 +7,23 @@
 CombinerKey::CombinerKey(u64 _mux, bool _setModeBits)
 {
 	m_key.mux = _mux;
+	m_secondaryFlags.mux = 0;
+	if (!_setModeBits)
+		return;
+
+	// High byte of muxs0 is zero. We can use it for addtional combiner flags:
+	// [0 - 0] polygon type: 0 - triangle, 1 - rect
+	// [1 - 2] cycle type
+	u32 flags = CombinerInfo::get().isRectMode() ? 1U : 0U;
+	flags |= (gDP.otherMode.cycleType << 1);
+
+	m_key.muxs0 |= (flags << 24);
+}
+
+CombinerKey::CombinerKey(u64 _mux, u64 secondaryParams, bool _setModeBits)
+{
+	m_key.mux = _mux;
+	m_secondaryFlags.mux = secondaryParams;
 	if (!_setModeBits)
 		return;
 
@@ -22,26 +39,30 @@ CombinerKey::CombinerKey(u64 _mux, bool _setModeBits)
 CombinerKey::CombinerKey(const CombinerKey & _other)
 {
 	m_key.mux = _other.m_key.mux;
+	m_secondaryFlags = _other.m_secondaryFlags;
 }
 
 void CombinerKey::operator=(u64 _mux)
 {
 	m_key.mux = _mux;
+	m_secondaryFlags.mux = 0;
 }
 
 void CombinerKey::operator=(const CombinerKey & _other)
 {
 	m_key.mux = _other.m_key.mux;
+	m_secondaryFlags = _other.m_secondaryFlags;
 }
 
 bool CombinerKey::operator==(const CombinerKey & _other) const
 {
-	return m_key.mux == _other.m_key.mux;
+	return m_key.mux == _other.m_key.mux && m_secondaryFlags.mux == _other.m_secondaryFlags.mux;
 }
 
 bool CombinerKey::operator<(const CombinerKey & _other) const
 {
-	return m_key.mux < _other.m_key.mux;
+	return (m_key.mux < _other.m_key.mux) ||
+		(m_key.mux == _other.m_key.mux && m_secondaryFlags.mux < _other.m_secondaryFlags.mux);
 }
 
 u32 CombinerKey::getCycleType() const
@@ -54,6 +75,17 @@ bool CombinerKey::isRectKey() const
 	return ((m_key.muxs0 >> 24) & 1) != 0;
 }
 
+void CombinerKey::setBiLerp0(unsigned int _bilerp0)
+{
+	m_secondaryFlags.bi_lerp0 = _bilerp0;
+}
+
+void CombinerKey::setBiLerp1(unsigned int _bilerp1)
+{
+	m_secondaryFlags.bi_lerp1 = _bilerp1;
+}
+
 void CombinerKey::read(std::istream & _is) {
 	_is.read((char*)&m_key.mux, sizeof(m_key.mux));
+	_is.read((char*)&m_secondaryFlags.mux, sizeof(m_secondaryFlags.mux));
 }

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -105,6 +105,16 @@ void CombinerKey::setAlphaCvgSel(unsigned int _alphaCvgSel)
 	m_secondaryFlags.alphaCvgSel = _alphaCvgSel;
 }
 
+void CombinerKey::setAlphaDither(unsigned int _alphaDither)
+{
+	m_secondaryFlags.alphaDither = _alphaDither;
+}
+
+void CombinerKey::setColorDither(unsigned int _colorDither)
+{
+	m_secondaryFlags.colorDither = _colorDither;
+}
+
 unsigned int CombinerKey::getBiLerp0(void) const
 {
 	return m_secondaryFlags.bi_lerp0;
@@ -133,6 +143,16 @@ unsigned int CombinerKey::getCvgXAlpha(void) const
 unsigned int CombinerKey::getAlphaCvgSel(void) const
 {
 	return m_secondaryFlags.alphaCvgSel;
+}
+
+unsigned int CombinerKey::getAlphaDither(void) const
+{
+	return m_secondaryFlags.alphaDither;
+}
+
+unsigned int CombinerKey::getColorDither(void) const
+{
+	return m_secondaryFlags.colorDither;
 }
 
 void CombinerKey::read(std::istream & _is) {

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -115,6 +115,11 @@ void CombinerKey::setColorDither(unsigned int _colorDither)
 	m_secondaryFlags.colorDither = _colorDither;
 }
 
+void CombinerKey::setRenderTarget(unsigned int _renderTarget)
+{
+	m_secondaryFlags.renderTarget = _renderTarget;
+}
+
 unsigned int CombinerKey::getBiLerp0(void) const
 {
 	return m_secondaryFlags.bi_lerp0;
@@ -153,6 +158,11 @@ unsigned int CombinerKey::getAlphaDither(void) const
 unsigned int CombinerKey::getColorDither(void) const
 {
 	return m_secondaryFlags.colorDither;
+}
+
+unsigned int CombinerKey::getRenderTarget(void) const
+{
+	return m_secondaryFlags.renderTarget;
 }
 
 void CombinerKey::read(std::istream & _is) {

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -90,6 +90,11 @@ void CombinerKey::setEnableAlphaTest(unsigned int _enableAlphaTest)
 	m_secondaryFlags.enableAlphaTest = _enableAlphaTest;
 }
 
+void CombinerKey::setAlphaCompareMode(unsigned int _alphaCompareMode)
+{
+	m_secondaryFlags.alphaCompareMode = _alphaCompareMode;
+}
+
 unsigned int CombinerKey::getBiLerp0(void)
 {
 	return m_secondaryFlags.bi_lerp0;
@@ -103,6 +108,11 @@ unsigned int CombinerKey::getBiLerp1(void)
 unsigned int CombinerKey::getEnableAlphaTest(void)
 {
 	return m_secondaryFlags.enableAlphaTest;
+}
+
+unsigned int CombinerKey::getAlphaCompareMode(void)
+{
+	return m_secondaryFlags.alphaCompareMode;
 }
 
 void CombinerKey::read(std::istream & _is) {

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -120,6 +120,11 @@ void CombinerKey::setRenderTarget(unsigned int _renderTarget)
 	m_secondaryFlags.renderTarget = _renderTarget;
 }
 
+void CombinerKey::setTextureFilter(unsigned int _textureFilter)
+{
+	m_secondaryFlags.textureFilter = _textureFilter;
+}
+
 unsigned int CombinerKey::getBiLerp0(void) const
 {
 	return m_secondaryFlags.bi_lerp0;
@@ -163,6 +168,11 @@ unsigned int CombinerKey::getColorDither(void) const
 unsigned int CombinerKey::getRenderTarget(void) const
 {
 	return m_secondaryFlags.renderTarget;
+}
+
+unsigned int CombinerKey::getTextureFilter(void) const
+{
+	return m_secondaryFlags.textureFilter;
 }
 
 void CombinerKey::read(std::istream & _is) {

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -95,24 +95,44 @@ void CombinerKey::setAlphaCompareMode(unsigned int _alphaCompareMode)
 	m_secondaryFlags.alphaCompareMode = _alphaCompareMode;
 }
 
-unsigned int CombinerKey::getBiLerp0(void)
+void CombinerKey::setCvgXAlpha(unsigned int _cvgXAlpha)
+{
+	m_secondaryFlags.cvgXAlpha = _cvgXAlpha;
+}
+
+void CombinerKey::setAlphaCvgSel(unsigned int _alphaCvgSel)
+{
+	m_secondaryFlags.alphaCvgSel = _alphaCvgSel;
+}
+
+unsigned int CombinerKey::getBiLerp0(void) const
 {
 	return m_secondaryFlags.bi_lerp0;
 }
 
-unsigned int CombinerKey::getBiLerp1(void)
+unsigned int CombinerKey::getBiLerp1(void) const
 {
 	return m_secondaryFlags.bi_lerp1;
 }
 
-unsigned int CombinerKey::getEnableAlphaTest(void)
+unsigned int CombinerKey::getEnableAlphaTest(void) const
 {
 	return m_secondaryFlags.enableAlphaTest;
 }
 
-unsigned int CombinerKey::getAlphaCompareMode(void)
+unsigned int CombinerKey::getAlphaCompareMode(void) const
 {
 	return m_secondaryFlags.alphaCompareMode;
+}
+
+unsigned int CombinerKey::getCvgXAlpha(void) const
+{
+	return m_secondaryFlags.cvgXAlpha;
+}
+
+unsigned int CombinerKey::getAlphaCvgSel(void) const
+{
+	return m_secondaryFlags.alphaCvgSel;
 }
 
 void CombinerKey::read(std::istream & _is) {

--- a/src/CombinerKey.cpp
+++ b/src/CombinerKey.cpp
@@ -125,6 +125,26 @@ void CombinerKey::setTextureFilter(unsigned int _textureFilter)
 	m_secondaryFlags.textureFilter = _textureFilter;
 }
 
+void CombinerKey::setFbMonochromeMode0(unsigned int _fbMonochromeMode0)
+{
+	m_secondaryFlags.fbMonochromeMode0 = _fbMonochromeMode0;
+}
+
+void CombinerKey::setFbMonochromeMode1(unsigned int _fbMonochromeMode1)
+{
+	m_secondaryFlags.fbMonochromeMode1 = _fbMonochromeMode1;
+}
+
+void CombinerKey::setFbFixedAlpha0(unsigned int _fbFixedAlpha0)
+{
+	m_secondaryFlags.fbFixedAlpha0 = _fbFixedAlpha0;
+}
+
+void CombinerKey::setFbFixedAlpha1(unsigned int _fbFixedAlpha1)
+{
+	m_secondaryFlags.fbFixedAlpha1 = _fbFixedAlpha1;
+}
+
 unsigned int CombinerKey::getBiLerp0(void) const
 {
 	return m_secondaryFlags.bi_lerp0;
@@ -173,6 +193,26 @@ unsigned int CombinerKey::getRenderTarget(void) const
 unsigned int CombinerKey::getTextureFilter(void) const
 {
 	return m_secondaryFlags.textureFilter;
+}
+
+unsigned int CombinerKey::getFbMonochromeMode0(void) const
+{
+	return m_secondaryFlags.fbMonochromeMode0;
+}
+
+unsigned int CombinerKey::getFbMonochromeMode1(void) const
+{
+	return m_secondaryFlags.fbMonochromeMode1;
+}
+
+unsigned int CombinerKey::getFbFixedAlpha0(void) const
+{
+	return m_secondaryFlags.fbFixedAlpha0;
+}
+
+unsigned int CombinerKey::getFbFixedAlpha1(void) const
+{
+	return m_secondaryFlags.fbFixedAlpha1;
 }
 
 void CombinerKey::read(std::istream & _is) {

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -10,9 +10,11 @@ class CombinerKey {
 		{
 			struct
 			{
-				unsigned	bi_lerp0 : 1;
-				unsigned	bi_lerp1 : 1;
-				unsigned	enableAlphaTest : 1;
+				unsigned int bi_lerp0 : 1;
+				unsigned int bi_lerp1 : 1;
+				unsigned int enableAlphaTest : 1;
+				unsigned int alphaCompareMode : 2;
+
 			};
 
 			u64				mux;
@@ -44,10 +46,12 @@ public:
 	void setBiLerp0(unsigned int _bilerp0);
 	void setBiLerp1(unsigned int _bilerp1);
 	void setEnableAlphaTest(unsigned int _enableAlphaTest);
+	void setAlphaCompareMode(unsigned int _alphaCompareMode);
 
 	unsigned int getBiLerp0(void);
 	unsigned int getBiLerp1(void);
 	unsigned int getEnableAlphaTest(void);
+	unsigned int getAlphaCompareMode(void);
 
 	void read(std::istream & _is);
 

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -3,11 +3,27 @@
 #include "gDP.h"
 
 class CombinerKey {
+
+	struct SecondaryShaderParams
+	{
+		union
+		{
+			struct
+			{
+				unsigned	bi_lerp0 : 1;
+				unsigned	bi_lerp1 : 1;
+			};
+
+			u64				mux;
+		};
+	};
+
 public:
 	CombinerKey() {
 		m_key.mux = 0;
 	}
 	explicit CombinerKey(u64 _mux, bool _setModeBits = true);
+	explicit CombinerKey(u64 _mux, u64 _secondaryFlags, bool _setModeBits = true);
 	CombinerKey(const CombinerKey & _other);
 
 	void operator=(u64 _mux);
@@ -22,8 +38,15 @@ public:
 
 	u64 getMux() const { return m_key.mux; }
 
+	u64 getSecondaryParams() const { return m_secondaryFlags.mux; }
+
+	void setBiLerp0(unsigned int _bilerp0);
+
+	void setBiLerp1(unsigned int _bilerp1);
+
 	void read(std::istream & _is);
 
 private:
 	gDPCombine m_key;
+	SecondaryShaderParams m_secondaryFlags;
 };

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -18,6 +18,7 @@ class CombinerKey {
 				unsigned int alphaCvgSel : 1;
 				unsigned int alphaDither : 2;
 				unsigned int colorDither : 2;
+				unsigned int renderTarget : 2;
 			};
 
 			u64				mux;
@@ -54,6 +55,7 @@ public:
 	void setAlphaCvgSel(unsigned int _alphaCvgSel);
 	void setAlphaDither(unsigned int _alphaDither);
 	void setColorDither(unsigned int _colorDither);
+	void setRenderTarget(unsigned int _renderTarget);
 
 	unsigned int getBiLerp0(void) const;
 	unsigned int getBiLerp1(void) const;
@@ -63,6 +65,7 @@ public:
 	unsigned int getAlphaCvgSel(void) const;
 	unsigned int getAlphaDither(void) const;
 	unsigned int getColorDither(void) const;
+	unsigned int getRenderTarget(void) const;
 
 	void read(std::istream & _is);
 

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -73,3 +73,11 @@ private:
 	gDPCombine m_key;
 	SecondaryShaderParams m_secondaryFlags;
 };
+
+struct CombinerKeyHash {
+public:
+	std::size_t operator()(const CombinerKey &x) const
+	{
+		return std::hash<u64>()(x.getMux()) ^ std::hash<u64>()(x.getSecondaryParams());
+	}
+};

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -16,6 +16,8 @@ class CombinerKey {
 				unsigned int alphaCompareMode : 2;
 				unsigned int cvgXAlpha : 1;
 				unsigned int alphaCvgSel : 1;
+				unsigned int alphaDither : 2;
+				unsigned int colorDither : 2;
 			};
 
 			u64				mux;
@@ -50,6 +52,8 @@ public:
 	void setAlphaCompareMode(unsigned int _alphaCompareMode);
 	void setCvgXAlpha(unsigned int _cvgXAlpha);
 	void setAlphaCvgSel(unsigned int _alphaCvgSel);
+	void setAlphaDither(unsigned int _alphaDither);
+	void setColorDither(unsigned int _colorDither);
 
 	unsigned int getBiLerp0(void) const;
 	unsigned int getBiLerp1(void) const;
@@ -57,6 +61,8 @@ public:
 	unsigned int getAlphaCompareMode(void) const;
 	unsigned int getCvgXAlpha(void) const;
 	unsigned int getAlphaCvgSel(void) const;
+	unsigned int getAlphaDither(void) const;
+	unsigned int getColorDither(void) const;
 
 	void read(std::istream & _is);
 

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -20,6 +20,10 @@ class CombinerKey {
 				unsigned int colorDither : 2;
 				unsigned int renderTarget : 2;
 				unsigned int textureFilter : 2;
+				unsigned int fbMonochromeMode0 : 3;
+				unsigned int fbMonochromeMode1 : 3;
+				unsigned int fbFixedAlpha0 : 1;
+				unsigned int fbFixedAlpha1 : 1;
 			};
 
 			u64				mux;
@@ -58,6 +62,10 @@ public:
 	void setColorDither(unsigned int _colorDither);
 	void setRenderTarget(unsigned int _renderTarget);
 	void setTextureFilter(unsigned int _textureFilter);
+	void setFbMonochromeMode0(unsigned int _fbMonochromeMode0);
+	void setFbMonochromeMode1(unsigned int _fbMonochromeMode1);
+	void setFbFixedAlpha0(unsigned int _fbFixedAlpha0);
+	void setFbFixedAlpha1(unsigned int _fbFixedAlpha1);
 
 	unsigned int getBiLerp0(void) const;
 	unsigned int getBiLerp1(void) const;
@@ -69,6 +77,10 @@ public:
 	unsigned int getColorDither(void) const;
 	unsigned int getRenderTarget(void) const;
 	unsigned int getTextureFilter(void) const;
+	unsigned int getFbMonochromeMode0(void) const;
+	unsigned int getFbMonochromeMode1(void) const;
+	unsigned int getFbFixedAlpha0(void) const;
+	unsigned int getFbFixedAlpha1(void) const;
 
 	void read(std::istream & _is);
 

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -12,6 +12,7 @@ class CombinerKey {
 			{
 				unsigned	bi_lerp0 : 1;
 				unsigned	bi_lerp1 : 1;
+				unsigned	enableAlphaTest : 1;
 			};
 
 			u64				mux;
@@ -41,8 +42,12 @@ public:
 	u64 getSecondaryParams() const { return m_secondaryFlags.mux; }
 
 	void setBiLerp0(unsigned int _bilerp0);
-
 	void setBiLerp1(unsigned int _bilerp1);
+	void setEnableAlphaTest(unsigned int _enableAlphaTest);
+
+	unsigned int getBiLerp0(void);
+	unsigned int getBiLerp1(void);
+	unsigned int getEnableAlphaTest(void);
 
 	void read(std::istream & _is);
 

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -19,6 +19,7 @@ class CombinerKey {
 				unsigned int alphaDither : 2;
 				unsigned int colorDither : 2;
 				unsigned int renderTarget : 2;
+				unsigned int textureFilter : 2;
 			};
 
 			u64				mux;
@@ -56,6 +57,7 @@ public:
 	void setAlphaDither(unsigned int _alphaDither);
 	void setColorDither(unsigned int _colorDither);
 	void setRenderTarget(unsigned int _renderTarget);
+	void setTextureFilter(unsigned int _textureFilter);
 
 	unsigned int getBiLerp0(void) const;
 	unsigned int getBiLerp1(void) const;
@@ -66,6 +68,7 @@ public:
 	unsigned int getAlphaDither(void) const;
 	unsigned int getColorDither(void) const;
 	unsigned int getRenderTarget(void) const;
+	unsigned int getTextureFilter(void) const;
 
 	void read(std::istream & _is);
 

--- a/src/CombinerKey.h
+++ b/src/CombinerKey.h
@@ -14,7 +14,8 @@ class CombinerKey {
 				unsigned int bi_lerp1 : 1;
 				unsigned int enableAlphaTest : 1;
 				unsigned int alphaCompareMode : 2;
-
+				unsigned int cvgXAlpha : 1;
+				unsigned int alphaCvgSel : 1;
 			};
 
 			u64				mux;
@@ -47,11 +48,15 @@ public:
 	void setBiLerp1(unsigned int _bilerp1);
 	void setEnableAlphaTest(unsigned int _enableAlphaTest);
 	void setAlphaCompareMode(unsigned int _alphaCompareMode);
+	void setCvgXAlpha(unsigned int _cvgXAlpha);
+	void setAlphaCvgSel(unsigned int _alphaCvgSel);
 
-	unsigned int getBiLerp0(void);
-	unsigned int getBiLerp1(void);
-	unsigned int getEnableAlphaTest(void);
-	unsigned int getAlphaCompareMode(void);
+	unsigned int getBiLerp0(void) const;
+	unsigned int getBiLerp1(void) const;
+	unsigned int getEnableAlphaTest(void) const;
+	unsigned int getAlphaCompareMode(void) const;
+	unsigned int getCvgXAlpha(void) const;
+	unsigned int getAlphaCvgSel(void) const;
 
 	void read(std::istream & _is);
 

--- a/src/Graphics/CombinerProgram.h
+++ b/src/Graphics/CombinerProgram.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <map>
 #include <vector>
+#include <unordered_map>
 #include "CombinerKey.h"
 
 namespace graphics {
@@ -25,5 +25,5 @@ namespace graphics {
 		static u32 getShaderCombinerOptionsBits();
 	};
 
-	typedef std::map<CombinerKey, graphics::CombinerProgram *> Combiners;
+	typedef std::unordered_map<CombinerKey, graphics::CombinerProgram *, CombinerKeyHash> Combiners;
 }

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -932,7 +932,6 @@ public:
 		if (!_glinfo.isGLES2) {
 			m_part =
 				"uniform lowp ivec2 uTextureFormat;									\n"
-				"uniform lowp ivec2 uBiLerp;										\n"
 				"uniform lowp ivec2 uTextureConvert;								\n"
 				"uniform mediump ivec4 uConvertParams;								\n"
 				"uniform lowp int uTextureFilterMode;								\n"
@@ -1014,7 +1013,6 @@ public:
 		} else {
 			m_part =
 				"uniform lowp ivec2 uTextureFormat;									\n"
-				"uniform lowp ivec2 uBiLerp;										\n"
 				"uniform lowp ivec2 uTextureConvert;								\n"
 				"uniform mediump ivec4 uConvertParams;								\n"
 				"uniform lowp int uTextureFilterMode;								\n"
@@ -1161,77 +1159,110 @@ public:
 class ShaderFragmentReadTex0 : public ShaderPart
 {
 public:
-	ShaderFragmentReadTex0(const opengl::GLInfo & _glinfo)
+	ShaderFragmentReadTex0(const opengl::GLInfo & _glinfo) : m_glinfo(_glinfo)
 	{
-		if (_glinfo.isGLES2) {
-			m_part =
-				"  nCurrentTile = 0; \n"
-				"  lowp vec4 readtex0;																\n"
-				"  if (uBiLerp[0] != 0)																\n"
-				"    readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);		\n"
-				"  else																				\n"
-				"    readtex0 = YUV_Convert(uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0);	\n"
-				;
-		} else {
+
+	}
+
+	void write(std::stringstream & shader) const override
+	{
+		std::string shaderPart;
+
+		if (m_glinfo.isGLES2) {
+			shaderPart = "  nCurrentTile = 0; \n";
+			if (gDP.otherMode.bi_lerp0 != 0) {
+				shaderPart += "  lowp vec4 readtex0 = readTex(uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);		\n";
+			}
+			else {
+				shaderPart += "  lowp vec4 readtex0 = YUV_Convert(uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0);	\n";
+			}
+
+		}
+		else {
 			if (config.video.multisampling > 0) {
-				m_part =
+				shaderPart =
 					"  lowp vec4 readtex0;																	\n"
-					"  if (uMSTexEnabled[0] == 0) {															\n"
-					"    if (uBiLerp[0] != 0)																\n"
-					"      READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n"
-					"    else																				\n"
-					"      YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)	\n"
-					"  } else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);\n"
-					;
-			} else {
-				m_part =
-					"  lowp vec4 readtex0;																\n"
-					"  if (uBiLerp[0] != 0)																\n"
-					"    READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n"
-					"  else																				\n"
-					"    YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)\n"
-					;
+					"  if (uMSTexEnabled[0] == 0) {															\n";
+
+				if (gDP.otherMode.bi_lerp0 != 0) {
+					shaderPart += "    READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n";
+				}
+				else {
+					shaderPart += "    YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)	\n";
+				}
+				shaderPart += "  } else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);\n";
+			}
+			else {
+				shaderPart = "  lowp vec4 readtex0;																	\n";
+				if (gDP.otherMode.bi_lerp0 != 0) {
+					shaderPart += "  READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n";
+				}
+				else {
+					shaderPart += "  YUVCONVERT_TEX(readtex0, uTex0, vTexCoord0, uTextureConvert[0], uTextureFormat[0], readtex0)\n";
+				}
 			}
 		}
+
+		shader << shaderPart;
 	}
+
+	const opengl::GLInfo& m_glinfo;
 };
 
 class ShaderFragmentReadTex1 : public ShaderPart
 {
 public:
-	ShaderFragmentReadTex1(const opengl::GLInfo & _glinfo)
+	ShaderFragmentReadTex1(const opengl::GLInfo & _glinfo) : m_glinfo(_glinfo)
 	{
-		if (_glinfo.isGLES2) {
-			m_part =
-				"  nCurrentTile = 1; \n"
-				"  lowp vec4 readtex1;																\n"
-				"  if (uBiLerp[1] != 0)																\n"
-				"    readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);		\n"
-				"  else																				\n"
-				"    readtex1 = YUV_Convert(uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0);	\n"
-				;
-		} else {
+
+	}
+
+	void write(std::stringstream & shader) const override
+	{
+		std::string shaderPart;
+
+		if (m_glinfo.isGLES2) {
+			shaderPart = "  nCurrentTile = 1; \n";
+
+			if (gDP.otherMode.bi_lerp1 != 0) {
+				shaderPart += "  lowp vec4 readtex1 = readTex(uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);		\n";
+			}
+			else {
+				shaderPart += "  lowp vec4 readtex1 = YUV_Convert(uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0);	\n";
+			}
+
+		}
+		else {
 			if (config.video.multisampling > 0) {
-				m_part =
+				shaderPart =
 					"  lowp vec4 readtex1; \n"
-					"  if (uMSTexEnabled[1] == 0) {															\n"
-					"    if (uBiLerp[1] != 0)																\n"
-					"      READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n"
-					"    else																				\n"
-					"      YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)	\n"
-					"  } else readtex1 = readTexMS(uMSTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);\n"
-					;
-			} else {
-				m_part =
-					"  lowp vec4 readtex1; \n"
-					"  if (uBiLerp[1] != 0)																\n"
-					"    READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n"
-					"  else																				\n"
-					"    YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)\n"
-					;
+					"  if (uMSTexEnabled[1] == 0) {															\n";
+
+				if (gDP.otherMode.bi_lerp1 != 0) {
+					shaderPart += "    READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n";
+				}
+				else {
+					shaderPart += "    YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)	\n";
+				}
+
+				shaderPart += "  } else readtex1 = readTexMS(uMSTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1]);\n";
+			}
+			else {
+				shaderPart = "  lowp vec4 readtex1; \n";
+
+				if (gDP.otherMode.bi_lerp1 != 0) {
+					shaderPart += "  READ_TEX(readtex1, uTex1, vTexCoord1, uFbMonochrome[1], uFbFixedAlpha[1])		\n";
+				}
+				else {
+					shaderPart += "  YUVCONVERT_TEX(readtex1, uTex1, vTexCoord1, uTextureConvert[1], uTextureFormat[1], readtex0)\n";
+				}
 			}
 		}
+
+		shader << shaderPart;
 	}
+
+	const opengl::GLInfo& m_glinfo;
 };
 
 class ShaderFragmentCallN64Depth : public ShaderPart

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -671,8 +671,13 @@ public:
 		std::string shaderPart;
 
 		if (_key.getEnableAlphaTest() != 0) {
-			shaderPart =
-				"  lowp float alphaTestValue = (uAlphaCompareMode == 3) ? snoise() : uAlphaTestValue;	\n"
+			if (_key.getAlphaCompareMode() == 3) {
+				shaderPart = "  lowp float alphaTestValue = snoise();	\n";
+			} else {
+				shaderPart = "  lowp float alphaTestValue = uAlphaTestValue;	\n";
+			}
+
+			shaderPart +=
 				"  lowp float alphaValue;								\n"
 				"  if ((uAlphaCvgSel != 0) && (uCvgXAlpha == 0)) {	\n"
 				"    alphaValue = 0.125;								\n"
@@ -718,7 +723,6 @@ public:
 			"uniform lowp float uPrimLod;	\n"
 			"uniform lowp float uK4;		\n"
 			"uniform lowp float uK5;		\n"
-			"uniform lowp int uAlphaCompareMode;	\n"
 			"uniform lowp ivec2 uFbMonochrome;		\n"
 			"uniform lowp ivec2 uFbFixedAlpha;		\n"
 			"uniform lowp int uCvgXAlpha;			\n"
@@ -793,7 +797,6 @@ public:
 			"uniform lowp float uPrimLod;	\n"
 			"uniform lowp float uK4;		\n"
 			"uniform lowp float uK5;		\n"
-			"uniform lowp int uAlphaCompareMode;	\n"
 			"uniform lowp ivec2 uFbMonochrome;		\n"
 			"uniform lowp ivec2 uFbFixedAlpha;		\n"
 			"uniform lowp int uCvgXAlpha;			\n"
@@ -1200,8 +1203,6 @@ public:
 				shaderPart += "  } else readtex0 = readTexMS(uMSTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0]);\n";
 			}
 			else {
-				LOG(LOG_ERROR, "YUV: lerp0=%d, lerp1=%d", gDP.otherMode.bi_lerp0, gDP.otherMode.bi_lerp1);
-
 				shaderPart = "  lowp vec4 readtex0;																	\n";
 				if (_key.getBiLerp0() != 0) {
 					shaderPart += "  READ_TEX(readtex0, uTex0, vTexCoord0, uFbMonochrome[0], uFbFixedAlpha[0])		\n";

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -693,15 +693,30 @@ public:
 class ShaderCallDither : public ShaderPart
 {
 public:
-	ShaderCallDither(const opengl::GLInfo & _glinfo)
+	ShaderCallDither(const opengl::GLInfo & _glinfo) : m_glinfo(_glinfo)
 	{
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
-			m_part =
-				"  if (uColorDitherMode == 2) colorNoiseDither(snoise(), clampedColor.rgb);	\n"
-				"  if (uAlphaDitherMode == 2) alphaNoiseDither(snoise(), clampedColor.a);	\n"
-				;
-		}
+
 	}
+
+	void write(std::stringstream & shader, CombinerKey _key) const override
+	{
+		std::string shaderPart;
+
+		if (!m_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
+
+			if(_key.getColorDither() == 2) {
+				shaderPart += "  colorNoiseDither(snoise(), clampedColor.rgb);	\n";
+			}
+
+			if(_key.getAlphaDither() == 2) {
+				shaderPart += "  alphaNoiseDither(snoise(), clampedColor.a);	\n";
+			}
+		}
+
+		shader << shaderPart;
+	}
+
+	const opengl::GLInfo& m_glinfo;
 };
 
 class ShaderFragmentGlobalVariablesTex : public ShaderPart
@@ -743,8 +758,6 @@ public:
 		if (!_glinfo.isGLES2) {
 			m_part +=
 				"uniform sampler2D uDepthTex;		\n"
-				"uniform lowp int uAlphaDitherMode;	\n"
-				"uniform lowp int uColorDitherMode;	\n"
 				"uniform lowp int uRenderTarget;	\n"
 				"uniform mediump vec2 uDepthScale;	\n"
 				;
@@ -815,8 +828,6 @@ public:
 		if (!_glinfo.isGLES2) {
 			m_part +=
 				"uniform sampler2D uDepthTex;		\n"
-				"uniform lowp int uAlphaDitherMode;	\n"
-				"uniform lowp int uColorDitherMode;	\n"
 				"uniform lowp int uRenderTarget;	\n"
 				"uniform mediump vec2 uDepthScale;	\n"
 				;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -677,15 +677,13 @@ public:
 				shaderPart = "  lowp float alphaTestValue = uAlphaTestValue;	\n";
 			}
 
-			shaderPart +=
-				"  lowp float alphaValue;								\n"
-				"  if ((uAlphaCvgSel != 0) && (uCvgXAlpha == 0)) {	\n"
-				"    alphaValue = 0.125;								\n"
-				"  } else {											\n"
-				"    alphaValue = clamp(alpha1, 0.0, 1.0);			\n"
-				"  }													\n"
-				"  if (alphaValue < alphaTestValue) discard;			\n"
-				;
+			if (_key.getAlphaCvgSel() != 0 && _key.getCvgXAlpha() == 0) {
+				shaderPart += "  lowp float alphaValue = 0.125;								\n";
+			} else {
+				shaderPart += "  lowp float alphaValue = clamp(alpha1, 0.0, 1.0);								\n";
+			}
+
+			shaderPart += "  if (alphaValue < alphaTestValue) discard;			\n";
 		}
 
 		shader << shaderPart;
@@ -725,8 +723,6 @@ public:
 			"uniform lowp float uK5;		\n"
 			"uniform lowp ivec2 uFbMonochrome;		\n"
 			"uniform lowp ivec2 uFbFixedAlpha;		\n"
-			"uniform lowp int uCvgXAlpha;			\n"
-			"uniform lowp int uAlphaCvgSel;			\n"
 			"uniform lowp float uAlphaTestValue;	\n"
 			"uniform lowp int uDepthSource;			\n"
 			"uniform highp float uPrimDepth;		\n"
@@ -799,8 +795,6 @@ public:
 			"uniform lowp float uK5;		\n"
 			"uniform lowp ivec2 uFbMonochrome;		\n"
 			"uniform lowp ivec2 uFbFixedAlpha;		\n"
-			"uniform lowp int uCvgXAlpha;			\n"
-			"uniform lowp int uAlphaCvgSel;			\n"
 			"uniform lowp float uAlphaTestValue;	\n"
 			"uniform lowp int uDepthSource;			\n"
 			"uniform highp float uPrimDepth;		\n"
@@ -1977,7 +1971,9 @@ CombinerInputs CombinerProgramBuilder::compileCombiner(const CombinerKey & _key,
 		else
 			ssShader << "  alpha2 = alpha1;" << std::endl;
 
-		ssShader << "  if (uCvgXAlpha != 0 && alpha2 < 0.125) discard;" << std::endl;
+		if(_key.getCvgXAlpha() != 0) {
+			ssShader << "  if (alpha2 < 0.125) discard;" << std::endl;
+		}
 
 		if (_color.numStages == 2) {
 			ssShader << "  color2 = ";
@@ -1990,8 +1986,9 @@ CombinerInputs CombinerProgramBuilder::compileCombiner(const CombinerKey & _key,
 		ssShader << "  lowp vec4 cmbRes = vec4(color2, alpha2);" << std::endl;
 	}
 	else {
-		if (g_cycleType < G_CYC_FILL)
-			ssShader << "  if (uCvgXAlpha != 0 && alpha1 < 0.125) discard;" << std::endl;
+		if (g_cycleType < G_CYC_FILL && _key.getCvgXAlpha() != 0) {
+			ssShader << "  if (alpha1 < 0.125) discard;" << std::endl;
+		}
 		ssShader << "  lowp vec4 cmbRes = vec4(color1, alpha1);" << std::endl;
 	}
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -2336,7 +2336,7 @@ graphics::CombinerProgram * CombinerProgramBuilder::buildCombinerProgram(Combine
 	const GLchar * strShaderData = strFragmentShader.data();
 	glShaderSource(fragmentShader, 1, &strShaderData, nullptr);
 	glCompileShader(fragmentShader);
-	if (!Utils::checkShaderCompileStatus(fragmentShader))
+	//if (!Utils::checkShaderCompileStatus(fragmentShader))
 	Utils::logErrorShader(GL_FRAGMENT_SHADER, strFragmentShader);
 
 	GLuint program = glCreateProgram();

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.h
@@ -61,7 +61,6 @@ namespace glsl {
 		ShaderPartPtr m_fragmentHeaderWriteDepth;
 		ShaderPartPtr m_fragmentHeaderCalcLight;
 		ShaderPartPtr m_fragmentHeaderMipMap;
-		ShaderPartPtr m_fragmentHeaderReadMSTex;
 		ShaderPartPtr m_fragmentHeaderDither;
 		ShaderPartPtr m_fragmentHeaderDepthCompare;
 		ShaderPartPtr m_fragmentHeaderReadTex;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramImpl.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramImpl.cpp
@@ -93,15 +93,21 @@ bool CombinerProgramImpl::getBinaryForm(std::vector<char> & _buffer)
 		return false;
 
 	u64 key = m_key.getMux();
+	u64 secondaryParams = m_key.getSecondaryParams();
+
 	int inputs(m_inputs);
 
-	int totalSize = sizeof(key)+sizeof(inputs)+sizeof(binaryFormat)+
+	int totalSize = sizeof(key)+sizeof(secondaryParams)+sizeof(inputs)+sizeof(binaryFormat)+
 		sizeof(binaryLength)+binaryLength;
 	_buffer.resize(totalSize);
 
 	char* keyData = reinterpret_cast<char*>(&key);
 	std::copy_n(keyData, sizeof(key), _buffer.data());
 	int offset = sizeof(key);
+
+	char* secondaryParamData = reinterpret_cast<char*>(&secondaryParams);
+	std::copy_n(secondaryParamData, sizeof(secondaryParams), _buffer.data());
+	offset += sizeof(secondaryParams);
 
 	char* inputData = reinterpret_cast<char*>(&inputs);
 	std::copy_n(inputData, sizeof(inputs), _buffer.data() + offset);

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -343,21 +343,10 @@ public:
 	UDitherMode(GLuint _program, bool _usesNoise)
 	: m_usesNoise(_usesNoise)
 	{
-		LocateUniform(uAlphaDitherMode);
-		LocateUniform(uColorDitherMode);
 	}
 
 	void update(bool _force) override
 	{
-		if (gDP.otherMode.cycleType < G_CYC_COPY) {
-			uAlphaDitherMode.set(gDP.otherMode.alphaDither, _force);
-			uColorDitherMode.set(gDP.otherMode.colorDither, _force);
-		}
-		else {
-			uAlphaDitherMode.set(0, _force);
-			uColorDitherMode.set(0, _force);
-		}
-
 		bool updateNoiseTex = m_usesNoise;
 		updateNoiseTex |= (gDP.otherMode.cycleType < G_CYC_COPY) && (gDP.otherMode.colorDither == G_CD_NOISE || gDP.otherMode.alphaDither == G_AD_NOISE || gDP.otherMode.alphaCompare == G_AC_DITHER);
 		if (updateNoiseTex)
@@ -365,8 +354,6 @@ public:
 	}
 
 private:
-	iUniform uAlphaDitherMode;
-	iUniform uColorDitherMode;
 	bool m_usesNoise;
 };
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -343,7 +343,6 @@ public:
 	UDitherMode(GLuint _program, bool _usesNoise)
 	: m_usesNoise(_usesNoise)
 	{
-		LocateUniform(uAlphaCompareMode);
 		LocateUniform(uAlphaDitherMode);
 		LocateUniform(uColorDitherMode);
 	}
@@ -351,12 +350,10 @@ public:
 	void update(bool _force) override
 	{
 		if (gDP.otherMode.cycleType < G_CYC_COPY) {
-			uAlphaCompareMode.set(gDP.otherMode.alphaCompare, _force);
 			uAlphaDitherMode.set(gDP.otherMode.alphaDither, _force);
 			uColorDitherMode.set(gDP.otherMode.colorDither, _force);
 		}
 		else {
-			uAlphaCompareMode.set(0, _force);
 			uAlphaDitherMode.set(0, _force);
 			uColorDitherMode.set(0, _force);
 		}
@@ -368,7 +365,6 @@ public:
 	}
 
 private:
-	iUniform uAlphaCompareMode;
 	iUniform uAlphaDitherMode;
 	iUniform uColorDitherMode;
 	bool m_usesNoise;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -437,7 +437,6 @@ class UTextureFetchMode : public UniformGroup
 {
 public:
 	UTextureFetchMode(GLuint _program) {
-		LocateUniform(uTextureFilterMode);
 		LocateUniform(uTextureFormat);
 		LocateUniform(uTextureConvert);
 		LocateUniform(uConvertParams);
@@ -445,10 +444,6 @@ public:
 
 	void update(bool _force) override
 	{
-		int textureFilter = gDP.otherMode.textureFilter;
-		if ((gSP.objRendermode&G_OBJRM_BILERP) != 0)
-			textureFilter |= 2;
-		uTextureFilterMode.set(textureFilter, _force);
 		uTextureFormat.set(gSP.textureTile[0]->format, gSP.textureTile[1]->format, _force);
 		uTextureConvert.set(0, gDP.otherMode.convert_one, _force);
 		if (gDP.otherMode.bi_lerp0 == 0 || gDP.otherMode.bi_lerp1 == 0)
@@ -456,7 +451,6 @@ public:
 	}
 
 private:
-	iUniform uTextureFilterMode;
 	iv2Uniform uTextureFormat;
 	iv2Uniform uTextureConvert;
 	i4Uniform uConvertParams;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -456,7 +456,6 @@ public:
 	UTextureFetchMode(GLuint _program) {
 		LocateUniform(uTextureFilterMode);
 		LocateUniform(uTextureFormat);
-		LocateUniform(uBiLerp);
 		LocateUniform(uTextureConvert);
 		LocateUniform(uConvertParams);
 	}
@@ -467,7 +466,6 @@ public:
 		if ((gSP.objRendermode&G_OBJRM_BILERP) != 0)
 			textureFilter |= 2;
 		uTextureFilterMode.set(textureFilter, _force);
-		uBiLerp.set(gDP.otherMode.bi_lerp0, gDP.otherMode.bi_lerp1, _force);
 		uTextureFormat.set(gSP.textureTile[0]->format, gSP.textureTile[1]->format, _force);
 		uTextureConvert.set(0, gDP.otherMode.convert_one, _force);
 		if (gDP.otherMode.bi_lerp0 == 0 || gDP.otherMode.bi_lerp1 == 0)
@@ -477,7 +475,6 @@ public:
 private:
 	iUniform uTextureFilterMode;
 	iv2Uniform uTextureFormat;
-	iv2Uniform uBiLerp;
 	iv2Uniform uTextureConvert;
 	i4Uniform uConvertParams;
 };

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -483,7 +483,6 @@ class UAlphaTestInfo : public UniformGroup
 {
 public:
 	UAlphaTestInfo(GLuint _program) {
-		LocateUniform(uEnableAlphaTest);
 		LocateUniform(uAlphaCvgSel);
 		LocateUniform(uCvgXAlpha);
 		LocateUniform(uAlphaTestValue);
@@ -492,32 +491,23 @@ public:
 	void update(bool _force) override
 	{
 		if (gDP.otherMode.cycleType == G_CYC_FILL) {
-			uEnableAlphaTest.set(0, _force);
+			//Do nothing
 		}
 		else if (gDP.otherMode.cycleType == G_CYC_COPY) {
 			if (gDP.otherMode.alphaCompare & G_AC_THRESHOLD) {
-				uEnableAlphaTest.set(1, _force);
 				uAlphaCvgSel.set(0, _force);
 				uAlphaTestValue.set(0.5f, _force);
 			}
-			else {
-				uEnableAlphaTest.set(0, _force);
-			}
 		}
 		else if ((gDP.otherMode.alphaCompare & G_AC_THRESHOLD) != 0) {
-			uEnableAlphaTest.set(1, _force);
 			uAlphaTestValue.set(gDP.blendColor.a, _force);
 			uAlphaCvgSel.set(gDP.otherMode.alphaCvgSel, _force);
-		}
-		else {
-			uEnableAlphaTest.set(0, _force);
 		}
 
 		uCvgXAlpha.set(gDP.otherMode.cvgXAlpha, _force);
 	}
 
 private:
-	iUniform uEnableAlphaTest;
 	iUniform uAlphaCvgSel;
 	iUniform uCvgXAlpha;
 	fUniform uAlphaTestValue;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -479,8 +479,6 @@ class UAlphaTestInfo : public UniformGroup
 {
 public:
 	UAlphaTestInfo(GLuint _program) {
-		LocateUniform(uAlphaCvgSel);
-		LocateUniform(uCvgXAlpha);
 		LocateUniform(uAlphaTestValue);
 	}
 
@@ -491,21 +489,15 @@ public:
 		}
 		else if (gDP.otherMode.cycleType == G_CYC_COPY) {
 			if (gDP.otherMode.alphaCompare & G_AC_THRESHOLD) {
-				uAlphaCvgSel.set(0, _force);
 				uAlphaTestValue.set(0.5f, _force);
 			}
 		}
 		else if ((gDP.otherMode.alphaCompare & G_AC_THRESHOLD) != 0) {
 			uAlphaTestValue.set(gDP.blendColor.a, _force);
-			uAlphaCvgSel.set(gDP.otherMode.alphaCvgSel, _force);
 		}
-
-		uCvgXAlpha.set(gDP.otherMode.cvgXAlpha, _force);
 	}
 
 private:
-	iUniform uAlphaCvgSel;
-	iUniform uCvgXAlpha;
 	fUniform uAlphaTestValue;
 };
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -185,54 +185,26 @@ class UFrameBufferInfo : public UniformGroup
 {
 public:
 	UFrameBufferInfo(GLuint _program) {
-		LocateUniform(uFbMonochrome);
-		LocateUniform(uFbFixedAlpha);
 		LocateUniform(uMSTexEnabled);
 	}
 
 	void update(bool _force) override
 	{
-		int nFbMonochromeMode0 = 0, nFbMonochromeMode1 = 0;
-		int nFbFixedAlpha0 = 0, nFbFixedAlpha1 = 0;
+
 		int nMSTex0Enabled = 0, nMSTex1Enabled = 0;
 		TextureCache & cache = textureCache();
 		if (cache.current[0] != nullptr && cache.current[0]->frameBufferTexture != CachedTexture::fbNone) {
-			if (cache.current[0]->size == G_IM_SIZ_8b) {
-				nFbMonochromeMode0 = 1;
-				if (gDP.otherMode.imageRead == 0)
-					nFbFixedAlpha0 = 1;
-			} else if (gSP.textureTile[0]->size == G_IM_SIZ_16b && gSP.textureTile[0]->format == G_IM_FMT_IA) {
-				nFbMonochromeMode0 = 2;
-			} else if ((config.generalEmulation.hacks & hack_ZeldaMonochrome) != 0 &&
-					   cache.current[0]->size == G_IM_SIZ_16b &&
-					   gSP.textureTile[0]->size == G_IM_SIZ_8b &&
-					   gSP.textureTile[0]->format == G_IM_FMT_CI) {
-				// Zelda monochrome effect
-				nFbMonochromeMode0 = 3;
-				nFbMonochromeMode1 = 3;
-			}
-
 			nMSTex0Enabled = cache.current[0]->frameBufferTexture == CachedTexture::fbMultiSample ? 1 : 0;
 		}
 		if (cache.current[1] != nullptr && cache.current[1]->frameBufferTexture != CachedTexture::fbNone) {
-			if (cache.current[1]->size == G_IM_SIZ_8b) {
-				nFbMonochromeMode1 = 1;
-				if (gDP.otherMode.imageRead == 0)
-					nFbFixedAlpha1 = 1;
-			}
-			else if (gSP.textureTile[1]->size == G_IM_SIZ_16b && gSP.textureTile[1]->format == G_IM_FMT_IA)
-				nFbMonochromeMode1 = 2;
 			nMSTex1Enabled = cache.current[1]->frameBufferTexture == CachedTexture::fbMultiSample ? 1 : 0;
 		}
-		uFbMonochrome.set(nFbMonochromeMode0, nFbMonochromeMode1, _force);
-		uFbFixedAlpha.set(nFbFixedAlpha0, nFbFixedAlpha1, _force);
+
 		uMSTexEnabled.set(nMSTex0Enabled, nMSTex1Enabled, _force);
 		gDP.changed &= ~CHANGED_FB_TEXTURE;
 	}
 
 private:
-	iv2Uniform uFbMonochrome;
-	iv2Uniform uFbFixedAlpha;
 	iv2Uniform uMSTexEnabled;
 };
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -574,26 +574,6 @@ private:
 	fUniform uPrimDepth;
 };
 
-class URenderTarget : public UniformGroup
-{
-public:
-	URenderTarget(GLuint _program) {
-		LocateUniform(uRenderTarget);
-	}
-
-	void update(bool _force) override
-	{
-		int renderTarget = 0;
-		if (gDP.colorImage.address == gDP.depthImageAddress ) {
-			renderTarget = gDP.otherMode.depthCompare + 1;
-		}
-		uRenderTarget.set(renderTarget, _force);
-	}
-
-private:
-	iUniform uRenderTarget;
-};
-
 class UScreenCoordsScale : public UniformGroup
 {
 public:
@@ -859,10 +839,6 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 		_uniforms.emplace_back(new UDepthInfo(_program));
 	else
 		_uniforms.emplace_back(new UDepthSource(_program));
-
-	if (config.generalEmulation.enableFragmentDepthWrite != 0 ||
-		config.frameBufferEmulation.N64DepthCompare != 0)
-		_uniforms.emplace_back(new URenderTarget(_program));
 
 	_uniforms.emplace_back(new UScreenCoordsScale(_program));
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderPart.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderPart.h
@@ -1,13 +1,14 @@
 #pragma once
 #include <string>
 #include <sstream>
+#include <CombinerKey.h>
 
 namespace glsl {
 
 	class ShaderPart
 	{
 	public:
-		virtual void write(std::stringstream & shader) const
+		virtual void write(std::stringstream & shader, CombinerKey _key) const
 		{
 			shader << m_part;
 		}

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -74,8 +74,10 @@ bool ShaderStorage::_saveCombinerKeys(const graphics::Combiners & _combiners) co
 	std::vector<char> allShaderData;
 	std::vector<u64> keysData;
 	keysData.reserve(szCombiners);
-	for (auto cur = _combiners.begin(); cur != _combiners.end(); ++cur)
+	for (auto cur = _combiners.begin(); cur != _combiners.end(); ++cur) {
 		keysData.push_back(cur->first.getMux());
+		keysData.push_back(cur->first.getSecondaryParams());
+	}
 
 	std::sort(keysData.begin(), keysData.end());
 	keysOut << "0x" << std::hex << std::setfill('0') << std::setw(8) << m_keysFormatVersion << "\n";
@@ -147,7 +149,6 @@ bool ShaderStorage::saveShadersStorage(const graphics::Combiners & _combiners) c
 
 	u32 totalWritten = 0;
 	std::vector<char> allShaderData;
-	std::vector<u64> keysData;
 
 	const f32 percent = szCombiners / 100.0f;
 	const f32 step = 100.0f / szCombiners;
@@ -246,9 +247,13 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 	f32 progress = 0.0f;
 	f32 percents = percent;
 	u64 key;
+	u64 secondaryParams;
+
 	for (u32 i = 0; i < szCombiners; ++i) {
 		fin >> std::hex >> key;
-		graphics::CombinerProgram * pCombiner = Combiner_Compile(CombinerKey(key, false));
+		fin >> std::hex >> secondaryParams;
+
+		graphics::CombinerProgram * pCombiner = Combiner_Compile(CombinerKey(key, secondaryParams, false));
 		pCombiner->update(true);
 		_combiners[pCombiner->getKey()] = pCombiner;
 		progress += step;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -111,7 +111,7 @@ bool ShaderStorage::saveShadersStorage(const graphics::Combiners & _combiners) c
 		// Created shaders are obsolete due to changes in config, but we saved combiners keys.
 		return true;
 
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (!CombinerInfo::get().isShaderCacheSupported())
 		// Shaders storage is not supported, but we saved combiners keys.
 		return true;
 
@@ -267,7 +267,7 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 	if (opengl::Utils::isGLError())
 		return false;
 
-	if (gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (CombinerInfo::get().isShaderCacheSupported())
 		// Restore shaders storage
 		return saveShadersStorage(_combiners);
 
@@ -277,7 +277,7 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 
 bool ShaderStorage::loadShadersStorage(graphics::Combiners & _combiners)
 {
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (!CombinerInfo::get().isShaderCacheSupported())
 		// Shaders storage is not supported, load from combiners keys.
 		return _loadFromCombinerKeys(_combiners);
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x17U;
+		const u32 m_formatVersion = 0x18U;
 		const u32 m_keysFormatVersion = 0x03;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -391,14 +391,14 @@ namespace glsl {
 			FragmentBody fragmentBody(_glinfo);
 
 			std::stringstream ssVertexShader;
-			_vertexHeader->write(ssVertexShader);
-			vertexBody.write(ssVertexShader);
+			_vertexHeader->write(ssVertexShader, CombinerKey(0,0,false));
+			vertexBody.write(ssVertexShader, CombinerKey(0,0,false));
 
 			std::stringstream ssFragmentShader;
-			_fragmentHeader->write(ssFragmentShader);
-			fragmentBody.write(ssFragmentShader);
+			_fragmentHeader->write(ssFragmentShader, CombinerKey(0,0,false));
+			fragmentBody.write(ssFragmentShader, CombinerKey(0,0,false));
 			if (_fragmentEnd != nullptr)
-				_fragmentEnd->write(ssFragmentShader);
+				_fragmentEnd->write(ssFragmentShader, CombinerKey(0,0,false));
 
 			m_program =
 				graphics::ObjectHandle(Utils::createRectShaderProgram(ssVertexShader.str().data(), ssFragmentShader.str().data()));
@@ -464,22 +464,22 @@ namespace glsl {
 		{
 			VertexShaderTexturedRect vertexBody(_glinfo);
 			std::stringstream ssVertexShader;
-			_vertexHeader->write(ssVertexShader);
-			vertexBody.write(ssVertexShader);
+			_vertexHeader->write(ssVertexShader, CombinerKey(0,0,false));
+			vertexBody.write(ssVertexShader, CombinerKey(0,0,false));
 
 			std::stringstream ssFragmentShader;
-			_fragmentHeader->write(ssFragmentShader);
+			_fragmentHeader->write(ssFragmentShader, CombinerKey(0,0,false));
 
 			if (config.texture.bilinearMode == BILINEAR_STANDARD) {
 				TexrectDrawerTexBilinearFilter filter(_glinfo);
-				filter.write(ssFragmentShader);
+				filter.write(ssFragmentShader, CombinerKey(0,0,false));
 			} else {
 				TexrectDrawerTex3PointFilter filter(_glinfo);
-				filter.write(ssFragmentShader);
+				filter.write(ssFragmentShader, CombinerKey(0,0,false));
 			}
 
 			TexrectDrawerFragmentDraw fragmentMain(_glinfo);
-			fragmentMain.write(ssFragmentShader);
+			fragmentMain.write(ssFragmentShader, CombinerKey(0,0,false));
 
 			m_program =
 				graphics::ObjectHandle(Utils::createRectShaderProgram(ssVertexShader.str().data(), ssFragmentShader.str().data()));


### PR DESCRIPTION
This is an ongoing attempt to continue to reduce shader logic as an experiment to improve performance on low end devices. I have removed only a few uniforms per commit to make it easy to find any regressions.

Although, I'm currently stuck, in the last commit where I removed ```uFbMonochrome``` and ```uFbFixedAlpha```, I'm getting this error in CBFD:

![conker_bfd-002](https://user-images.githubusercontent.com/11581687/33799157-cdb07e58-dcf3-11e7-86db-da5f9142d9ff.png)

Conker has a black spot in his shirt.

All I can say is that ```ShaderFragmentReadTex0```, ```_key.getFbMonochrome0()``` is coming out to 1 instead of zero when it shouldn't. @gonetz Any ideas?