### PR TITLE
Added VERO4K flag - triggering the custom path to libGLESv2.so

### DIFF
--- a/projects/cmake/Readme.txt
+++ b/projects/cmake/Readme.txt
@@ -11,3 +11,5 @@ cmake [-DCMAKE_BUILD_TYPE=Debug] [-DVEC4_OPT=On] [-DCRC_OPT=On] [-DX86_OPT=On] [
 -DNOHQ=On - optional parameter. set to build without realtime texture enhancer library (GLideNHQ).
 -DUSE_SYSTEM_LIBS=On - optional parameter. set to use system provided libraries for libpng and zlib.
 -DMUPENPLUSAPI=On - required parameter. currently cmake build works only for mupen64plus version of the plugin.
+-DODROID=On - set if you need to build on an Odroid board.
+-DVERO4K=On - set if you need to build on the OSMC Vero4k.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})
 option(ODROID "Set to ON if targeting an Odroid" ${ODROID})
 option(MUPENPLUSAPI "Set to ON for Mupen64Plus plugin" ${MUPENPLUSAPI})
 option(MESA "Set to ON to disable Raspberry Pi autodetection" ${MESA})
+option(VERO4K "Set to ON if targeting a Vero4k" ${VERO4K})
 
 project( GLideN64 )
 
@@ -231,6 +232,12 @@ if(ODROID)
   -DODROID
    )
 endif(ODROID)
+
+if(VERO4K)
+  add_definitions(
+  -DVERO4K
+   )
+endif(VERO4K)
 
 if(UNIX OR BCMHOST)
   SET( FREETYPE_INCLUDE_DIRS "/usr/include/freetype2/" )

--- a/src/Graphics/OpenGLContext/GLFunctions.cpp
+++ b/src/Graphics/OpenGLContext/GLFunctions.cpp
@@ -5,7 +5,7 @@
 #define glGetProcAddress wglGetProcAddress
 #define GL_GET_PROC_ADR(proc_type, proc_name) g_##proc_name = (proc_type) glGetProcAddress(#proc_name)
 
-#elif defined(ODROID) || defined(VC)
+#elif defined(VERO4K) || defined(ODROID) || defined(VC)
 
 #define GL_GET_PROC_ADR(proc_type, proc_name) g_##proc_name = (proc_type) dlsym(gles2so, #proc_name);
 
@@ -186,6 +186,8 @@ void initGLFunctions()
 	void *gles2so = dlopen("/opt/vc/lib/libbrcmGLESv2.so", RTLD_NOW);
 #elif defined(ODROID)
 	void *gles2so = dlopen("/usr/lib/arm-linux-gnueabihf/libGLESv2.so", RTLD_NOW);
+#elif defined(VERO4K)
+       void *gles2so = dlopen("/opt/vero3/lib/libGLESv2.so", RTLD_NOW);
 #endif
 #ifdef OS_WINDOWS
 	GL_GET_PROC_ADR(PFNGLACTIVETEXTUREPROC, glActiveTexture);


### PR DESCRIPTION
As per #1765 - this helps to fix a segmentation fault at run-time due to the non-standard path to `libGLESv2.so` on the Vero4k.

Also needs #1774 to be merged.
Until then requires `EnableShadersStorage = False` to be set in `mupen64plus.cfg`.

Even then, the shader cache at `/home/.cache/mupen64plus/shaders` must be deleted prior to each run.