### PR TITLE
Disable clipping using Vertex shader

### DIFF
--- a/src/GBI.cpp
+++ b/src/GBI.cpp
@@ -282,31 +282,15 @@ void GBIInfo::_makeCurrent(MicrocodeInfo * _pCurrent)
 				m_hwlSupported = true;
 			break;
 		}
-
-		if (gfxContext.isSupported(graphics::SpecialFeatures::NearPlaneClipping)) {
-			if (m_pCurrent->NoN) {
-				// Disable near and far plane clipping
-				gfxContext.enable(graphics::enable::DEPTH_CLAMP, true);
-				// Enable Far clipping plane in vertex shader
-				gfxContext.enable(graphics::enable::CLIP_DISTANCE0, true);
-			} else {
-				gfxContext.enable(graphics::enable::DEPTH_CLAMP, false);
-				gfxContext.enable(graphics::enable::CLIP_DISTANCE0, false);
-			}
-		}
+		if (m_pCurrent->NoN)
+			gfxContext.setClampMode(graphics::ClampMode::NoNearPlaneClipping);
+		else
+			gfxContext.setClampMode(graphics::ClampMode::ClippingEnabled);
 	} else if (m_pCurrent->NoN != _pCurrent->NoN) {
-		if (gfxContext.isSupported(graphics::SpecialFeatures::NearPlaneClipping)) {
-			if (_pCurrent->NoN) {
-				// Disable near and far plane clipping
-				gfxContext.enable(graphics::enable::DEPTH_CLAMP, true);
-				// Enable Far clipping plane in vertex shader
-				gfxContext.enable(graphics::enable::CLIP_DISTANCE0, true);
-			}
-			else {
-				gfxContext.enable(graphics::enable::DEPTH_CLAMP, false);
-				gfxContext.enable(graphics::enable::CLIP_DISTANCE0, false);
-			}
-		}
+		if (_pCurrent->NoN)
+			gfxContext.setClampMode(graphics::ClampMode::NoNearPlaneClipping);
+		else
+			gfxContext.setClampMode(graphics::ClampMode::ClippingEnabled);
 	}
 	m_pCurrent = _pCurrent;
 }

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -30,9 +30,24 @@ void Context::destroy()
 	m_impl.reset();
 }
 
+void Context::setClampMode(ClampMode _mode)
+{
+	m_impl->setClampMode(_mode);
+}
+
+ClampMode Context::getClampMode()
+{
+	return m_impl->getClampMode();
+}
+
 void Context::enable(EnableParam _parameter, bool _enable)
 {
 	m_impl->enable(_parameter, _enable);
+}
+
+u32 Context::isEnabled(EnableParam _parameter)
+{
+	return m_impl->isEnabled(_parameter);
 }
 
 void Context::cullFace(CullModeParam _parameter)

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -17,13 +17,18 @@ namespace graphics {
 
 	enum class SpecialFeatures {
 		Multisampling,
-		NearPlaneClipping,
 		FragmentDepthWrite,
 		BlitFramebuffer,
 		WeakBlitFramebuffer,
 		DepthFramebufferTextures,
 		ShaderProgramBinary,
 		ImageTextures
+	};
+
+	enum class ClampMode {
+		ClippingEnabled,
+		NoNearPlaneClipping,
+		NoClipping
 	};
 
 	class ContextImpl;
@@ -39,7 +44,13 @@ namespace graphics {
 
 		void destroy();
 
+		void setClampMode(ClampMode _mode);
+
+		ClampMode getClampMode();
+
 		void enable(EnableParam _parameter, bool _enable);
+
+		u32 isEnabled(EnableParam _parameter);
 
 		void cullFace(CullModeParam _mode);
 

--- a/src/Graphics/ContextImpl.h
+++ b/src/Graphics/ContextImpl.h
@@ -12,7 +12,10 @@ namespace graphics {
 		virtual ~ContextImpl() {}
 		virtual void init() = 0;
 		virtual void destroy() = 0;
+		virtual void setClampMode(ClampMode _mode) = 0;
+		virtual ClampMode getClampMode() = 0;
 		virtual void enable(EnableParam _parameter, bool _enable) = 0;
+		virtual u32 isEnabled(EnableParam _parameter) = 0;
 		virtual void cullFace(CullModeParam _mode) = 0;
 		virtual void enableDepthWrite(bool _enable) = 0;
 		virtual void setDepthCompare(CompareParam _mode) = 0;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.h
@@ -49,6 +49,7 @@ namespace glsl {
 		ShaderPartPtr m_callDither;
 
 		ShaderPartPtr m_vertexHeader;
+		ShaderPartPtr m_vertexEnd;
 		ShaderPartPtr m_vertexRect;
 		ShaderPartPtr m_vertexTexturedRect;
 		ShaderPartPtr m_vertexTriangle;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x1AU;
+		const u32 m_formatVersion = 0x1BU;
 		const u32 m_keysFormatVersion = 0x04;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
@@ -27,6 +27,11 @@ void CachedEnable::enable(bool _enable)
 	}
 }
 
+u32 CachedEnable::get()
+{
+	return u32(m_cached);
+}
+
 /*---------------CachedBindTexture-------------*/
 
 void CachedBindTexture::bind(Parameter _tmuIndex, Parameter _target, ObjectHandle _name)

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
@@ -103,6 +103,8 @@ namespace opengl {
 
 		void enable(bool _enable);
 
+		u32 get();
+
 	private:
 		const graphics::Parameter m_parameter;
 	};

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -24,7 +24,13 @@ namespace opengl {
 
 		void destroy() override;
 
+		void setClampMode(graphics::ClampMode _mode) override;
+
+		graphics::ClampMode getClampMode() override;
+
 		void enable(graphics::EnableParam _parameter, bool _enable) override;
+
+		u32 isEnabled(graphics::EnableParam _parameter) override;
 
 		void cullFace(graphics::CullModeParam _mode) override;
 
@@ -156,6 +162,7 @@ namespace opengl {
 		std::unique_ptr<glsl::CombinerProgramBuilder> m_combinerProgramBuilder;
 		std::unique_ptr<glsl::SpecialShadersFactory> m_specialShadersFactory;
 		GLInfo m_glInfo;
+		graphics::ClampMode m_clampMode;
 	};
 
 }

--- a/src/GraphicsDrawer.cpp
+++ b/src/GraphicsDrawer.cpp
@@ -88,7 +88,7 @@ void GraphicsDrawer::addTriangle(int _v0, int _v1, int _v2)
 		}
 	}
 
-	if (!gfxContext.isSupported(SpecialFeatures::NearPlaneClipping)) {
+	if (!gfxContext.isSupported(SpecialFeatures::FragmentDepthWrite)) {
 		if (GBI.isNoN() && gDP.otherMode.depthCompare == 0 && gDP.otherMode.depthUpdate == 0) {
 			for (u32 i = firstIndex; i < triangles.num; ++i) {
 				SPVertex & vtx = triangles.vertices[triangles.elements[i]];
@@ -155,11 +155,11 @@ void GraphicsDrawer::_updateDepthCompare() const
 
 			gfxContext.enable(enable::DEPTH_TEST, true);
 			if (!GBI.isNoN())
-				gfxContext.enable(enable::DEPTH_CLAMP, false);
+				gfxContext.setClampMode(graphics::ClampMode::ClippingEnabled);
 		} else {
 			gfxContext.enable(enable::DEPTH_TEST, false);
 			if (!GBI.isNoN())
-				gfxContext.enable(enable::DEPTH_CLAMP, true);
+				gfxContext.setClampMode(graphics::ClampMode::NoClipping);
 		}
 	}
 }

--- a/src/gSP.h
+++ b/src/gSP.h
@@ -87,7 +87,7 @@ struct gSPInfo
 		f32 pos_xyzw[2][4];
 		f32 ca[2], la[2], qa[2];
 	} lookat;
-	
+
 	u32 numLights;
 	bool lookatEnable;
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/gonetz/GLideN64/issues/1211 and https://github.com/gonetz/GLideN64/issues/588

Before:

![the_legend_of_zelda-003](https://user-images.githubusercontent.com/848146/37250042-dac784b0-24b0-11e8-897a-3e71fa43413a.png)

After:

![the_legend_of_zelda-001](https://user-images.githubusercontent.com/848146/37250046-e5033c80-24b0-11e8-865c-f585743c360d.png)

Before:

![star_wars_ep1_racer-003](https://user-images.githubusercontent.com/848146/37250049-ed3b9028-24b0-11e8-81f5-35dc152be5e9.png)

After:

![star_wars_ep1_racer-001](https://user-images.githubusercontent.com/848146/37250052-f4ac27c8-24b0-11e8-9a25-52217cc00c08.png)

As you can see from the Ep I: Racer screenshot, it's not perfect yet. The pilot is still partially missing. I'm kind of stumped on this one, are there other Vertex shaders that need this applied? I see that there are a few "special shaders" do they apply here?

How this works (from the description of glDepthRangef):

> After clipping and division by w, depth coordinates range from -1 to 1, corresponding to the near and far clipping planes

So after clipping, z/w will be between -1 and 1. In the Vertex shader, I check if z/w would be less than -1 (for near plane) or over 1 (for far plane), if it is, I modify z so that z/w will equal -1 or 1, basically I am doing "manual clamping".

We could still use GL_DEPTH_CLAMP for desktops, but I figured the code would be simpler if we just got this working in the vertex shader, then it would work from GLES2 to desktop.

I'm not sure what the issue is with Ep I Racer, I'm hoping somebody will be able to spot the error, I'm also not sure what other games would be a good test for this, so suggestions are welcome. Don't expect this to fix any current clipping issues, this is just to bring the GLES version up to the same level of support as the desktop version.