### PR TITLE
Remove PixelWriteBuffer

### DIFF
--- a/src/BufferCopy/RDRAMtoColorBuffer.h
+++ b/src/BufferCopy/RDRAMtoColorBuffer.h
@@ -6,10 +6,6 @@
 #include <Graphics/ObjectHandle.h>
 #include <FrameBuffer.h>
 
-namespace graphics {
-	class PixelWriteBuffer;
-}
-
 struct CachedTexture;
 struct FrameBuffer;
 
@@ -47,7 +43,7 @@ private:
 	FrameBuffer * m_pCurBuffer;
 	CachedTexture * m_pTexture;
 	std::vector<u32> m_vecAddress;
-	std::unique_ptr<graphics::PixelWriteBuffer> m_pbuf;
+	u8* m_pbuf;
 };
 
 #endif // RDRAMtoColorBuffer_H

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -182,11 +182,6 @@ bool Context::blitFramebuffers(const BlitFramebuffersParams & _params)
 	return m_impl->blitFramebuffers(_params);
 }
 
-PixelWriteBuffer * Context::createPixelWriteBuffer(size_t _sizeInBytes)
-{
-	return m_impl->createPixelWriteBuffer(_sizeInBytes);
-}
-
 PixelReadBuffer * Context::createPixelReadBuffer(size_t _sizeInBytes)
 {
 	return m_impl->createPixelReadBuffer(_sizeInBytes);

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -192,8 +192,6 @@ namespace graphics {
 
 		/*---------------Pixelbuffer-------------*/
 
-		PixelWriteBuffer * createPixelWriteBuffer(size_t _sizeInBytes);
-
 		PixelReadBuffer * createPixelReadBuffer(size_t _sizeInBytes);
 
 		ColorBufferReader * createColorBufferReader(CachedTexture * _pTexture);

--- a/src/Graphics/ContextImpl.h
+++ b/src/Graphics/ContextImpl.h
@@ -42,7 +42,6 @@ namespace graphics {
 		virtual ObjectHandle createRenderbuffer() = 0;
 		virtual void initRenderbuffer(const Context::InitRenderbufferParams & _params) = 0;
 		virtual bool blitFramebuffers(const Context::BlitFramebuffersParams & _params) = 0;
-		virtual PixelWriteBuffer * createPixelWriteBuffer(size_t _sizeInBytes) = 0;
 		virtual PixelReadBuffer * createPixelReadBuffer(size_t _sizeInBytes) = 0;
 		virtual ColorBufferReader * createColorBufferReader(CachedTexture * _pTexture) = 0;
 		virtual bool isCombinerProgramBuilderObsolete() = 0;

--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -120,173 +120,6 @@ public:
 	}
 };
 
-/*---------------CreatePixelWriteBuffer-------------*/
-
-class PBOWriteBuffer : public graphics::PixelWriteBuffer
-{
-public:
-	PBOWriteBuffer(CachedBindBuffer * _bind, size_t _size)
-		: m_bind(_bind)
-		, m_size(_size)
-	{
-		glGenBuffers(1, &m_PBO);
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle(m_PBO));
-		glBufferData(GL_PIXEL_UNPACK_BUFFER, m_size, nullptr, GL_DYNAMIC_DRAW);
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle::null);
-	}
-
-	~PBOWriteBuffer() {
-		glDeleteBuffers(1, &m_PBO);
-		m_PBO = 0;
-	}
-
-	void * getWriteBuffer(size_t _size) override
-	{
-		if (_size > m_size)
-			_size = m_size;
-		return glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, _size, GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
-	}
-
-	void closeWriteBuffer() override
-	{
-		glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
-	}
-
-	void * getData() override {
-		return nullptr;
-	}
-
-	void bind() override {
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle(m_PBO));
-	}
-
-	void unbind() override {
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle::null);
-	}
-
-private:
-	CachedBindBuffer * m_bind;
-	size_t m_size;
-	GLuint m_PBO;
-};
-
-class PersistentWriteBuffer : public graphics::PixelWriteBuffer
-{
-public:
-	PersistentWriteBuffer(CachedBindBuffer * _bind, size_t _size)
-		: m_bind(_bind)
-		, m_size(_size)
-	{
-		glGenBuffers(1, &m_PBO);
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle(m_PBO));
-		glBufferStorage(GL_PIXEL_UNPACK_BUFFER, m_size * 32, nullptr, m_bufAccessBits);
-		m_bufferData = glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, m_size * 32, m_bufMapBits);
-		m_bufferOffset = 0;
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle::null);
-	}
-
-	~PersistentWriteBuffer() {
-		glDeleteBuffers(1, &m_PBO);
-		m_PBO = 0;
-	}
-
-	void * getWriteBuffer(size_t _size) override
-	{
-		if (_size > m_size)
-			_size = m_size;
-		if (m_bufferOffset + _size > m_size * 32)
-			m_bufferOffset = 0;
-		return (char*)m_bufferData + m_bufferOffset;
-	}
-
-	void closeWriteBuffer() override
-	{
-#ifdef GL_DEBUG
-		glFlushMappedBufferRange(GL_PIXEL_UNPACK_BUFFER, m_bufferOffset, m_size);
-#endif
-		m_bufferOffset += m_size;
-	}
-
-	void * getData() override {
-		return (char*)nullptr + m_bufferOffset - m_size;
-	}
-
-	void bind() override {
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle(m_PBO));
-	}
-
-	void unbind() override {
-		m_bind->bind(graphics::Parameter(GL_PIXEL_UNPACK_BUFFER), graphics::ObjectHandle::null);
-	}
-
-private:
-	CachedBindBuffer * m_bind;
-	size_t m_size;
-	void* m_bufferData;
-	u32 m_bufferOffset;
-	GLuint m_PBO;
-#ifndef GL_DEBUG
-	GLbitfield m_bufAccessBits = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
-	GLbitfield m_bufMapBits = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
-#else
-	GLbitfield m_bufAccessBits = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT;
-	GLbitfield m_bufMapBits = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT;
-#endif
-};
-
-class MemoryWriteBuffer : public graphics::PixelWriteBuffer
-{
-public:
-	MemoryWriteBuffer(CachedBindBuffer * _bind, size_t _size)
-		: m_size(_size)
-		, m_pData(new GLubyte[_size])
-	{
-	}
-
-	~MemoryWriteBuffer() {
-	}
-
-	void * getWriteBuffer(size_t _size) override
-	{
-		return m_pData.get();
-	}
-
-	void closeWriteBuffer() override
-	{
-	}
-
-	void * getData() override {
-		return m_pData.get();
-	}
-
-	void bind() override {
-	}
-
-	void unbind() override {
-	}
-
-private:
-	size_t m_size;
-	std::unique_ptr<GLubyte[]> m_pData;
-};
-
-template<typename T>
-class CreatePixelWriteBufferT : public CreatePixelWriteBuffer
-{
-public:
-	CreatePixelWriteBufferT(CachedBindBuffer * _bind)
-		: m_bind(_bind) {
-	}
-
-	graphics::PixelWriteBuffer * createPixelWriteBuffer(size_t _sizeInBytes) override
-	{
-		return new T(m_bind, _sizeInBytes);
-	}
-
-private:
-	CachedBindBuffer * m_bind;
-};
-
 /*---------------CreatePixelReadBuffer-------------*/
 
 class PBOReadBuffer : public graphics::PixelReadBuffer
@@ -323,7 +156,6 @@ public:
 	{
 		glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
 	}
-
 
 	void bind() override {
 		m_bind->bind(graphics::Parameter(GL_PIXEL_PACK_BUFFER), graphics::ObjectHandle(m_PBO));
@@ -613,16 +445,6 @@ BlitFramebuffers * BufferManipulationObjectFactory::getBlitFramebuffers() const
 										m_glInfo.renderer);
 
 	return new DummyBlitFramebuffers;
-}
-
-CreatePixelWriteBuffer * BufferManipulationObjectFactory::createPixelWriteBuffer() const
-{
-	if (m_glInfo.isGLES2)
-		return new CreatePixelWriteBufferT<MemoryWriteBuffer>(nullptr);
-	if (m_glInfo.bufferStorage)
-		return new CreatePixelWriteBufferT<PersistentWriteBuffer>(m_cachedFunctions.getCachedBindBuffer());
-
-	return new CreatePixelWriteBufferT<PBOWriteBuffer>(m_cachedFunctions.getCachedBindBuffer());
 }
 
 CreatePixelReadBuffer * BufferManipulationObjectFactory::createPixelReadBuffer() const

--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.h
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.h
@@ -38,13 +38,6 @@ namespace opengl {
 		virtual void addFrameBufferRenderTarget(const graphics::Context::FrameBufferRenderTarget & _params) = 0;
 	};
 
-	class CreatePixelWriteBuffer
-	{
-	public:
-		virtual ~CreatePixelWriteBuffer() {}
-		virtual graphics::PixelWriteBuffer * createPixelWriteBuffer(size_t _sizeInBytes) = 0;
-	};
-
 	class CreatePixelReadBuffer
 	{
 	public:
@@ -72,8 +65,6 @@ namespace opengl {
 		InitRenderbuffer * getInitRenderbuffer() const;
 
 		AddFramebufferRenderTarget * getAddFramebufferRenderTarget() const;
-
-		CreatePixelWriteBuffer * createPixelWriteBuffer() const;
 
 		CreatePixelReadBuffer * createPixelReadBuffer() const;
 

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -44,10 +44,8 @@ const u8 * ColorBufferReaderWithEGLImage::_readPixels(const ReadColorBufferParam
 	GLenum type = GLenum(_params.colorType);
 
 	void* gpuData = nullptr;
-	const u8* returnData = nullptr;
 
 	if (!_params.sync) {
-
 		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_2D), m_pTexture->name);
 		m_glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_image);
 		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_2D), ObjectHandle());
@@ -56,12 +54,11 @@ const u8 * ColorBufferReaderWithEGLImage::_readPixels(const ReadColorBufferParam
 		m_bufferLocked = true;
 		_heightOffset = static_cast<u32>(_params.y0);
 		_stride = m_pTexture->realWidth;
-
 	} else {
 		gpuData = m_pixelData.data();
 		glReadPixels(_params.x0, _params.y0, _params.width, _params.height, format, type, gpuData);
 		_heightOffset = 0;
-		_stride = 0;
+		_stride = m_pTexture->realWidth;
 	}
 
 	return reinterpret_cast<u8*>(gpuData);

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.h
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.h
@@ -9,7 +9,6 @@
 
 typedef void (APIENTRYP PFNGLEGLIMAGETARGETTEXTURE2DOESPROC) (GLenum target, EGLImageKHR image);
 
-
 namespace opengl {
 
 class ColorBufferReaderWithEGLImage : public graphics::ColorBufferReader

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -54,7 +54,6 @@ void ContextImpl::init()
 		m_createRenderbuffer.reset(bufferObjectFactory.getCreateRenderbuffer());
 		m_initRenderbuffer.reset(bufferObjectFactory.getInitRenderbuffer());
 		m_addFramebufferRenderTarget.reset(bufferObjectFactory.getAddFramebufferRenderTarget());
-		m_createPixelWriteBuffer.reset(bufferObjectFactory.createPixelWriteBuffer());
 		m_createPixelReadBuffer.reset(bufferObjectFactory.createPixelReadBuffer());
 		m_blitFramebuffers.reset(bufferObjectFactory.getBlitFramebuffers());
 	}
@@ -282,11 +281,6 @@ void ContextImpl::addFrameBufferRenderTarget(const graphics::Context::FrameBuffe
 bool ContextImpl::blitFramebuffers(const graphics::Context::BlitFramebuffersParams & _params)
 {
 	return m_blitFramebuffers->blitFramebuffers(_params);
-}
-
-graphics::PixelWriteBuffer * ContextImpl::createPixelWriteBuffer(size_t _sizeInBytes)
-{
-	return m_createPixelWriteBuffer->createPixelWriteBuffer(_sizeInBytes);
 }
 
 graphics::PixelReadBuffer * ContextImpl::createPixelReadBuffer(size_t _sizeInBytes)

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -90,8 +90,6 @@ namespace opengl {
 
 		/*---------------Pixelbuffer-------------*/
 
-		graphics::PixelWriteBuffer * createPixelWriteBuffer(size_t _sizeInBytes) override;
-
 		graphics::PixelReadBuffer * createPixelReadBuffer(size_t _sizeInBytes) override;
 
 		graphics::ColorBufferReader * createColorBufferReader(CachedTexture * _pTexture) override;
@@ -149,7 +147,6 @@ namespace opengl {
 		std::unique_ptr<CreateRenderbuffer> m_createRenderbuffer;
 		std::unique_ptr<InitRenderbuffer> m_initRenderbuffer;
 		std::unique_ptr<AddFramebufferRenderTarget> m_addFramebufferRenderTarget;
-		std::unique_ptr<CreatePixelWriteBuffer> m_createPixelWriteBuffer;
 		std::unique_ptr<CreatePixelReadBuffer> m_createPixelReadBuffer;
 		std::unique_ptr<BlitFramebuffers> m_blitFramebuffers;
 		std::unique_ptr<graphics::FramebufferTextureFormats> m_fbTexFormats;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -60,12 +60,15 @@ void GLInfo::init() {
 	}
 	if (isGLES2)
 		config.generalEmulation.enableFragmentDepthWrite = 0;
+
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");
+
 #ifdef EGL
 	if (isGLESX && bufferStorage)
 		g_glBufferStorage = (PFNGLBUFFERSTORAGEPROC) eglGetProcAddress("glBufferStorageEXT");
 #endif
+
 	texStorage = (isGLESX && (numericVersion >= 30)) || (!isGLESX && numericVersion >= 42) ||
 			Utils::isExtensionSupported(*this, "GL_ARB_texture_storage");
 

--- a/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
@@ -58,7 +58,6 @@ namespace opengl {
 		void init2DTexture(const graphics::Context::InitTextureParams & _params) override
 		{
 			if (_params.msaaLevel == 0) {
-
 				m_bind->bind(_params.textureUnitIndex, graphics::textureTarget::TEXTURE_2D, _params.handle);
 				glTexImage2D(GL_TEXTURE_2D,
 							 _params.mipMapLevel,
@@ -101,8 +100,7 @@ namespace opengl {
 
 		Init2DTexStorage(CachedBindTexture* _bind, bool _imageTextures)
 			: m_bind(_bind)
-			, m_imageTextures(_imageTextures) {
-		}
+			, m_imageTextures(_imageTextures) {}
 
 		void init2DTexture(const graphics::Context::InitTextureParams & _params) override
 		{
@@ -225,8 +223,7 @@ namespace opengl {
 	public:
 		Update2DTexSubImage(CachedBindTexture* _bind, bool _imageTextures)
 			: m_bind(_bind)
-			, m_imageTextures(_imageTextures) {
-		}
+			, m_imageTextures(_imageTextures) {}
 
 		void update2DTexture(const graphics::Context::UpdateTextureDataParams & _params) override
 		{

--- a/src/Graphics/PixelBuffer.h
+++ b/src/Graphics/PixelBuffer.h
@@ -3,17 +3,6 @@
 
 namespace graphics {
 
-	class PixelWriteBuffer
-	{
-	public:
-		virtual ~PixelWriteBuffer() {}
-		virtual void * getWriteBuffer(size_t _size) = 0;
-		virtual void closeWriteBuffer() = 0;
-		virtual void * getData() = 0;
-		virtual void bind() = 0;
-		virtual void unbind() = 0;
-	};
-
 	class PixelReadBuffer
 	{
 	public:
@@ -41,5 +30,4 @@ namespace graphics {
 	private:
 		T * m_buffer;
 	};
-
 }

--- a/src/NoiseTexture.cpp
+++ b/src/NoiseTexture.cpp
@@ -130,11 +130,13 @@ void NoiseTexture::init()
 		{
 			Context::InitTextureParams params;
 			params.handle = m_pTexture[i]->name;
+			params.textureUnitIndex = textureIndices::NoiseTex;
 			params.width = m_pTexture[i]->realWidth;
 			params.height = m_pTexture[i]->realHeight;
 			params.internalFormat = fbTexFormats.noiseInternalFormat;
 			params.format = fbTexFormats.noiseFormat;
 			params.dataType = fbTexFormats.noiseType;
+			params.data = m_texData[i].data();
 			gfxContext.init2DTexture(params);
 		}
 		{
@@ -145,17 +147,6 @@ void NoiseTexture::init()
 			params.minFilter = textureParameters::FILTER_NEAREST;
 			params.magFilter = textureParameters::FILTER_NEAREST;
 			gfxContext.setTextureParameters(params);
-		}
-		{
-			Context::UpdateTextureDataParams params;
-			params.handle = m_pTexture[i]->name;
-			params.textureUnitIndex = textureIndices::NoiseTex;
-			params.width = m_pTexture[i]->realWidth;
-			params.height = m_pTexture[i]->realHeight;
-			params.format = fbTexFormats.noiseFormat;
-			params.dataType = fbTexFormats.noiseType;
-			params.data = m_texData[i].data();
-			gfxContext.update2DTexture(params);
 		}
 	}
 }

--- a/src/PaletteTexture.h
+++ b/src/PaletteTexture.h
@@ -1,10 +1,6 @@
 #pragma once
 #include <memory>
 
-namespace graphics {
-	class PixelWriteBuffer;
-}
-
 struct CachedTexture;
 
 class PaletteTexture
@@ -18,7 +14,7 @@ public:
 
 private:
 	CachedTexture * m_pTexture;
-	std::unique_ptr<graphics::PixelWriteBuffer> m_pbuf;
+	u8* m_pbuf;
 	u32 m_paletteCRC256;
 };
 


### PR DESCRIPTION
Using a PBO to upload texture data is no faster than referencing client data in glTexSubImage2D, and in many cases it's slower. You still have to copy the data to the PBO, and unless you have ARB_buffer_storage, you also have to do glMapBufferRange/glUnmapBuffer, which can be very slow on mobile devices.

It is better to just reference the client-side data in glTexSubImage2D and let the driver figure out the fastest way to upload the data. The only time a PBO might be faster is if you already had the data in the PBO, and were reusing it, thus saving yourself from copying to the PBO, but we aren't doing this, we are copying the data to the PBO each time.

This commit also includes:

- fixing the value of _stride in ColorBufferReaderWithEGLImage while in sync mode.
- Small formatting changes
- consolidating the init2DTexture and update2DTexture calls in NoiseTexture.cpp to one call, since init2DTexture can handle initial data as well.

You can read this as an example of why glMapBufferRange/UnmapBuffer can be bad on mobile devices: https://community.arm.com/graphics/f/discussions/8750/glmapbufferrange-and-glunmapbuffer-performance-on-the-mali-t880

> Is it normal for the glUnmapBuffer call to take this long?
Yes, it can be quite slow depending the platform

You can Google "glmapbufferrange android performance" as well to see countless examples of people having issues with this.

I have also tried this myself, I tried using PixelWriteBuffer for all textures (so instead of malloc'ing pDest in Textures.cpp, I made pDest a PixelWriteBuffer and upload the texture that way). It made the performance on my phone (Snapdragon 835) grind to a halt. This is with ARB_buffer_storage as well. On desktop I saw no difference. So based on my testing, PixelWriteBuffer either provides no performance benefit, or it can hinder performance.