### PR TITLE
Only write to gl_FragDepth once

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x1BU;
+		const u32 m_formatVersion = 0x1CU;
 		const u32 m_keysFormatVersion = 0x04;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;


### PR DESCRIPTION
I was trying to fix N64 Depth Compare for GLES using this method. It didn't work (N64 Depth Compare is still broken for GLES).

However, I still think this would be a good change to incorporate. Given that there are drivers that seem very fragile around gl_FragDepth, I think it would be a good idea to write to it only once, and never read from it. It could possibly avoid driver bugs. You never know what kind of optimizations the driver might be trying to perform.

That's what this does. Also, for N64 Depth Compare, gl_FragDepth is never written to now, whereas before it would have been.