### PR TITLE
Fix GLES2 shader storage support

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -2238,8 +2238,10 @@ graphics::CombinerProgram * CombinerProgramBuilder::buildCombinerProgram(Combine
 	else
 		glAttachShader(program, bUseTextures ? m_vertexShaderTexturedTriangle : m_vertexShaderTriangle);
 	glAttachShader(program, fragmentShader);
-	if (CombinerInfo::get().isShaderCacheSupported())
-		glProgramParameteri(program, GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_TRUE);
+	if (CombinerInfo::get().isShaderCacheSupported()) {
+		if (IS_GL_FUNCTION_VALID(glProgramParameteri))
+			glProgramParameteri(program, GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_TRUE);
+	}
 	glLinkProgram(program);
 	assert(Utils::checkProgramLinkStatus(program));
 	glDeleteShader(fragmentShader);


### PR DESCRIPTION
This is to fix a crash reported in https://github.com/gonetz/GLideN64/issues/1765 (glProgramParameteri does not exist in GLES2)

I also changed GLES2 to use glProgramBinaryOES and glGetProgramBinaryOES.

Finally, we used to just check for GL_OES_get_program_binary or GL_ARB_get_program_binary, but I added a check for GLES 3.0+ or GL4.1+, since program binaries are not extensions in those versions.