### PR TITLE
[WIP] use gl_LastFragData/DepthARM when possible

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -63,8 +63,18 @@ namespace glsl {
 				"OUT lowp vec4 fragColor;									\n"
 				"lowp float get_alpha()										\n"
 				"{															\n"
-				"  mediump ivec2 coord = ivec2(gl_FragCoord.xy);			\n"
-				"  highp float bufZ = texelFetch(uDepthImage,coord, 0).r;	\n"
+				;
+			if (_glinfo.fetch_depth) {
+				m_part +=
+					"  highp float bufZ = gl_LastFragDepthARM;	\n"
+					;
+			} else {
+				m_part +=
+					"  mediump ivec2 coord = ivec2(gl_FragCoord.xy);	\n"
+					"  highp float bufZ = texelFetch(uDepthImage,coord, 0).r;	\n"
+					;
+			}
+			m_part +=
 				"  highp int iZ = bufZ > 0.999 ? 262143 : int(floor(bufZ * 262143.0));\n"
 				"  mediump int y0 = clamp(iZ/512, 0, 511);					\n"
 				"  mediump int x0 = iZ - 512*y0;							\n"

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -102,4 +102,8 @@ void GLInfo::init() {
 
 	depthTexture = !isGLES2 || Utils::isExtensionSupported(*this, "GL_OES_depth_texture");
 	noPerspective = Utils::isExtensionSupported(*this, "GL_NV_shader_noperspective_interpolation");
+
+	fetch_depth = Utils::isExtensionSupported(*this, "GL_ARM_shader_framebuffer_fetch_depth_stencil");
+	arm_fetch = Utils::isExtensionSupported(*this, "GL_ARM_shader_framebuffer_fetch");
+	ext_fetch = Utils::isExtensionSupported(*this, "GL_EXT_shader_framebuffer_fetch");
 }

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -25,6 +25,9 @@ struct GLInfo {
 	bool msaa = false;
 	bool depthTexture = false;
 	bool noPerspective = false;
+	bool fetch_depth = false;
+	bool ext_fetch = false;
+	bool arm_fetch = false;
 	Renderer renderer = Renderer::Other;
 
 	void init();


### PR DESCRIPTION
This is a fix for the issues with the BAR fog and Majora's Mask monochrome scene in GLES.

I haven't tested the Majora's Mask scene yet, so this shouldn't be merged yet, just opening for review.

If/when this is tested and merged, a similar fix should be applied for desktop GPUs. We haven't seen anyone on the desktop have issues with the BAR fog, but we have had a report of issues with Majora's Mask scene.

On the desktop, this should be possible to fix via ARB_texture_barrier/NV_texture_barrier, but I'll probably deal with that in a separate pull request.


These extensions are available on all Mali GPUs, and Adreno 5XX. I don't know of any way to fix this on pre 5XX Adreno devices. We would probably have to resort to ugly hacks.