### PR TITLE
Fix slow down on Adreno 540 GPUs.

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -478,7 +478,7 @@ struct FramebufferTextureFormatsGLES3 : public graphics::FramebufferTextureForma
 protected:
 	void init() override
 	{
-		if (m_glinfo.renderer == Renderer::Adreno500) {
+		if (m_glinfo.renderer == Renderer::Adreno530) {
 			colorInternalFormat = GL_RGBA32F;
 			colorFormat = GL_RGBA;
 			colorType = GL_FLOAT;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -27,8 +27,11 @@ void GLInfo::init() {
 	LOG(LOG_VERBOSE, "OpenGL vendor: %s\n", glGetString(GL_VENDOR));
 	const GLubyte * strRenderer = glGetString(GL_RENDERER);
 
-	if (std::regex_match(std::string((const char*)strRenderer), std::regex("Adreno.*5\\d\\d") ))
-		renderer = Renderer::Adreno500;
+	if (std::regex_match(std::string((const char*)strRenderer), std::regex("Adreno.*530")))
+		renderer = Renderer::Adreno530;
+	else if (std::regex_match(std::string((const char*)strRenderer), std::regex("Adreno.*540")) ||
+		std::regex_match(std::string((const char*)strRenderer), std::regex("Adreno.*6\\d\\d")))
+		renderer = Renderer::Adreno_no_bugs;
 	else if (strstr((const char*)strRenderer, "Adreno") != nullptr)
 		renderer = Renderer::Adreno;
 	else if (strstr((const char*)strRenderer, "VideoCore IV") != nullptr)

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -4,7 +4,8 @@
 namespace opengl {
 
 enum class Renderer {
-	Adreno500,
+	Adreno530,
+	Adreno_no_bugs,
 	Adreno,
 	VideoCore,
 	Intel,


### PR DESCRIPTION
Adreno 540 GPUs don't need to frame buffer textures to be in floating point format. And actually, it runs a lot faster when using integer format. So limit the floating point frame buffer texture workaround to only Adreno 530.