### PR TITLE
Adjust font defaults

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -94,9 +94,11 @@ void Config::resetToDefaults()
 #elif defined (OS_ANDROID)
 	font.name.assign("DroidSans.ttf");
 #elif defined (PANDORA)
-	font.name.assign("LiberationMono-Regular.ttf");
+	font.name.assign("truetype/LiberationMono-Regular.ttf");
+#elif defined (OS_LINUX)
+	font.name.assign("liberation/LiberationMono-Regular.ttf");
 #else
-	font.name = "FreeSans.ttf";
+	font.name.assign("truetype/freefont/FreeSans.ttf");
 #endif
 	font.size = 18;
 	font.color[0] = 0xB5;

--- a/src/TextDrawer.cpp
+++ b/src/TextDrawer.cpp
@@ -202,9 +202,11 @@ bool getFontFileName(char * _strName)
 #elif defined (OS_ANDROID)
 	sprintf(_strName, "/system/fonts/%s", config.font.name.c_str());
 #elif defined (PANDORA)
-	sprintf(_strName, "/usr/share/fonts/truetype/%s", config.font.name.c_str());
+	sprintf(_strName, "/usr/share/fonts/%s", config.font.name.c_str());
+#elif defined (OS_LINUX)
+	sprintf(_strName, "/usr/share/fonts/%s", config.font.name.c_str());
 #else
-    sprintf(_strName, "/usr/share/fonts/truetype/freefont/%s", config.font.name.c_str());
+	sprintf(_strName, "/usr/share/fonts/%s", config.font.name.c_str());
 #endif
 	return true;
 }


### PR DESCRIPTION
On Linux systems (Fedora, Ubuntu, OpenSUSE, etc.) it's far more likely that they're going to have `LiberationMono` instead of `FreeSans` installed by default (which comes with a GNU package). Also, I adjusted the font paths because `/usr/share/fonts` is universal, but not all fonts will be installed to the same subdirs.