### PR TITLE
Reduce some debug GL calls in production

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_Utils.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_Utils.cpp
@@ -29,6 +29,7 @@ static const GLsizei nShaderLogSize = 1024;
 
 bool Utils::checkShaderCompileStatus(GLuint obj)
 {
+#ifdef GL_DEBUG
 	GLint status;
 	glGetShaderiv(obj, GL_COMPILE_STATUS, &status);
 	if (status == GL_FALSE) {
@@ -39,11 +40,13 @@ bool Utils::checkShaderCompileStatus(GLuint obj)
 		LOG(LOG_ERROR, "shader_compile error: %s\n", shader_log);
 		return false;
 	}
+#endif
 	return true;
 }
 
 bool Utils::checkProgramLinkStatus(GLuint obj)
 {
+#ifdef GL_DEBUG
 	GLint status;
 	glGetProgramiv(obj, GL_LINK_STATUS, &status);
 	if (status == GL_FALSE) {
@@ -53,6 +56,7 @@ bool Utils::checkProgramLinkStatus(GLuint obj)
 		LOG(LOG_ERROR, "shader_link error: %s\n", shader_log);
 		return false;
 	}
+#endif
 	return true;
 }
 

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -431,10 +431,7 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 	case graphics::SpecialFeatures::ShaderProgramBinary:
 		return m_glInfo.shaderStorage;
 	case graphics::SpecialFeatures::DepthFramebufferTextures:
-		if (!m_glInfo.isGLES2 || Utils::isExtensionSupported(m_glInfo, "GL_OES_depth_texture"))
-			return true;
-		else
-			return false;
+		return m_glInfo.depthTexture;
 	}
 	return false;
 }

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -92,4 +92,6 @@ void GLInfo::init() {
 			LOG(LOG_WARNING, "LOD emulation not possible on this device\n");
 		}
 	}
+
+	depthTexture = !isGLES2 || Utils::isExtensionSupported(*this, "GL_OES_depth_texture");
 }

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -23,6 +23,7 @@ struct GLInfo {
 	bool texStorage    = false;
 	bool shaderStorage = false;
 	bool msaa = false;
+	bool depthTexture = false;
 	Renderer renderer = Renderer::Other;
 
 	void init();

--- a/src/Graphics/OpenGLContext/opengl_Utils.cpp
+++ b/src/Graphics/OpenGLContext/opengl_Utils.cpp
@@ -82,6 +82,7 @@ const char* GLErrorString(GLenum errorCode)
 
 bool Utils::isGLError()
 {
+#ifdef GL_DEBUG
 	GLenum errCode;
 	const char* errString;
 
@@ -95,11 +96,13 @@ bool Utils::isGLError()
 
 		return true;
 	}
+#endif
 	return false;
 }
 
 bool Utils::isFramebufferError()
 {
+#ifdef GL_DEBUG
 	GLenum e = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 	switch (e) {
 		//		case GL_FRAMEBUFFER_UNDEFINED:
@@ -131,4 +134,7 @@ bool Utils::isFramebufferError()
 	}
 
 	return e != GL_FRAMEBUFFER_COMPLETE;
+#else
+	return false;
+#endif
 }


### PR DESCRIPTION
We are currently calling glGetError() (and glCheckFramebufferStatus()) in the production builds. This could have a negative impact on performance, and we already have a GL_DEBUG definition in other areas of the code.

I also moved the check for depth texture support into GLInfo::init(). Checking for extension support only needs to be done once, and could also have a performance impact.