### PR TITLE
Remove Image Texture requirement for some shaders

### DIFF
--- a/src/Combiner.cpp
+++ b/src/Combiner.cpp
@@ -320,7 +320,7 @@ ShaderProgram * CombinerInfo::getTexrectCopyProgram()
 
 bool CombinerInfo::isShaderCacheSupported() const
 {
-	return config.generalEmulation.enableShadersStorage != 0 && gfxContext.isSupported(SpecialFeatures::ShaderProgramBinary);
+	return config.generalEmulation.enableShadersStorage != 0 && Context::ShaderProgramBinary;
 }
 
 void CombinerInfo::setPolygonMode(DrawingState _drawingState)

--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -191,7 +191,7 @@ void DepthBuffer::setDepthAttachment(ObjectHandle _fbo, BufferTargetParam _targe
 	params.attachment = bufferAttachment::DEPTH_ATTACHMENT;
 	params.bufferHandle = _fbo;
 	params.bufferTarget = _target;
-	if (gfxContext.isSupported(SpecialFeatures::DepthFramebufferTextures)) {
+	if (Context::DepthFramebufferTextures) {
 		params.textureHandle = m_pDepthBufferTexture->name;
 		params.textureTarget = config.video.multisampling != 0 ? textureTarget::TEXTURE_2D_MULTISAMPLE : textureTarget::TEXTURE_2D;
 	} else {
@@ -206,7 +206,7 @@ void DepthBuffer::setDepthAttachment(ObjectHandle _fbo, BufferTargetParam _targe
 
 void DepthBuffer::initDepthBufferTexture(FrameBuffer * _pBuffer)
 {
-	if (gfxContext.isSupported(SpecialFeatures::DepthFramebufferTextures)) {
+	if (Context::DepthFramebufferTextures) {
 		if (m_pDepthBufferTexture == nullptr) {
 			m_pDepthBufferTexture = textureCache().addFrameBufferTexture(config.video.multisampling != 0);
 			_initDepthBufferTexture(_pBuffer, m_pDepthBufferTexture, config.video.multisampling != 0);
@@ -318,7 +318,7 @@ void DepthBuffer::activateDepthBufferTexture(FrameBuffer * _pBuffer)
 
 void DepthBuffer::bindDepthImageTexture()
 {
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ImageTextures))
+	if (!Context::ImageTextures)
 		return;
 
 	Context::BindImageTextureParameters bindParams;

--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -318,7 +318,7 @@ void DepthBuffer::activateDepthBufferTexture(FrameBuffer * _pBuffer)
 
 void DepthBuffer::bindDepthImageTexture()
 {
-	if (!Context::imageTextures)
+	if (!gfxContext.isSupported(graphics::SpecialFeatures::ImageTextures))
 		return;
 
 	Context::BindImageTextureParameters bindParams;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -310,7 +310,7 @@ bool FrameBuffer::isValid(bool _forceCheck) const
 
 void FrameBuffer::resolveMultisampledTexture(bool _bForce)
 {
-	if (!Context::multisampling)
+	if (!gfxContext.isSupported(SpecialFeatures::Multisampling))
 		return;
 
 	if (m_resolved && !_bForce)

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -310,7 +310,7 @@ bool FrameBuffer::isValid(bool _forceCheck) const
 
 void FrameBuffer::resolveMultisampledTexture(bool _bForce)
 {
-	if (!gfxContext.isSupported(SpecialFeatures::Multisampling))
+	if (!Context::Multisampling)
 		return;
 
 	if (m_resolved && !_bForce)
@@ -373,7 +373,7 @@ bool FrameBuffer::_initSubTexture(u32 _t)
 
 CachedTexture * FrameBuffer::_getSubTexture(u32 _t)
 {
-	if (!gfxContext.isSupported(SpecialFeatures::BlitFramebuffer))
+	if (!Context::BlitFramebuffer)
 		return m_pTexture;
 
 	if (!_initSubTexture(_t))
@@ -389,7 +389,7 @@ CachedTexture * FrameBuffer::_getSubTexture(u32 _t)
 		copyHeight = m_pTexture->realHeight - y0;
 
 	ObjectHandle readFBO = m_FBO;
-	if (gfxContext.isSupported(SpecialFeatures::WeakBlitFramebuffer) &&
+	if (Context::WeakBlitFramebuffer &&
 			m_pTexture->frameBufferTexture == CachedTexture::fbMultiSample) {
 		resolveMultisampledTexture(true);
 		readFBO = m_resolveFBO;
@@ -795,8 +795,8 @@ void FrameBufferList::attachDepthBuffer()
 		pDepthBuffer->initDepthBufferTexture(pCurrent);
 
 		bool goodDepthBufferTexture = false;
-		if (gfxContext.isSupported(SpecialFeatures::DepthFramebufferTextures)) {
-			goodDepthBufferTexture = gfxContext.isSupported(SpecialFeatures::WeakBlitFramebuffer) ?
+		if (Context::DepthFramebufferTextures) {
+			goodDepthBufferTexture = Context::WeakBlitFramebuffer ?
 				pDepthBuffer->m_pDepthBufferTexture->realWidth == pCurrent->m_pTexture->realWidth :
 				pDepthBuffer->m_pDepthBufferTexture->realWidth >= pCurrent->m_pTexture->realWidth;
 		} else {

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -5,9 +5,6 @@ using namespace graphics;
 
 Context gfxContext;
 
-bool Context::imageTextures = false;
-bool Context::multisampling = false;
-
 Context::Context() {}
 
 Context::~Context() {
@@ -20,8 +17,6 @@ void Context::init()
 	m_impl.reset(new opengl::ContextImpl);
 	m_impl->init();
 	m_fbTexFormats.reset(m_impl->getFramebufferTextureFormats());
-	imageTextures = isSupported(SpecialFeatures::ImageTextures);
-	multisampling = isSupported(SpecialFeatures::Multisampling);
 }
 
 void Context::destroy()

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -5,6 +5,15 @@ using namespace graphics;
 
 Context gfxContext;
 
+bool Context::Multisampling = false;
+bool Context::BlitFramebuffer = false;
+bool Context::WeakBlitFramebuffer = false;
+bool Context::DepthFramebufferTextures = false;
+bool Context::ShaderProgramBinary = false;
+bool Context::ImageTextures = false;
+bool Context::IntegerTextures = false;
+bool Context::ClipControl = false;
+
 Context::Context() {}
 
 Context::~Context() {
@@ -17,6 +26,14 @@ void Context::init()
 	m_impl.reset(new opengl::ContextImpl);
 	m_impl->init();
 	m_fbTexFormats.reset(m_impl->getFramebufferTextureFormats());
+	Multisampling = m_impl->isSupported(SpecialFeatures::Multisampling);
+	BlitFramebuffer = m_impl->isSupported(SpecialFeatures::BlitFramebuffer);
+	WeakBlitFramebuffer = m_impl->isSupported(SpecialFeatures::WeakBlitFramebuffer);
+	DepthFramebufferTextures = m_impl->isSupported(SpecialFeatures::DepthFramebufferTextures);
+	ShaderProgramBinary = m_impl->isSupported(SpecialFeatures::ShaderProgramBinary);
+	ImageTextures = m_impl->isSupported(SpecialFeatures::ImageTextures);
+	IntegerTextures = m_impl->isSupported(SpecialFeatures::IntegerTextures);
+	ClipControl = m_impl->isSupported(SpecialFeatures::ClipControl);
 }
 
 void Context::destroy()
@@ -288,11 +305,6 @@ void Context::drawLine(f32 _width, SPVertex * _vertices)
 f32 Context::getMaxLineWidth()
 {
 	return m_impl->getMaxLineWidth();
-}
-
-bool Context::isSupported(SpecialFeatures _feature) const
-{
-	return m_impl->isSupported(_feature);
 }
 
 bool Context::isError() const

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -22,7 +22,8 @@ namespace graphics {
 		WeakBlitFramebuffer,
 		DepthFramebufferTextures,
 		ShaderProgramBinary,
-		ImageTextures
+		ImageTextures,
+		LUTTextures
 	};
 
 	enum class ClampMode {
@@ -273,9 +274,6 @@ namespace graphics {
 		bool isError() const;
 
 		bool isFramebufferError() const;
-
-		static bool imageTextures;
-		static bool multisampling;
 
 	private:
 		std::unique_ptr<ContextImpl> m_impl;

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -22,7 +22,7 @@ namespace graphics {
 		DepthFramebufferTextures,
 		ShaderProgramBinary,
 		ImageTextures,
-		LUTTextures,
+		IntegerTextures,
 		ClipControl
 	};
 
@@ -269,11 +269,18 @@ namespace graphics {
 
 		/*---------------Misc-------------*/
 
-		bool isSupported(SpecialFeatures _feature) const;
-
 		bool isError() const;
 
 		bool isFramebufferError() const;
+
+		static bool Multisampling;
+		static bool BlitFramebuffer;
+		static bool WeakBlitFramebuffer;
+		static bool DepthFramebufferTextures;
+		static bool ShaderProgramBinary;
+		static bool ImageTextures;
+		static bool IntegerTextures;
+		static bool ClipControl;
 
 	private:
 		std::unique_ptr<ContextImpl> m_impl;

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -17,13 +17,13 @@ namespace graphics {
 
 	enum class SpecialFeatures {
 		Multisampling,
-		FragmentDepthWrite,
 		BlitFramebuffer,
 		WeakBlitFramebuffer,
 		DepthFramebufferTextures,
 		ShaderProgramBinary,
 		ImageTextures,
-		LUTTextures
+		LUTTextures,
+		ClipControl
 	};
 
 	enum class ClampMode {

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -236,10 +236,6 @@ public:
 		else {
 			std::stringstream ss;
 			ss << "#version " << Utils::to_string(_glinfo.majorVersion) << Utils::to_string(_glinfo.minorVersion) << "0 core " << std::endl;
-			if (_glinfo.imageTextures && _glinfo.majorVersion * 10 + _glinfo.minorVersion < 42) {
-				ss << "#extension GL_ARB_shader_image_load_store : enable" << std::endl
-					<< "#extension GL_ARB_shading_language_420pack : enable" << std::endl;
-			}
 			ss << "# define IN in" << std::endl << "# define OUT out" << std::endl;
 			m_part = ss.str();
 		}
@@ -1444,9 +1440,9 @@ public:
 					"}						\n"
 				;
 			} else {
-				if (_glinfo.imageTextures && (config.generalEmulation.hacks & hack_RE2) != 0) {
+				if ((config.generalEmulation.hacks & hack_RE2) != 0) {
 					m_part =
-						"layout(binding = 0, r32ui) highp uniform readonly uimage2D uZlutImage;\n"
+						"uniform lowp usampler2D uZlutImage;\n"
 						"highp float writeDepth()						        													\n"
 						"{																									\n"
 						;
@@ -1464,7 +1460,7 @@ public:
 						"  highp int iZ = FragDepth > 0.999 ? 262143 : int(floor(FragDepth * 262143.0));				\n"
 						"  mediump int y0 = clamp(iZ/512, 0, 511);															\n"
 						"  mediump int x0 = iZ - 512*y0;																	\n"
-						"  highp uint iN64z = imageLoad(uZlutImage,ivec2(x0,y0)).r;											\n"
+						"  highp uint iN64z = texelFetch(uZlutImage,ivec2(x0,y0), 0).r;											\n"
 						"  return clamp(float(iN64z)/65532.0, 0.0, 1.0);											\n"
 						"}																									\n"
 						;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -141,6 +141,22 @@ private:
 	iUniform uDepthTex;
 };
 
+class UZLutTexture : public UniformGroup
+{
+public:
+	UZLutTexture(GLuint _program) {
+		LocateUniform(uZlutImage);
+	}
+
+	void update(bool _force) override
+	{
+		uZlutImage.set(int(graphics::textureIndices::ZLUTTex), _force);
+	}
+
+private:
+	iUniform uZlutImage;
+};
+
 class UTextures : public UniformGroup
 {
 public:
@@ -961,6 +977,9 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 	_uniforms.emplace_back(new UScreenScale(_program));
 
 	_uniforms.emplace_back(new UAlphaTestInfo(_program));
+
+	if ((config.generalEmulation.hacks & hack_RE2) != 0 && config.generalEmulation.enableFragmentDepthWrite != 0)
+		_uniforms.emplace_back(new UZLutTexture(_program));
 
 	if (config.frameBufferEmulation.N64DepthCompare != 0)
 		_uniforms.emplace_back(new UDepthInfo(_program));

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -109,7 +109,7 @@ bool ShaderStorage::saveShadersStorage(const graphics::Combiners & _combiners) c
 		// Created shaders are obsolete due to changes in config, but we saved combiners keys.
 		return true;
 
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (!graphics::Context::ShaderProgramBinary)
 		// Shaders storage is not supported, but we saved combiners keys.
 		return true;
 
@@ -262,7 +262,7 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 	if (opengl::Utils::isGLError())
 		return false;
 
-	if (gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (graphics::Context::ShaderProgramBinary)
 		// Restore shaders storage
 		return saveShadersStorage(_combiners);
 
@@ -272,7 +272,7 @@ bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
 
 bool ShaderStorage::loadShadersStorage(graphics::Combiners & _combiners)
 {
-	if (!gfxContext.isSupported(graphics::SpecialFeatures::ShaderProgramBinary))
+	if (!graphics::Context::ShaderProgramBinary)
 		// Shaders storage is not supported, load from combiners keys.
 		return _loadFromCombinerKeys(_combiners);
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x1DU;
+		const u32 m_formatVersion = 0x1EU;
 		const u32 m_keysFormatVersion = 0x04;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -469,6 +469,8 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return m_glInfo.shaderStorage;
 	case graphics::SpecialFeatures::DepthFramebufferTextures:
 		return m_glInfo.depthTexture;
+	case graphics::SpecialFeatures::LUTTextures:
+		return !m_glInfo.isGLES2;
 	}
 	return false;
 }

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -459,8 +459,6 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return !m_glInfo.isGLES2;
 	case graphics::SpecialFeatures::WeakBlitFramebuffer:
 		return m_glInfo.isGLESX;
-	case graphics::SpecialFeatures::FragmentDepthWrite:
-		return config.generalEmulation.enableFragmentDepthWrite;
 	case graphics::SpecialFeatures::Multisampling:
 		return m_glInfo.msaa;
 	case graphics::SpecialFeatures::ImageTextures:
@@ -471,6 +469,8 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return m_glInfo.depthTexture;
 	case graphics::SpecialFeatures::LUTTextures:
 		return !m_glInfo.isGLES2;
+	case graphics::SpecialFeatures::ClipControl:
+		return !m_glInfo.isGLESX;
 	}
 	return false;
 }

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -467,7 +467,7 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return m_glInfo.shaderStorage;
 	case graphics::SpecialFeatures::DepthFramebufferTextures:
 		return m_glInfo.depthTexture;
-	case graphics::SpecialFeatures::LUTTextures:
+	case graphics::SpecialFeatures::IntegerTextures:
 		return !m_glInfo.isGLES2;
 	case graphics::SpecialFeatures::ClipControl:
 		return !m_glInfo.isGLESX;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -56,7 +56,7 @@ void GLInfo::init() {
 	}
 	if (!imageTextures && config.frameBufferEmulation.N64DepthCompare != 0) {
 		config.frameBufferEmulation.N64DepthCompare = 0;
-		LOG(LOG_WARNING, "N64 depth compare and depth based fog will not work without Image Textures support provided in OpenGL >= 4.3 or GLES >= 3.1\n");
+		LOG(LOG_WARNING, "N64 depth compare will not work without Image Textures support provided in OpenGL >= 4.3 or GLES >= 3.1\n");
 	}
 	if (isGLES2)
 		config.generalEmulation.enableFragmentDepthWrite = 0;

--- a/src/Graphics/OpenGLContext/opengl_Parameters.cpp
+++ b/src/Graphics/OpenGLContext/opengl_Parameters.cpp
@@ -74,8 +74,6 @@ namespace graphics {
 	}
 
 	namespace textureImageUnits {
-		ImageUnitParam Zlut(0U);
-		ImageUnitParam Tlut(1U);
 		ImageUnitParam DepthZ(2U);
 		ImageUnitParam DepthDeltaZ(3U);
 	}

--- a/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
@@ -191,7 +191,6 @@ namespace opengl {
 				}
 
 				if (_params.ImageUnit.isValid()) {
-					assert(IS_GL_FUNCTION_VALID(glBindImageTexture));
 					glBindImageTexture(GLuint(_params.ImageUnit), GLuint(_params.handle),
 					0, GL_FALSE, GL_FALSE, GL_READ_ONLY, GLuint(_params.internalFormat));
 				}
@@ -273,7 +272,6 @@ namespace opengl {
 				_params.data);
 
 			if (_params.ImageUnit.isValid() && _params.internalFormat.isValid()) {
-				assert(IS_GL_FUNCTION_VALID(glBindImageTexture));
 				glBindImageTexture(GLuint(_params.ImageUnit), GLuint(_params.handle),
 				0, GL_FALSE, GL_FALSE, GL_READ_ONLY, GLuint(_params.internalFormat));
 			}

--- a/src/GraphicsDrawer.cpp
+++ b/src/GraphicsDrawer.cpp
@@ -87,7 +87,7 @@ void GraphicsDrawer::addTriangle(int _v0, int _v1, int _v2)
 		}
 	}
 
-	if (!gfxContext.isSupported(SpecialFeatures::ClipControl)) {
+	if (!Context::ClipControl) {
 		if (GBI.isNoN() && gDP.otherMode.depthCompare == 0 && gDP.otherMode.depthUpdate == 0) {
 			for (u32 i = firstIndex; i < triangles.num; ++i) {
 				SPVertex & vtx = triangles.vertices[triangles.elements[i]];
@@ -990,7 +990,7 @@ bool texturedRectShadowMap(const GraphicsDrawer::TexturedRectParams &)
 		if (gDP.textureImage.size == 2 && gDP.textureImage.address >= gDP.depthImageAddress &&
 			gDP.textureImage.address < (gDP.depthImageAddress + gDP.colorImage.width*gDP.colorImage.width * 6 / 4)) {
 
-			if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
+			if (!Context::IntegerTextures)
 				return true;
 
 			pCurrentBuffer->m_pDepthBuffer->activateDepthBufferTexture(pCurrentBuffer);

--- a/src/GraphicsDrawer.cpp
+++ b/src/GraphicsDrawer.cpp
@@ -31,7 +31,6 @@ GraphicsDrawer::GraphicsDrawer()
 , m_dmaVerticesNum(0)
 , m_modifyVertices(0)
 , m_maxLineWidth(1.0f)
-, m_bImageTexture(false)
 , m_bFlatColors(false)
 {
 	memset(m_rect, 0, sizeof(m_rect));
@@ -991,7 +990,7 @@ bool texturedRectShadowMap(const GraphicsDrawer::TexturedRectParams &)
 		if (gDP.textureImage.size == 2 && gDP.textureImage.address >= gDP.depthImageAddress &&
 			gDP.textureImage.address < (gDP.depthImageAddress + gDP.colorImage.width*gDP.colorImage.width * 6 / 4)) {
 
-			if (!Context::imageTextures)
+			if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
 				return true;
 
 			pCurrentBuffer->m_pDepthBuffer->activateDepthBufferTexture(pCurrentBuffer);
@@ -1721,7 +1720,6 @@ void GraphicsDrawer::_initData()
 	FBInfo::fbInfo.reset();
 	m_texrectDrawer.init();
 	m_drawingState = DrawingState::Non;
-	m_bImageTexture = gfxContext.isSupported(SpecialFeatures::ImageTextures);
 	m_maxLineWidth = gfxContext.getMaxLineWidth();
 
 	gSP.changed = gDP.changed = 0xFFFFFFFF;

--- a/src/GraphicsDrawer.cpp
+++ b/src/GraphicsDrawer.cpp
@@ -87,7 +87,7 @@ void GraphicsDrawer::addTriangle(int _v0, int _v1, int _v2)
 		}
 	}
 
-	if (!gfxContext.isSupported(SpecialFeatures::FragmentDepthWrite)) {
+	if (!gfxContext.isSupported(SpecialFeatures::ClipControl)) {
 		if (GBI.isNoN() && gDP.otherMode.depthCompare == 0 && gDP.otherMode.depthUpdate == 0) {
 			for (u32 i = firstIndex; i < triangles.num; ++i) {
 				SPVertex & vtx = triangles.vertices[triangles.elements[i]];
@@ -653,7 +653,7 @@ void GraphicsDrawer::_updateStates(DrawingState _drawingState) const
 
 	cmbInfo.updateParameters();
 
-	if (!gfxContext.isSupported(SpecialFeatures::FragmentDepthWrite))
+	if (!config.generalEmulation.enableFragmentDepthWrite)
 		return;
 
 	if (gDP.colorImage.address == gDP.depthImageAddress &&

--- a/src/GraphicsDrawer.h
+++ b/src/GraphicsDrawer.h
@@ -132,8 +132,6 @@ public:
 		return (triangles.vertices[_v0].clip & triangles.vertices[_v1].clip & triangles.vertices[_v2].clip) != 0;
 	}
 
-	bool isImageTexturesSupported() const { return m_bImageTexture; }
-
 	SPVertex & getVertex(u32 _v) { return triangles.vertices[_v]; }
 
 	SPVertex * getVertexPtr(u32 _v) { return triangles.vertices.data() + _v; }
@@ -205,7 +203,6 @@ private:
 
 	u32 m_modifyVertices;
 	f32 m_maxLineWidth;
-	bool m_bImageTexture;
 	bool m_bFlatColors;
 	TexrectDrawer m_texrectDrawer;
 	OSDMessages m_osdMessages;

--- a/src/PaletteTexture.cpp
+++ b/src/PaletteTexture.cpp
@@ -19,7 +19,7 @@ PaletteTexture::PaletteTexture()
 
 void PaletteTexture::init()
 {
-	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
+	if (!Context::IntegerTextures)
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
@@ -63,7 +63,7 @@ void PaletteTexture::init()
 
 void PaletteTexture::destroy()
 {
-	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
+	if (!Context::IntegerTextures)
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
@@ -75,7 +75,7 @@ void PaletteTexture::destroy()
 
 void PaletteTexture::update()
 {
-	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
+	if (!Context::IntegerTextures)
 		return;
 
 	if (m_paletteCRC256 == gDP.paletteCRC256)

--- a/src/PaletteTexture.cpp
+++ b/src/PaletteTexture.cpp
@@ -19,7 +19,7 @@ PaletteTexture::PaletteTexture()
 
 void PaletteTexture::init()
 {
-	if (!Context::imageTextures)
+	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
@@ -40,7 +40,6 @@ void PaletteTexture::init()
 
 	Context::InitTextureParams initParams;
 	initParams.handle = m_pTexture->name;
-	initParams.ImageUnit = textureImageUnits::Tlut;
 	initParams.width = m_pTexture->realWidth;
 	initParams.height = m_pTexture->realHeight;
 	initParams.internalFormat = fbTexFormats.lutInternalFormat;
@@ -64,18 +63,10 @@ void PaletteTexture::init()
 
 void PaletteTexture::destroy()
 {
-	if (!Context::imageTextures)
+	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
-
-	Context::BindImageTextureParameters bindParams;
-	bindParams.imageUnit = textureImageUnits::Tlut;
-	bindParams.texture = ObjectHandle::null;
-	bindParams.accessMode = textureImageAccessMode::READ_ONLY;
-	bindParams.textureFormat = fbTexFormats.lutInternalFormat;
-
-	gfxContext.bindImageTexture(bindParams);
 
 	textureCache().removeFrameBufferTexture(m_pTexture);
 	m_pTexture = nullptr;
@@ -84,7 +75,7 @@ void PaletteTexture::destroy()
 
 void PaletteTexture::update()
 {
-	if (!Context::imageTextures)
+	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
 		return;
 
 	if (m_paletteCRC256 == gDP.paletteCRC256)
@@ -100,7 +91,6 @@ void PaletteTexture::update()
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
 	Context::UpdateTextureDataParams params;
 	params.handle = m_pTexture->name;
-	params.ImageUnit = textureImageUnits::Tlut;
 	params.textureUnitIndex = textureIndices::PaletteTex;
 	params.width = m_pTexture->realWidth;
 	params.height = m_pTexture->realHeight;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -968,7 +968,7 @@ bool TextureCache::_loadHiresTexture(u32 _tile, CachedTexture *_pTexture, u64 & 
 
 void TextureCache::_loadDepthTexture(CachedTexture * _pTexture, u16* _pDest)
 {
-	if (!gfxContext.isSupported(SpecialFeatures::FragmentDepthWrite))
+	if (!config.generalEmulation.enableFragmentDepthWrite)
 		return;
 
 	Context::InitTextureParams params;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -500,7 +500,7 @@ void TextureCache::init()
 
 
 	m_pMSDummy = nullptr;
-	if (config.video.multisampling != 0 && gfxContext.isSupported(SpecialFeatures::Multisampling)) {
+	if (config.video.multisampling != 0 && Context::Multisampling) {
 		m_pMSDummy = addFrameBufferTexture(true); // we don't want to remove dummy texture
 		_initDummyTexture(m_pMSDummy);
 

--- a/src/ZlutTexture.cpp
+++ b/src/ZlutTexture.cpp
@@ -16,7 +16,7 @@ ZlutTexture::ZlutTexture()
 
 void ZlutTexture::init()
 {
-	if (!Context::imageTextures)
+	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
@@ -41,7 +41,6 @@ void ZlutTexture::init()
 
 	Context::InitTextureParams initParams;
 	initParams.handle = m_pTexture->name;
-	initParams.ImageUnit = textureImageUnits::Zlut;
 	initParams.width = m_pTexture->realWidth;
 	initParams.height = m_pTexture->realHeight;
 	initParams.internalFormat = fbTexFormats.lutInternalFormat;
@@ -61,19 +60,12 @@ void ZlutTexture::init()
 	gfxContext.setTextureParameters(setParams);
 }
 
-void ZlutTexture::destroy() {
-	if (!Context::imageTextures)
+void ZlutTexture::destroy()
+{
+	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
-
-	Context::BindImageTextureParameters bindParams;
-	bindParams.imageUnit = textureImageUnits::Zlut;
-	bindParams.texture = ObjectHandle::null;
-	bindParams.accessMode = textureImageAccessMode::READ_ONLY;
-	bindParams.textureFormat = fbTexFormats.lutInternalFormat;
-
-	gfxContext.bindImageTexture(bindParams);
 
 	textureCache().removeFrameBufferTexture(m_pTexture);
 	m_pTexture = nullptr;

--- a/src/ZlutTexture.cpp
+++ b/src/ZlutTexture.cpp
@@ -16,7 +16,7 @@ ZlutTexture::ZlutTexture()
 
 void ZlutTexture::init()
 {
-	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
+	if (!Context::IntegerTextures)
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();
@@ -62,7 +62,7 @@ void ZlutTexture::init()
 
 void ZlutTexture::destroy()
 {
-	if (!gfxContext.isSupported(SpecialFeatures::LUTTextures))
+	if (!Context::IntegerTextures)
 		return;
 
 	const FramebufferTextureFormats & fbTexFormats = gfxContext.getFramebufferTextureFormats();

--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -2232,7 +2232,7 @@ void _copyDepthBuffer()
 	if (!config.frameBufferEmulation.enable)
 		return;
 
-	if (!gfxContext.isSupported(SpecialFeatures::BlitFramebuffer))
+	if (!Context::BlitFramebuffer)
 		return;
 
 	// The game copies content of depth buffer into current color buffer


### PR DESCRIPTION
This removes the Image Texture requirement for the fog effect in Beetle Adventure Racing and the depth in Resident Evil 2.

Tested on Windows + Intel. I haven't tested this on GLES.

@fzurita This should make RE2 work in GLES I would assume. It should also make the BAR fog work on all devices. Hopefully it might fix the bug in https://github.com/gonetz/GLideN64/issues/1777