### PR TITLE
Remove unsafe compiler optimizations

### DIFF
--- a/src/mupen64plus-video-gliden64.mk
+++ b/src/mupen64plus-video-gliden64.mk
@@ -141,7 +141,7 @@ ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
     MY_LOCAL_SRC_FILES += $(SRCDIR)/Neon/gSPNeon.cpp
     MY_LOCAL_SRC_FILES += $(SRCDIR)/Neon/RSP_LoadMatrixNeon.cpp
     MY_LOCAL_CFLAGS += -D__NEON_OPT
-    MY_LOCAL_CFLAGS += -D__VEC4_OPT -mfpu=neon -mfloat-abi=softfp -ftree-vectorize -funsafe-math-optimizations -fno-finite-math-only
+    MY_LOCAL_CFLAGS += -D__VEC4_OPT -mfpu=neon
 
 else ifeq ($(TARGET_ARCH_ABI), x86)
 #    MY_LOCAL_CFLAGS += -DX86_ASM


### PR DESCRIPTION
They are causing conflicts with neon.

This is being done in response to https://github.com/gonetz/GLideN64/issues/1755

I'm removing them to be in the safe side, and the downstream project can define them if they want to. As far as I know only "fast-math" was causing issues.