### PR TITLE
Use included font.ttf for mupen64plus

### DIFF
--- a/src/TextDrawer.cpp
+++ b/src/TextDrawer.cpp
@@ -25,6 +25,11 @@
 
 #include "TextDrawer.h"
 
+#ifdef MUPENPLUSAPI
+#include "mupenplus/GLideN64_mupenplus.h"
+#include <osal_files.h>
+#endif
+
 using namespace graphics;
 
 // Maximum texture width
@@ -203,7 +208,14 @@ bool getFontFileName(char * _strName)
 #elif defined (PANDORA)
 	sprintf(_strName, "/usr/share/fonts/truetype/%s", config.font.name.c_str());
 #else
-    sprintf(_strName, "/usr/share/fonts/truetype/freefont/%s", config.font.name.c_str());
+	sprintf(_strName, "/usr/share/fonts/truetype/freefont/%s", config.font.name.c_str());
+#endif
+#ifdef MUPENPLUSAPI
+	if (!osal_path_existsA(_strName)) {
+		const char * fontPath = ConfigGetSharedDataFilepath("font.ttf");
+		if (osal_path_existsA(fontPath))
+			strncpy(_strName, fontPath, PLUGIN_PATH_SIZE);
+	}
 #endif
 	return true;
 }


### PR DESCRIPTION
mupen64plus is typically distributed with a "font.ttf" file for the built-in OSD. Since it seems a little tricky to always get a valid path from the OS, this will try to use that "font.ttf" file first, if it can't find it, it will still fall back to looking for the TTF file in the system dirs.