### PR TITLE
Fix Zelda MM cutscene

### DIFF
--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -61,6 +61,10 @@ struct FrameBuffer
 	graphics::ObjectHandle m_SubFBO;
 	CachedTexture *m_pSubTexture;
 
+	// copy FBO
+	graphics::ObjectHandle m_copyFBO;
+	CachedTexture * m_pFrameBufferCopyTexture;
+
 	std::vector<u8> m_RdramCopy;
 
 private:
@@ -75,6 +79,7 @@ private:
 	void _initTexture(u16 _width, u16 _height, u16 _format, u16 _size, CachedTexture *_pTexture);
 	void _setAndAttachTexture(graphics::ObjectHandle _fbo, CachedTexture *_pTexture, u32 _t, bool _multisampling);
 	bool _initSubTexture(u32 _t);
+	CachedTexture * _copyFrameBufferTexture();
 	CachedTexture * _getSubTexture(u32 _t);
 	mutable u32 m_validityChecked;
 };


### PR DESCRIPTION
This is a companion PR to https://github.com/gonetz/GLideN64/pull/1790

I would say the BAR fog PR if very safe, I know that code is specific only to the BAR fog scene.

This PR could affect games other than Zelda MM, I'm not sure what other games use this feature.

It does the same thing though: when we used to sample from an FBO texture, we now copy that texture using glBlitFramebuffer, and sample from the copied texture. This fixes the monochrome scene for me in VMware and on my phone.