### PR TITLE
Keep track of FB attachments

### DIFF
--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -90,9 +90,9 @@ ObjectHandle Context::createTexture(Parameter _target)
 	return m_impl->createTexture(_target);
 }
 
-void Context::deleteTexture(ObjectHandle _name)
+void Context::deleteTexture(ObjectHandle _name, bool _isFBTexture)
 {
-	m_impl->deleteTexture(_name);
+	m_impl->deleteTexture(_name, _isFBTexture);
 }
 
 void Context::init2DTexture(const InitTextureParams & _params)

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -65,7 +65,7 @@ namespace graphics {
 
 		ObjectHandle createTexture(Parameter _target);
 
-		void deleteTexture(ObjectHandle _name);
+		void deleteTexture(ObjectHandle _name, bool _isFBTexture);
 
 		struct InitTextureParams {
 			ObjectHandle handle;

--- a/src/Graphics/ContextImpl.h
+++ b/src/Graphics/ContextImpl.h
@@ -24,7 +24,7 @@ namespace graphics {
 		virtual void clearDepthBuffer() = 0;
 		virtual void setPolygonOffset(f32 _factor, f32 _units) = 0;
 		virtual ObjectHandle createTexture(Parameter _target) = 0;
-		virtual void deleteTexture(ObjectHandle _name) = 0;
+		virtual void deleteTexture(ObjectHandle _name, bool _isFBTexture) = 0;
 		virtual void init2DTexture(const Context::InitTextureParams & _params) = 0;
 		virtual void update2DTexture(const Context::UpdateTextureDataParams & _params) = 0;
 		virtual void setTextureParameters(const Context::TexParameters & _parameters) = 0;

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
@@ -157,6 +157,7 @@ void CachedFunctions::reset()
 	for (auto it : m_enables)
 		it.second.reset();
 
+	m_fbattachments.clear();
 	m_bindTexture.reset();
 	m_bindFramebuffer.reset();
 	m_bindRenderbuffer.reset();
@@ -259,4 +260,9 @@ CachedUseProgram * CachedFunctions::getCachedUseProgram()
 CachedTextureUnpackAlignment * CachedFunctions::getCachedTextureUnpackAlignment()
 {
 	return &m_unpackAlignment;
+}
+
+FramebufferAttachments * CachedFunctions::getFBAttachments()
+{
+	return &m_fbattachments;
 }

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
@@ -205,6 +205,8 @@ namespace opengl {
 		void setTextureUnpackAlignment(s32 _param);
 	};
 
+	typedef std::unordered_map<u32, u32> FramebufferAttachments;
+
 	/*---------------CachedFunctions-------------*/
 
 	class CachedFunctions
@@ -247,9 +249,12 @@ namespace opengl {
 
 		CachedTextureUnpackAlignment * getCachedTextureUnpackAlignment();
 
+		FramebufferAttachments * getFBAttachments();
+
 	private:
 		typedef std::unordered_map<u32, CachedEnable> EnableParameters;
 
+		FramebufferAttachments m_fbattachments;
 		EnableParameters m_enables;
 		CachedBindTexture m_bindTexture;
 		CachedBindFramebuffer m_bindFramebuffer;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -251,6 +251,7 @@ void ContextImpl::deleteFramebuffer(graphics::ObjectHandle _name)
 	if (fbo != 0) {
 		glDeleteFramebuffers(1, &fbo);
 		m_cachedFunctions->getCachedBindFramebuffer()->reset();
+		m_cachedFunctions->getFBAttachments()->erase(u32(_name));
 	}
 }
 

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -165,11 +165,21 @@ graphics::ObjectHandle ContextImpl::createTexture(graphics::Parameter _target)
 	return m_createTexture->createTexture(_target);
 }
 
-void ContextImpl::deleteTexture(graphics::ObjectHandle _name)
+void ContextImpl::deleteTexture(graphics::ObjectHandle _name, bool _isFBTexture)
 {
 	u32 glName(_name);
 	glDeleteTextures(1, &glName);
 	m_init2DTexture->reset(_name);
+
+	if (_isFBTexture) {
+		FramebufferAttachments * fbAtt =  m_cachedFunctions->getFBAttachments();
+		for (auto iter = fbAtt->begin(); iter != fbAtt->end(); ++iter) {
+			if (iter->second == u32(_name)) {
+				fbAtt->erase(iter);
+				break;
+			}
+		}
+	}
 }
 
 void ContextImpl::init2DTexture(const graphics::Context::InitTextureParams & _params)

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -50,7 +50,7 @@ namespace opengl {
 
 		graphics::ObjectHandle createTexture(graphics::Parameter _target) override;
 
-		void deleteTexture(graphics::ObjectHandle _name) override;
+		void deleteTexture(graphics::ObjectHandle _name, bool _isFBTexture) override;
 
 		void init2DTexture(const graphics::Context::InitTextureParams & _params) override;
 

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -527,12 +527,12 @@ void TextureCache::destroy()
 	current[0] = current[1] = nullptr;
 
 	for (Textures::const_iterator cur = m_textures.cbegin(); cur != m_textures.cend(); ++cur)
-		gfxContext.deleteTexture(cur->name);
+		gfxContext.deleteTexture(cur->name, false);
 	m_textures.clear();
 	m_lruTextureLocations.clear();
 
 	for (FBTextures::const_iterator cur = m_fbTextures.cbegin(); cur != m_fbTextures.cend(); ++cur)
-		gfxContext.deleteTexture(cur->second.name);
+		gfxContext.deleteTexture(cur->second.name, true);
 	m_fbTextures.clear();
 }
 
@@ -540,7 +540,7 @@ void TextureCache::_checkCacheSize()
 {
 	if (m_textures.size() >= m_maxCacheSize) {
 		CachedTexture& clsTex = m_textures.back();
-		gfxContext.deleteTexture(clsTex.name);
+		gfxContext.deleteTexture(clsTex.name, false);
 		m_lruTextureLocations.erase(clsTex.crc);
 		m_textures.pop_back();
 	}
@@ -564,7 +564,7 @@ void TextureCache::removeFrameBufferTexture(CachedTexture * _pTexture)
 		return;
 	FBTextures::const_iterator iter = m_fbTextures.find(u32(_pTexture->name));
 	assert(iter != m_fbTextures.cend());
-	gfxContext.deleteTexture(ObjectHandle(iter->second.name));
+	gfxContext.deleteTexture(ObjectHandle(iter->second.name), true);
 	m_fbTextures.erase(iter);
 }
 
@@ -1445,7 +1445,7 @@ void TextureCache::_clear()
 	current[0] = current[1] = nullptr;
 
 	for (auto cur = m_textures.cbegin(); cur != m_textures.cend(); ++cur) {
-		gfxContext.deleteTexture(cur->name);
+		gfxContext.deleteTexture(cur->name, false);
 	}
 	m_textures.clear();
 	m_lruTextureLocations.clear();
@@ -1543,7 +1543,7 @@ void TextureCache::update(u32 _t)
 			return;
 		}
 
-		gfxContext.deleteTexture(currentTex.name);
+		gfxContext.deleteTexture(currentTex.name, false);
 		m_lruTextureLocations.erase(locations_iter);
 		m_textures.erase(iter);
 	}


### PR DESCRIPTION
This is a minor optimisation to reduce the number of times glFramebufferTexture2D and glBindFramebuffer is called.

It just keeps track of the attachments and ignores redundant calls. glFramebufferTexture2D itself probably isn't an expensive all, but glBindFramebuffer can be expensive on mobile chipsets and should be avoided when possible