### PR TITLE
Only do depth hack for GLES devices

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -143,8 +143,10 @@ void ContextImpl::clearDepthBuffer()
 	enableScissor->enable(false);
 
 #ifdef OS_ANDROID
-	depthMask->setDepthMask(false);
-	glClear(GL_DEPTH_BUFFER_BIT);
+	if (m_glInfo.isGLESX) {
+		depthMask->setDepthMask(false);
+		glClear(GL_DEPTH_BUFFER_BIT);
+	}
 #endif
 
 	depthMask->setDepthMask(true);


### PR DESCRIPTION
This was actually a hack to fix some depth issue on certain Android devices (I want to say it was only PowerVR devices, but I can't remember exactly).

According to at least one GPU vendor (Adreno): https://developer.qualcomm.com/qfile/28557/80-nu141-1_b_adreno_opengl_es_developer_guide.pdf

> The Adreno driver handles glClear() calls by drawing viewport-covering quads into the frame
buffer, using clear color values specified earlier by the application. Clear calls operate at the
normal pixel rate.
Avoid redundant clears as they are costly.

So ideally this would actually just apply to whatever GPU driver had the issue, but at least it should apply to GLES devices only (not OpenGL/Nvidia devices that have good drivers)