### PR TITLE
Cleanup FB Texture caching code

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -79,7 +79,6 @@ void ColorBufferToRDRAM::_initFBTexture(void)
 	m_pTexture->realWidth = m_lastBufferWidth;
 	m_pTexture->realHeight = VI_GetMaxBufferHeight(m_lastBufferWidth);
 	m_pTexture->textureBytes = m_pTexture->realWidth * m_pTexture->realHeight * fbTexFormat.colorFormatBytes;
-	textureCache().addFrameBufferTextureSize(m_pTexture->textureBytes);
 
 	{
 		Context::InitTextureParams params;

--- a/src/BufferCopy/DepthBufferToRDRAM.cpp
+++ b/src/BufferCopy/DepthBufferToRDRAM.cpp
@@ -61,7 +61,6 @@ void DepthBufferToRDRAM::init()
 	m_pColorTexture->realWidth = DEPTH_TEX_WIDTH;
 	m_pColorTexture->realHeight = DEPTH_TEX_HEIGHT;
 	m_pColorTexture->textureBytes = m_pColorTexture->realWidth * m_pColorTexture->realHeight;
-	textureCache().addFrameBufferTextureSize(m_pColorTexture->textureBytes);
 
 	m_pDepthTexture = textureCache().addFrameBufferTexture(false);
 	m_pDepthTexture->format = G_IM_FMT_I;
@@ -76,7 +75,6 @@ void DepthBufferToRDRAM::init()
 	m_pDepthTexture->realWidth = DEPTH_TEX_WIDTH;
 	m_pDepthTexture->realHeight = DEPTH_TEX_HEIGHT;
 	m_pDepthTexture->textureBytes = m_pDepthTexture->realWidth * m_pDepthTexture->realHeight * sizeof(float);
-	textureCache().addFrameBufferTextureSize(m_pDepthTexture->textureBytes);
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
 	Context::InitTextureParams initParams;

--- a/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -43,7 +43,6 @@ void RDRAMtoColorBuffer::init()
 	m_pTexture->realWidth = 640;
 	m_pTexture->realHeight = 580;
 	m_pTexture->textureBytes = m_pTexture->realWidth * m_pTexture->realHeight * fbTexFormats.colorFormatBytes;
-	textureCache().addFrameBufferTextureSize(m_pTexture->textureBytes);
 
 	Context::InitTextureParams initParams;
 	initParams.handle = m_pTexture->name;

--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -59,7 +59,6 @@ void DepthBuffer::_initDepthImageTexture(FrameBuffer * _pBuffer, CachedTexture& 
 	_cachedTexture.realWidth = _cachedTexture.width;
 	_cachedTexture.realHeight = _cachedTexture.height;
 	_cachedTexture.textureBytes = _cachedTexture.realWidth * _cachedTexture.realHeight * fbTexFormat.depthImageFormatBytes;
-	textureCache().addFrameBufferTextureSize(_cachedTexture.textureBytes);
 
 	{
 		Context::InitTextureParams params;
@@ -133,7 +132,6 @@ void DepthBuffer::_initDepthBufferTexture(FrameBuffer * _pBuffer, CachedTexture 
 	_pTexture->realWidth = _pTexture->width;
 	_pTexture->realHeight = _pTexture->height;
 	_pTexture->textureBytes = _pTexture->realWidth * _pTexture->realHeight * fbTexFormat.depthFormatBytes;
-	textureCache().addFrameBufferTextureSize(_pTexture->textureBytes);
 
 	Context::InitTextureParams initParams;
 	initParams.handle = _pTexture->name;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -95,7 +95,6 @@ void FrameBuffer::_initTexture(u16 _width, u16 _height, u16 _format, u16 _size, 
 		_pTexture->textureBytes *= fbTexFormats.colorFormatBytes;
 	else
 		_pTexture->textureBytes *= fbTexFormats.monochromeFormatBytes;
-	textureCache().addFrameBufferTextureSize(_pTexture->textureBytes);
 }
 
 void FrameBuffer::_setAndAttachTexture(ObjectHandle _fbo, CachedTexture *_pTexture, u32 _t, bool _multisampling)

--- a/src/NoiseTexture.cpp
+++ b/src/NoiseTexture.cpp
@@ -125,7 +125,6 @@ void NoiseTexture::init()
 		m_pTexture[i]->realWidth = NOISE_TEX_WIDTH;
 		m_pTexture[i]->realHeight = NOISE_TEX_HEIGHT;
 		m_pTexture[i]->textureBytes = m_pTexture[i]->realWidth * m_pTexture[i]->realHeight;
-		textureCache().addFrameBufferTextureSize(m_pTexture[i]->textureBytes);
 
 		const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
 		{

--- a/src/PaletteTexture.cpp
+++ b/src/PaletteTexture.cpp
@@ -37,7 +37,6 @@ void PaletteTexture::init()
 	m_pTexture->realWidth = 256;
 	m_pTexture->realHeight = 1;
 	m_pTexture->textureBytes = m_pTexture->realWidth * m_pTexture->realHeight * fbTexFormats.lutFormatBytes;
-	textureCache().addFrameBufferTextureSize(m_pTexture->textureBytes);
 
 	Context::InitTextureParams initParams;
 	initParams.handle = m_pTexture->name;

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -36,7 +36,6 @@ void PostProcessor::_createResultBuffer(const FrameBuffer * _pMainBuffer)
 	pTexture->realWidth = pMainTexture->realWidth;
 	pTexture->realHeight = pMainTexture->realHeight;
 	pTexture->textureBytes = pTexture->realWidth * pTexture->realHeight * 4;
-	textureCache().addFrameBufferTextureSize(pTexture->textureBytes);
 
 	Context::InitTextureParams initParams;
 	initParams.handle = pTexture->name;

--- a/src/TexrectDrawer.cpp
+++ b/src/TexrectDrawer.cpp
@@ -46,7 +46,6 @@ void TexrectDrawer::init()
 	m_pTexture->realWidth = 640;
 	m_pTexture->realHeight = 580;
 	m_pTexture->textureBytes = m_pTexture->realWidth * m_pTexture->realHeight * fbTexFormats.colorFormatBytes;
-	textureCache().addFrameBufferTextureSize(m_pTexture->textureBytes);
 	m_stepX = 2.0f / 640.0f;
 	m_stepY = 2.0f / 580.0f;
 

--- a/src/TextDrawer.cpp
+++ b/src/TextDrawer.cpp
@@ -106,7 +106,6 @@ struct Atlas {
 		m_pTexture->realWidth = w;
 		m_pTexture->realHeight = h;
 		m_pTexture->textureBytes = m_pTexture->realWidth * m_pTexture->realHeight * fbTexFormats.noiseFormatBytes;
-		textureCache().addFrameBufferTextureSize(m_pTexture->textureBytes);
 
 		Context::InitTextureParams initParams;
 		initParams.handle = m_pTexture->name;

--- a/src/Textures.h
+++ b/src/Textures.h
@@ -54,7 +54,6 @@ struct TextureCache
 	void init();
 	void destroy();
 	CachedTexture * addFrameBufferTexture(bool _multisample);
-	void addFrameBufferTextureSize(u32 _size) {m_cachedBytes += _size;}
 	void removeFrameBufferTexture(CachedTexture * _pTexture);
 	void activateTexture(u32 _t, CachedTexture *_pTexture);
 	void activateDummy(u32 _t);
@@ -69,7 +68,6 @@ private:
 		, m_pMSDummy(nullptr)
 		, m_hits(0)
 		, m_misses(0)
-		, m_cachedBytes(0)
 		, m_curUnpackAlignment(4)
 		, m_toggleDumpTex(false)
 	{
@@ -93,14 +91,13 @@ private:
 
 	typedef std::list<CachedTexture> Textures;
 	typedef std::unordered_map<u32, Textures::iterator> Texture_Locations;
-	typedef std::map<graphics::ObjectHandle, CachedTexture> FBTextures;
+	typedef std::unordered_map<u32, CachedTexture> FBTextures;
 	Textures m_textures;
 	Texture_Locations m_lruTextureLocations;
 	FBTextures m_fbTextures;
 	CachedTexture * m_pDummy;
 	CachedTexture * m_pMSDummy;
 	u32 m_hits, m_misses;
-	u32 m_cachedBytes;
 	s32 m_curUnpackAlignment;
 	bool m_toggleDumpTex;
 	const size_t m_maxCacheSize = 8000;

--- a/src/ZlutTexture.cpp
+++ b/src/ZlutTexture.cpp
@@ -38,7 +38,6 @@ void ZlutTexture::init()
 	m_pTexture->realWidth = 512;
 	m_pTexture->realHeight = 512;
 	m_pTexture->textureBytes = m_pTexture->realWidth * m_pTexture->realHeight * fbTexFormats.lutFormatBytes;
-	textureCache().addFrameBufferTextureSize(m_pTexture->textureBytes);
 
 	Context::InitTextureParams initParams;
 	initParams.handle = m_pTexture->name;


### PR DESCRIPTION
m_cachedBytes is not actually read or used anymore, so I removed it and all its modifiers.

I also switched FBTextures from a map to an unordered_map, since the order of the elements doesn't matter and unordered_map offers faster searching.

Finally, I removed the call to ```_checkCacheSize()``` when adding a FBTexture. _checkCacheSize() just checks the number of elements in the regular texture cache, and removes one if its full. The FBTextures have nothing to do with that cache (adding an FBTexture doesn't add to that list), so we shouldn't be checking that texture cache when adding a FBTexture