### PR TITLE
Fix BAR fog

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -313,7 +313,7 @@ CachedTexture * DepthBuffer::copyDepthBufferTexture(FrameBuffer * _pBuffer)
 
 void DepthBuffer::activateDepthBufferTexture(FrameBuffer * _pBuffer)
 {
-	textureCache().activateTexture(0, resolveDepthBufferTexture(_pBuffer));
+	textureCache().activateTexture(0, copyDepthBufferTexture(_pBuffer));
 }
 
 void DepthBuffer::bindDepthImageTexture()


### PR DESCRIPTION
After playing around with all sorts of exotic extensions, I realized there is a very simple fix for this problem, and the function to fix it already exists.

Basically, you should never ever ever sample from a texture that is attached to a FBO. You need to copy it first. This is explained in the page for glFramebufferTexture2D:

> Special precautions need to be taken to avoid attaching a texture image to the currently bound framebuffer while the texture object is currently bound and potentially sampled by the current vertex or fragment shader. Doing so could lead to the creation of a "feedback loop" between the writing of pixels by rendering operations and the simultaneous reading of those same pixels when used as texels in the currently bound texture. In this scenario, the framebuffer will be considered framebuffer complete, but the values of fragments rendered while in this state will be undefined. The values of texture samples may be undefined as well.

So what this PR does, is copy the depth texture and then attaches that copy instead.

A similar fix is needed for FrameBuffer_ActivateBufferTexture/FrameBuffer_ActivateBufferTextureBG. That will fix the Majora's Mask cutscene. I will submit a separate PR for that.