### PR TITLE
Fix RE2 and NFL QB Club 98 on GLES

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_Parameters.cpp
+++ b/src/Graphics/OpenGLContext/opengl_Parameters.cpp
@@ -19,7 +19,7 @@ namespace graphics {
 		InternalColorFormatParam RGBA4(GL_RGBA4);
 		InternalColorFormatParam RGB5_A1(GL_RGB5_A1);
 		InternalColorFormatParam RG(GL_RG8);
-		InternalColorFormatParam RED(GL_R8);
+		InternalColorFormatParam R16F(GL_R16F);
 		InternalColorFormatParam DEPTH(GL_DEPTH_COMPONENT24);
 		InternalColorFormatParam RG32F(GL_RG32F);
 		InternalColorFormatParam LUMINANCE(0x1909);

--- a/src/Graphics/Parameters.h
+++ b/src/Graphics/Parameters.h
@@ -19,7 +19,7 @@ namespace graphics {
 		extern InternalColorFormatParam RGBA4;
 		extern InternalColorFormatParam RGB5_A1;
 		extern InternalColorFormatParam RG;
-		extern InternalColorFormatParam RED;
+		extern InternalColorFormatParam R16F;
 		extern InternalColorFormatParam DEPTH;
 		extern InternalColorFormatParam RG32F;
 		extern InternalColorFormatParam LUMINANCE;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -971,16 +971,21 @@ void TextureCache::_loadDepthTexture(CachedTexture * _pTexture, u16* _pDest)
 	if (!config.generalEmulation.enableFragmentDepthWrite)
 		return;
 
+	u32 size = _pTexture->realWidth * _pTexture->realHeight;
+	std::vector<f32> pDestFloat(size);
+	for (u32 i = 0; i < size; ++i)
+		pDestFloat[i] = _pDest[i] / 65535.0;
+
 	Context::InitTextureParams params;
 	params.handle = _pTexture->name;
 	params.mipMapLevel = 0;
 	params.msaaLevel = 0;
 	params.width = _pTexture->realWidth;
 	params.height = _pTexture->realHeight;
-	params.internalFormat = internalcolorFormat::RED;
+	params.internalFormat = internalcolorFormat::R16F;
 	params.format = colorFormat::RED;
-	params.dataType = datatype::UNSIGNED_SHORT;
-	params.data = _pDest;
+	params.dataType = datatype::FLOAT;
+	params.data = pDestFloat.data();
 	gfxContext.init2DTexture(params);
 }
 


### PR DESCRIPTION
Right now RE2 doesn't work properly on GLES (can't see any 3D objects).

It is because the texture upload uses GL_R8 for the internal format, and GL_RED/GL_UNSIGNED_SHORT for the format. This isn't allowed on GLES.

You can see the allowed combinations on this page: https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glTexStorage2D.xhtml

To use GL_R8, you must use GL_UNSIGNED_BYTE. That would result in a lose in precision, so I changed it to GL_R16F/GL_FLOAT. This works in OpenGL and GLES.