### PR TITLE
Cache glTexParameter calls

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
@@ -157,6 +157,7 @@ void CachedFunctions::reset()
 	for (auto it : m_enables)
 		it.second.reset();
 
+	m_fbattachments.clear();
 	m_bindTexture.reset();
 	m_bindFramebuffer.reset();
 	m_bindRenderbuffer.reset();
@@ -259,4 +260,9 @@ CachedUseProgram * CachedFunctions::getCachedUseProgram()
 CachedTextureUnpackAlignment * CachedFunctions::getCachedTextureUnpackAlignment()
 {
 	return &m_unpackAlignment;
+}
+
+FramebufferAttachments * CachedFunctions::getFBAttachments()
+{
+	return &m_fbattachments;
 }

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
@@ -157,6 +157,7 @@ void CachedFunctions::reset()
 	for (auto it : m_enables)
 		it.second.reset();
 
+	m_texparams.clear();
 	m_fbattachments.clear();
 	m_bindTexture.reset();
 	m_bindFramebuffer.reset();
@@ -265,4 +266,9 @@ CachedTextureUnpackAlignment * CachedFunctions::getCachedTextureUnpackAlignment(
 FramebufferAttachments * CachedFunctions::getFBAttachments()
 {
 	return &m_fbattachments;
+}
+
+TextureParams * CachedFunctions::getTexParams()
+{
+	return &m_texparams;
 }

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
@@ -205,7 +205,17 @@ namespace opengl {
 		void setTextureUnpackAlignment(s32 _param);
 	};
 
+	struct texture_params {
+		GLint magFilter;
+		GLint minFilter;
+		GLint wrapS;
+		GLint wrapT;
+		GLint maxMipmapLevel;
+		GLfloat maxAnisotropy;
+	};
+
 	typedef std::unordered_map<u32, u32> FramebufferAttachments;
+	typedef std::unordered_map<u32, texture_params> TextureParams;
 
 	/*---------------CachedFunctions-------------*/
 
@@ -251,9 +261,12 @@ namespace opengl {
 
 		FramebufferAttachments * getFBAttachments();
 
+		TextureParams * getTexParams();
+
 	private:
 		typedef std::unordered_map<u32, CachedEnable> EnableParameters;
 
+		TextureParams m_texparams;
 		FramebufferAttachments m_fbattachments;
 		EnableParameters m_enables;
 		CachedBindTexture m_bindTexture;

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
@@ -205,6 +205,8 @@ namespace opengl {
 		void setTextureUnpackAlignment(s32 _param);
 	};
 
+	typedef std::unordered_map<u32, u32> FramebufferAttachments;
+
 	/*---------------CachedFunctions-------------*/
 
 	class CachedFunctions
@@ -247,9 +249,12 @@ namespace opengl {
 
 		CachedTextureUnpackAlignment * getCachedTextureUnpackAlignment();
 
+		FramebufferAttachments * getFBAttachments();
+
 	private:
 		typedef std::unordered_map<u32, CachedEnable> EnableParameters;
 
+		FramebufferAttachments m_fbattachments;
 		EnableParameters m_enables;
 		CachedBindTexture m_bindTexture;
 		CachedBindFramebuffer m_bindFramebuffer;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -251,6 +251,7 @@ void ContextImpl::deleteFramebuffer(graphics::ObjectHandle _name)
 	if (fbo != 0) {
 		glDeleteFramebuffers(1, &fbo);
 		m_cachedFunctions->getCachedBindFramebuffer()->reset();
+		m_cachedFunctions->getFBAttachments()->erase(u32(_name));
 	}
 }
 

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -170,6 +170,7 @@ void ContextImpl::deleteTexture(graphics::ObjectHandle _name)
 	u32 glName(_name);
 	glDeleteTextures(1, &glName);
 	m_init2DTexture->reset(_name);
+	m_cachedFunctions->getTexParams()->erase(u32(_name));
 }
 
 void ContextImpl::init2DTexture(const graphics::Context::InitTextureParams & _params)


### PR DESCRIPTION
This PR depends on https://github.com/gonetz/GLideN64/pull/1727. Please only focus on commit https://github.com/gonetz/GLideN64/commit/83b8ba35bf8b87f7f67d115e1610639afb0188b9 for this PR, the other commit is from the other PR.

This furthers the work of optimizing the GL calls.

I profiled the application on my laptop, here are the top 10 GL calls from 60 seconds of GoldenEye (sorted by the total time spent servicing each call):

![image](https://user-images.githubusercontent.com/848146/36561606-74fee02e-17d1-11e8-8d7c-5b50b8c0831f.png)

Most of that is pretty normal, except you can see that glTexParameteri is called about 1.5 million times, and it's number 4 on the list.

Here is the summary of my CPU/GPU usage (related to OpenGL):

![image](https://user-images.githubusercontent.com/848146/36561656-a30b9944-17d1-11e8-82e4-f909accba9cd.png)

After this PR, glTexParameteri is only called about 10,000 times over the same time period, and here is my CPU/GPU usage:

![image](https://user-images.githubusercontent.com/848146/36561703-c54f6b98-17d1-11e8-87f0-78d060cfa09e.png)

As you can see, the difference isn't massive, but it's measurable, and the benefit may be more pronounced on slower devices.