### PR TITLE
rpi: limit m_maxCacheSize to fix texture corruption

### DIFF
--- a/src/Textures.h
+++ b/src/Textures.h
@@ -100,7 +100,11 @@ private:
 	u32 m_hits, m_misses;
 	s32 m_curUnpackAlignment;
 	bool m_toggleDumpTex;
+#ifdef VC
+	const size_t m_maxCacheSize = 3500;
+#else
 	const size_t m_maxCacheSize = 8000;
+#endif
 };
 
 void getTextureShiftScale(u32 tile, const TextureCache & cache, f32 & shiftScaleS, f32 & shiftScaleT);


### PR DESCRIPTION
Limit m_maxCachSize to fix texture corruption in beetle adventure
racing. I have tested values between 3500 and 8000. Everything >= 4000
produces texture corruption or stuttering after some time.