### PR TITLE
Offset polygons in fragment shader

### DIFF
--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -45,9 +45,14 @@ void Context::enable(EnableParam _parameter, bool _enable)
 	m_impl->enable(_parameter, _enable);
 }
 
-u32 Context::isEnabled(EnableParam _parameter)
+void Context::polygonOffsetEnable(bool _enable)
 {
-	return m_impl->isEnabled(_parameter);
+	m_impl->polygonOffsetEnable(_enable);
+}
+
+bool Context::polygonOffsetEnabled()
+{
+	return m_impl->polygonOffsetEnabled();
 }
 
 void Context::cullFace(CullModeParam _parameter)

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -50,7 +50,9 @@ namespace graphics {
 
 		void enable(EnableParam _parameter, bool _enable);
 
-		u32 isEnabled(EnableParam _parameter);
+		void polygonOffsetEnable(bool _enable);
+
+		bool polygonOffsetEnabled();
 
 		void cullFace(CullModeParam _mode);
 

--- a/src/Graphics/ContextImpl.h
+++ b/src/Graphics/ContextImpl.h
@@ -15,7 +15,8 @@ namespace graphics {
 		virtual void setClampMode(ClampMode _mode) = 0;
 		virtual ClampMode getClampMode() = 0;
 		virtual void enable(EnableParam _parameter, bool _enable) = 0;
-		virtual u32 isEnabled(EnableParam _parameter) = 0;
+		virtual void polygonOffsetEnable(bool _enable) = 0;
+		virtual bool polygonOffsetEnabled() = 0;
 		virtual void cullFace(CullModeParam _mode) = 0;
 		virtual void enableDepthWrite(bool _enable) = 0;
 		virtual void setDepthCompare(CompareParam _mode) = 0;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -861,12 +861,12 @@ public:
 	{
 		if (!_glinfo.isGLES2) {
 			m_part =
+				"uniform lowp float uPolygonOffset;	\n"
 				"void writeDepth();\n";
 			;
 			if (_glinfo.isGLESX) {
 				m_part =
 					"IN highp float vZCoord;	\n"
-					"uniform lowp float uPolygonOffset;	\n"
 					"uniform lowp int uClampMode;	\n"
 					+ m_part
 				;
@@ -1455,7 +1455,7 @@ public:
 							;
 					} else {
 						m_part +=
-							"  gl_FragDepth = clamp((gl_FragCoord.z * 2.0 - 1.0) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
+							"  gl_FragDepth = clamp(((gl_FragCoord.z * 2.0 - 1.0) - uPolygonOffset) * uDepthScale.s + uDepthScale.t, 0.0, 1.0);	\n"
 						;
 					}
 					m_part +=
@@ -1481,7 +1481,7 @@ public:
 						m_part =
 							"void writeDepth()						        										\n"
 							"{																						\n"
-							"  highp float depth = uDepthSource == 0 ? (gl_FragCoord.z * 2.0 - 1.0) : uPrimDepth;	\n"
+							"  highp float depth = uDepthSource == 0 ? ((gl_FragCoord.z * 2.0 - 1.0) - uPolygonOffset) : uPrimDepth;	\n"
 							"  gl_FragDepth = clamp(depth * uDepthScale.s + uDepthScale.t, 0.0, 1.0);				\n"
 							"}																						\n"
 							;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -692,7 +692,7 @@ public:
 
 	void update(bool _force) override
 	{
-		f32 offset = gfxContext.isEnabled(graphics::enable::POLYGON_OFFSET_FILL) ? 0.003f : 0.0f;
+		f32 offset = gfxContext.polygonOffsetEnabled() ? 0.003f : 0.0f;
 		uPolygonOffset.set(offset, _force);
 	}
 
@@ -968,13 +968,13 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 		_uniforms.emplace_back(new UDepthSource(_program));
 
 	if (config.generalEmulation.enableFragmentDepthWrite != 0 ||
-		config.frameBufferEmulation.N64DepthCompare != 0)
+		config.frameBufferEmulation.N64DepthCompare != 0) {
 		_uniforms.emplace_back(new URenderTarget(_program));
-
-	if (m_glInfo.isGLESX) {
-		_uniforms.emplace_back(new UClampMode(_program));
 		_uniforms.emplace_back(new UPolygonOffset(_program));
 	}
+
+	if (m_glInfo.isGLESX)
+		_uniforms.emplace_back(new UClampMode(_program));
 
 	_uniforms.emplace_back(new UScreenCoordsScale(_program));
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x1BU;
+		const u32 m_formatVersion = 0x1CU;
 		const u32 m_keysFormatVersion = 0x04;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -29,6 +29,7 @@ ContextImpl::~ContextImpl()
 void ContextImpl::init()
 {
 	m_clampMode = graphics::ClampMode::ClippingEnabled;
+	m_polygonOffset = false;
 	m_glInfo.init();
 
 	if (m_glInfo.isGLES2) {
@@ -116,9 +117,17 @@ void ContextImpl::enable(graphics::EnableParam _parameter, bool _enable)
 	m_cachedFunctions->getCachedEnable(_parameter)->enable(_enable);
 }
 
-u32 ContextImpl::isEnabled(graphics::EnableParam _parameter)
+void ContextImpl::polygonOffsetEnable(bool _enable)
 {
-	return m_cachedFunctions->getCachedEnable(_parameter)->get();
+	if (config.generalEmulation.enableFragmentDepthWrite == 0 && config.frameBufferEmulation.N64DepthCompare == 0)
+		m_cachedFunctions->getCachedEnable(graphics::enable::POLYGON_OFFSET_FILL)->enable(_enable);
+
+	m_polygonOffset = _enable;
+}
+
+bool ContextImpl::polygonOffsetEnabled()
+{
+	return m_polygonOffset;
 }
 
 void ContextImpl::cullFace(graphics::CullModeParam _mode)

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -30,7 +30,9 @@ namespace opengl {
 
 		void enable(graphics::EnableParam _parameter, bool _enable) override;
 
-		u32 isEnabled(graphics::EnableParam _parameter) override;
+		void polygonOffsetEnable(bool _enable) override;
+
+		bool polygonOffsetEnabled() override;
 
 		void cullFace(graphics::CullModeParam _mode) override;
 
@@ -163,6 +165,7 @@ namespace opengl {
 		std::unique_ptr<glsl::SpecialShadersFactory> m_specialShadersFactory;
 		GLInfo m_glInfo;
 		graphics::ClampMode m_clampMode;
+		bool m_polygonOffset;
 	};
 
 }

--- a/src/GraphicsDrawer.cpp
+++ b/src/GraphicsDrawer.cpp
@@ -127,13 +127,13 @@ void GraphicsDrawer::_updateDepthCompare() const
 			if (gDP.otherMode.depthCompare != 0) {
 				switch (gDP.otherMode.depthMode) {
 				case ZMODE_INTER:
-					gfxContext.enable(enable::POLYGON_OFFSET_FILL, false);
+					gfxContext.polygonOffsetEnable(false);
 					gfxContext.setDepthCompare(compare::LEQUAL);
 					break;
 				case ZMODE_OPA:
 				case ZMODE_XLU:
 					// Max || Infront;
-					gfxContext.enable(enable::POLYGON_OFFSET_FILL, false);
+					gfxContext.polygonOffsetEnable(false);
 					if (gDP.otherMode.depthSource == G_ZS_PRIM && gDP.primDepth.z == 1.0f)
 						// Max
 						gfxContext.setDepthCompare(compare::LEQUAL);
@@ -142,12 +142,12 @@ void GraphicsDrawer::_updateDepthCompare() const
 						gfxContext.setDepthCompare(compare::LESS);
 					break;
 				case ZMODE_DEC:
-					gfxContext.enable(enable::POLYGON_OFFSET_FILL, true);
+					gfxContext.polygonOffsetEnable(true);
 					gfxContext.setDepthCompare(compare::LEQUAL);
 					break;
 				}
 			} else {
-				gfxContext.enable(enable::POLYGON_OFFSET_FILL, false);
+				gfxContext.polygonOffsetEnable(false);
 				gfxContext.setDepthCompare(compare::ALWAYS);
 			}
 
@@ -1662,7 +1662,7 @@ void GraphicsDrawer::_initStates()
 
 	if (config.frameBufferEmulation.N64DepthCompare != 0) {
 		gfxContext.enable(enable::DEPTH_TEST, false);
-		gfxContext.enable(enable::POLYGON_OFFSET_FILL, false);
+		gfxContext.polygonOffsetEnable(false);
 	}
 	else {
 		gfxContext.enable(enable::DEPTH_TEST, true);


### PR DESCRIPTION
This is a potential fix for https://github.com/gonetz/GLideN64/issues/1754 https://github.com/gonetz/GLideN64/issues/541

If fragment depth writing is enabled, this no longer uses glPolygonOffset to offset the polygons, but simply offsets the fragments in the fragment shader.

If fragment depth writing is not used, the glPolygonOffset is still used.

The number I used for the uniform (0.003f) was just based on testing OoT and Mario 64, it could be adjusted if needed.