### PR TITLE
Only use ColorBufferReaderWithBufferStorage for GLES

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_BufferedDrawer.h
+++ b/src/Graphics/OpenGLContext/opengl_BufferedDrawer.h
@@ -49,7 +49,6 @@ namespace opengl {
 		struct TrisBuffers {
 			GLuint vao = 0;
 			Buffer vbo = Buffer(GL_ARRAY_BUFFER);
-			Buffer ebo = Buffer(GL_ELEMENT_ARRAY_BUFFER);
 		};
 
 		struct Vertex

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -298,7 +298,7 @@ graphics::PixelReadBuffer * ContextImpl::createPixelReadBuffer(size_t _sizeInByt
 
 graphics::ColorBufferReader * ContextImpl::createColorBufferReader(CachedTexture * _pTexture)
 {
-	if (m_glInfo.bufferStorage && m_glInfo.renderer != Renderer::Intel)
+	if (m_glInfo.bufferStorage && m_glInfo.isGLESX)
 		return new ColorBufferReaderWithBufferStorage(_pTexture, m_cachedFunctions->getCachedBindBuffer());
 
 	if (!m_glInfo.isGLES2)


### PR DESCRIPTION
I have tested sync and async performance on Mesa and Windows+NVidia and saw no performance difference using ColorBufferReaderWithBufferStorage.

Given that we've had performance issues with Intel (https://github.com/gonetz/GLideN64/issues/1312), and now AMD+Mesa (https://github.com/gonetz/GLideN64/issues/1561), I think it would be best to just enable it for GLES

@Jj0YzL5nvJ can you please test this PR with the latest master + ```EnableCopyColorToRDRAM = 2``` and let me know if it resolves your issue and runs at full speed?