### PR TITLE
Workaround for Adreno issues with buggy FBOs

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -101,11 +101,14 @@ void ColorBufferToRDRAM::_initFBTexture(void)
 	}
 	{
 		Context::FrameBufferRenderTarget bufTarget;
-		bufTarget.bufferHandle = ObjectHandle(m_FBO);
+		bufTarget.bufferHandle = m_FBO;
 		bufTarget.bufferTarget = bufferTarget::DRAW_FRAMEBUFFER;
 		bufTarget.attachment = bufferAttachment::COLOR_ATTACHMENT0;
 		bufTarget.textureTarget = textureTarget::TEXTURE_2D;
 		bufTarget.textureHandle = m_pTexture->name;
+		m_pTexture->fbo = m_FBO;
+		m_pTexture->isFboValid = true;
+		m_pTexture->isDepthAttachment = false;
 		gfxContext.addFrameBufferRenderTarget(bufTarget);
 	}
 

--- a/src/BufferCopy/DepthBufferToRDRAM.cpp
+++ b/src/BufferCopy/DepthBufferToRDRAM.cpp
@@ -113,10 +113,16 @@ void DepthBufferToRDRAM::init()
 	bufTarget.attachment = bufferAttachment::COLOR_ATTACHMENT0;
 	bufTarget.textureTarget = textureTarget::TEXTURE_2D;
 	bufTarget.textureHandle = m_pColorTexture->name;
+	m_pColorTexture->fbo = m_FBO;
+	m_pColorTexture->isFboValid = true;
+	m_pColorTexture->isDepthAttachment = false;
 	gfxContext.addFrameBufferRenderTarget(bufTarget);
 
 	bufTarget.attachment = bufferAttachment::DEPTH_ATTACHMENT;
 	bufTarget.textureHandle = m_pDepthTexture->name;
+	m_pDepthTexture->fbo = m_FBO;
+	m_pDepthTexture->isFboValid = true;
+	m_pDepthTexture->isDepthAttachment = true;
 	gfxContext.addFrameBufferRenderTarget(bufTarget);
 
 	// check if everything is OK

--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -198,6 +198,10 @@ void DepthBuffer::setDepthAttachment(ObjectHandle _fbo, BufferTargetParam _targe
 		params.textureHandle = m_depthRenderbuffer;
 		params.textureTarget = textureTarget::RENDERBUFFER;
 	}
+
+	m_pDepthBufferTexture->fbo = _fbo;
+	m_pDepthBufferTexture->isFboValid = true;
+	m_pDepthBufferTexture->isDepthAttachment = true;
 	gfxContext.addFrameBufferRenderTarget(params);
 
 	m_copied = false;
@@ -235,6 +239,9 @@ CachedTexture * DepthBuffer::resolveDepthBufferTexture(FrameBuffer * _pBuffer)
 	targetParams.bufferTarget = bufferTarget::DRAW_FRAMEBUFFER;
 	targetParams.textureHandle = m_pResolveDepthBufferTexture->name;
 	targetParams.textureTarget = textureTarget::TEXTURE_2D;
+	m_pResolveDepthBufferTexture->fbo = _pBuffer->m_resolveFBO;
+	m_pResolveDepthBufferTexture->isFboValid = true;
+	m_pResolveDepthBufferTexture->isDepthAttachment = true;
 	gfxContext.addFrameBufferRenderTarget(targetParams);
 
 	Context::BlitFramebuffersParams blitParams;
@@ -272,18 +279,24 @@ CachedTexture * DepthBuffer::copyDepthBufferTexture(FrameBuffer * _pBuffer)
 
 
 	Context::FrameBufferRenderTarget targetParams;
+	CachedTexture* texture = _pBuffer->m_pTexture->frameBufferTexture == CachedTexture::fbMultiSample ?
+		_pBuffer->m_pResolveTexture : _pBuffer->m_pTexture;
 	targetParams.bufferHandle = m_copyFBO;
 	targetParams.bufferTarget = bufferTarget::DRAW_FRAMEBUFFER;
 	targetParams.attachment = bufferAttachment::COLOR_ATTACHMENT0;
-	targetParams.textureHandle = _pBuffer->m_pTexture->frameBufferTexture == CachedTexture::fbMultiSample ?
-		_pBuffer->m_pResolveTexture->name :
-		_pBuffer->m_pTexture->name;
+	targetParams.textureHandle = texture->name;
 	targetParams.textureTarget = textureTarget::TEXTURE_2D;
+	texture->fbo = m_copyFBO;
+	texture->isFboValid = true;
+	texture->isDepthAttachment = false;
 
 	gfxContext.addFrameBufferRenderTarget(targetParams);
 
 	targetParams.attachment = bufferAttachment::DEPTH_ATTACHMENT;
 	targetParams.textureHandle = m_pDepthBufferCopyTexture->name;
+	m_pDepthBufferCopyTexture->fbo = m_copyFBO;
+	m_pDepthBufferCopyTexture->isFboValid = true;
+	m_pDepthBufferCopyTexture->isDepthAttachment = true;
 
 	gfxContext.addFrameBufferRenderTarget(targetParams);
 

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -134,6 +134,9 @@ void FrameBuffer::_setAndAttachTexture(ObjectHandle _fbo, CachedTexture *_pTextu
 	bufTarget.attachment = bufferAttachment::COLOR_ATTACHMENT0;
 	bufTarget.textureTarget = _multisampling ? textureTarget::TEXTURE_2D_MULTISAMPLE : textureTarget::TEXTURE_2D;
 	bufTarget.textureHandle = _pTexture->name;
+	_pTexture->fbo = _fbo;
+	_pTexture->isFboValid = true;
+	_pTexture->isDepthAttachment = false;
 	gfxContext.addFrameBufferRenderTarget(bufTarget);
 	assert(!gfxContext.isFramebufferError());
 }

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -122,6 +122,10 @@ namespace graphics {
 			TextureParam wrapT;
 			Parameter maxMipmapLevel;
 			Parameter maxAnisotropy;
+			bool isFrameBufferTexture = false;
+			bool isDepthAttachment = false;
+			ObjectHandle textureFBO;
+			ObjectHandle currentFBO;
 		};
 
 		void setTextureParameters(const TexParameters & _parameters);

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -143,6 +143,9 @@ namespace opengl {
 		bool isFramebufferError() const override;
 
 	private:
+
+		void generateAdrenoFBOs();
+
 		std::unique_ptr<CachedFunctions> m_cachedFunctions;
 		std::unique_ptr<Create2DTexture> m_createTexture;
 		std::unique_ptr<Init2DTexture> m_init2DTexture;
@@ -163,6 +166,11 @@ namespace opengl {
 		std::unique_ptr<glsl::SpecialShadersFactory> m_specialShadersFactory;
 		GLInfo m_glInfo;
 		graphics::ClampMode m_clampMode;
+
+		graphics::ObjectHandle m_AdrenoFBO;
+		graphics::ObjectHandle m_AdrenoTexture;
+		graphics::Context::TexParameters m_currentFBOTextParams;
+		bool hasFBOBeenBlit;
 	};
 
 }

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -42,6 +42,8 @@ void GLInfo::init() {
 		renderer = Renderer::PowerVR;
 	LOG(LOG_VERBOSE, "OpenGL renderer: %s\n", strRenderer);
 
+	buggyFBO = strstr((const char*)strRenderer, "Adreno") != nullptr;
+
 	int numericVersion = majorVersion * 10 + minorVersion;
 	if (isGLES2) {
 		imageTextures = false;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -25,6 +25,7 @@ struct GLInfo {
 	bool msaa = false;
 	bool depthTexture = false;
 	bool noPerspective = false;
+	bool buggyFBO = false;
 	Renderer renderer = Renderer::Other;
 
 	void init();

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -59,6 +59,9 @@ void PostProcessor::_createResultBuffer(const FrameBuffer * _pMainBuffer)
 	bufTarget.attachment = bufferAttachment::COLOR_ATTACHMENT0;
 	bufTarget.textureTarget = textureTarget::TEXTURE_2D;
 	bufTarget.textureHandle = pTexture->name;
+	pTexture->fbo = m_pResultBuffer->m_FBO;
+	pTexture->isFboValid = true;
+	pTexture->isDepthAttachment = false;
 	gfxContext.addFrameBufferRenderTarget(bufTarget);
 	assert(!gfxContext.isFramebufferError());
 }

--- a/src/TexrectDrawer.cpp
+++ b/src/TexrectDrawer.cpp
@@ -74,6 +74,9 @@ void TexrectDrawer::init()
 	bufTarget.attachment = bufferAttachment::COLOR_ATTACHMENT0;
 	bufTarget.textureTarget = textureTarget::TEXTURE_2D;
 	bufTarget.textureHandle = m_pTexture->name;
+	m_pTexture->fbo = m_FBO;
+	m_pTexture->isFboValid = true;
+	m_pTexture->isDepthAttachment = false;
 	gfxContext.addFrameBufferRenderTarget(bufTarget);
 
 	// check if everything is OK

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1288,6 +1288,12 @@ void TextureCache::activateTexture(u32 _t, CachedTexture *_pTexture)
 
 	Context::TexParameters params;
 	params.handle = _pTexture->name;
+	params.isFrameBufferTexture = _pTexture->frameBufferTexture != CachedTexture::fbNone && _pTexture->isFboValid;
+	params.isDepthAttachment = _pTexture->isDepthAttachment;
+
+	params.textureFBO = _pTexture->fbo;
+	params.currentFBO = frameBufferList().getCurrent()->m_FBO;
+
 	if (config.video.multisampling > 0 && _pTexture->frameBufferTexture == CachedTexture::fbMultiSample) {
 		params.target = textureTarget::TEXTURE_2D_MULTISAMPLE;
 		params.textureUnitIndex = textureIndices::MSTex[_t];

--- a/src/Textures.h
+++ b/src/Textures.h
@@ -14,9 +14,12 @@ typedef u32 (*GetTexelFunc)( u64 *src, u16 x, u16 i, u8 palette );
 
 struct CachedTexture
 {
-	CachedTexture(graphics::ObjectHandle _name) : name(_name), max_level(0), frameBufferTexture(fbNone), bHDTexture(false) {}
+	CachedTexture(graphics::ObjectHandle _name) : name(_name), isFboValid(false), max_level(0), frameBufferTexture(fbNone), bHDTexture(false) {}
 
 	graphics::ObjectHandle name;
+	graphics::ObjectHandle fbo;
+	bool isFboValid;
+	bool isDepthAttachment;
 	u32		crc = 0;
 //	float	fulS, fulT;
 //	WORD	ulS, ulT, lrS, lrT;


### PR DESCRIPTION
If we are updating texture parameters on a frame buffer texture, and the previous frame buffer texture for which we are updating parameters has not been blit at any point, then we will perform a zero size blit to a fbo that was allocated just for this workaround.

This is because with Adreno, the color buffer for an FBO is getting thrown away if it's not used at least once, so when we go and use the FBO's texture in a shader, there is nothing there.