### PR TITLE
Only call texture barrier if we are sampling from current FB

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1278,7 +1278,8 @@ void FrameBuffer_ActivateBufferTexture(u32 t, u32 _frameBufferAddress)
 
 //	frameBufferList().renderBuffer(pBuffer->m_startAddress);
 	textureCache().activateTexture(t, pTexture);
-	gfxContext.textureBarrier();
+	if (pBuffer == frameBufferList().getCurrent())
+		gfxContext.textureBarrier();
 	gDP.changed |= CHANGED_FB_TEXTURE;
 }
 
@@ -1294,7 +1295,8 @@ void FrameBuffer_ActivateBufferTextureBG(u32 t, u32 _frameBufferAddress)
 
 //	frameBufferList().renderBuffer(pBuffer->m_startAddress);
 	textureCache().activateTexture(t, pTexture);
-	gfxContext.textureBarrier();
+	if (pBuffer == frameBufferList().getCurrent())
+		gfxContext.textureBarrier();
 	gDP.changed |= CHANGED_FB_TEXTURE;
 }
 


### PR DESCRIPTION
This is just a small refinement of c01c0d5166d4df0d7c9c4334c8cac58331a1b67c

This is actually only an issue when we are trying to sample from the currently bound FBO, it's fine if we try to sample from the FB texture of a different FBO.

So this just limits the number of times we call glTextureBarrier.

This explains the difference between the "spinning mask" scene and the monochrome scene in Zelda MM, and why only the monochrome scene has issues. Both scenes call these functions, but only the monochrome scene tries to sample from the FB texture of the current framebuffer.