### PR TITLE
Only call glTexSubImage2D is there is data

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
@@ -229,15 +229,17 @@ namespace opengl {
 		{
 			m_bind->bind(_params.textureUnitIndex, GL_TEXTURE_2D, _params.handle);
 
-			glTexSubImage2D(GL_TEXTURE_2D,
-				_params.mipMapLevel,
-				_params.x,
-				_params.y,
-				_params.width,
-				_params.height,
-				GLuint(_params.format),
-				GLenum(_params.dataType),
-				_params.data);
+			if (_params.data != nullptr) {
+				glTexSubImage2D(GL_TEXTURE_2D,
+					_params.mipMapLevel,
+					_params.x,
+					_params.y,
+					_params.width,
+					_params.height,
+					GLuint(_params.format),
+					GLenum(_params.dataType),
+					_params.data);
+			}
 
 			if (_params.ImageUnit.isValid() && _params.internalFormat.isValid() && m_imageTextures)
 				glBindImageTexture(GLuint(_params.ImageUnit), GLuint(_params.handle),


### PR DESCRIPTION
Sometimes TextDrawer calls Update2DTexture will a nullptr for the data.

Since we don't use PBO's for texture uploads anymore, a nullptr is never valid for glTexSubImage2D. The Intel Windows driver was flagging this as "undefined behavior"