### PR TITLE
Copy FBO texture if glTextureBarrier is unsupported

### DIFF
--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -42,6 +42,7 @@ struct FrameBuffer
 	bool m_isOBScreen;
 	bool m_isMainBuffer;
 	bool m_readable;
+	bool m_copied;
 
 	struct {
 		u32 uls, ult;
@@ -61,6 +62,10 @@ struct FrameBuffer
 	graphics::ObjectHandle m_SubFBO;
 	CachedTexture *m_pSubTexture;
 
+	// copy FBO
+	graphics::ObjectHandle m_copyFBO;
+	CachedTexture * m_pFrameBufferCopyTexture;
+
 	std::vector<u8> m_RdramCopy;
 
 private:
@@ -75,6 +80,8 @@ private:
 	void _initTexture(u16 _width, u16 _height, u16 _format, u16 _size, CachedTexture *_pTexture);
 	void _setAndAttachTexture(graphics::ObjectHandle _fbo, CachedTexture *_pTexture, u32 _t, bool _multisampling);
 	bool _initSubTexture(u32 _t);
+	void _initCopyTexture();
+	CachedTexture * _copyFrameBufferTexture();
 	CachedTexture * _getSubTexture(u32 _t);
 	mutable u32 m_validityChecked;
 };

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -14,6 +14,7 @@ bool Context::ImageTextures = false;
 bool Context::IntegerTextures = false;
 bool Context::ClipControl = false;
 bool Context::FramebufferFetch = false;
+bool Context::TextureBarrier = false;
 
 Context::Context() {}
 
@@ -36,6 +37,7 @@ void Context::init()
 	IntegerTextures = m_impl->isSupported(SpecialFeatures::IntegerTextures);
 	ClipControl = m_impl->isSupported(SpecialFeatures::ClipControl);
 	FramebufferFetch = m_impl->isSupported(SpecialFeatures::FramebufferFetch);
+	TextureBarrier = m_impl->isSupported(SpecialFeatures::TextureBarrier);
 }
 
 void Context::destroy()

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -24,7 +24,8 @@ namespace graphics {
 		ImageTextures,
 		IntegerTextures,
 		ClipControl,
-		FramebufferFetch
+		FramebufferFetch,
+		TextureBarrier
 	};
 
 	enum class ClampMode {
@@ -285,6 +286,7 @@ namespace graphics {
 		static bool IntegerTextures;
 		static bool ClipControl;
 		static bool FramebufferFetch;
+		static bool TextureBarrier;
 
 	private:
 		std::unique_ptr<ContextImpl> m_impl;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -491,6 +491,8 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return !m_glInfo.isGLESX;
 	case graphics::SpecialFeatures::FramebufferFetch:
 		return m_glInfo.ext_fetch;
+	case graphics::SpecialFeatures::TextureBarrier:
+		return m_glInfo.texture_barrier || m_glInfo.texture_barrierNV;
 	}
 	return false;
 }

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -121,7 +121,7 @@ void GLInfo::init() {
 	noPerspective = Utils::isExtensionSupported(*this, "GL_NV_shader_noperspective_interpolation");
 
 	fetch_depth = Utils::isExtensionSupported(*this, "GL_ARM_shader_framebuffer_fetch_depth_stencil");
-	texture_barrier = (!isGLESX && numericVersion >= 45) || Utils::isExtensionSupported(*this, "GL_ARB_texture_barrier");
+	texture_barrier = !isGLESX && (numericVersion >= 45 || Utils::isExtensionSupported(*this, "GL_ARB_texture_barrier"));
 	texture_barrierNV = Utils::isExtensionSupported(*this, "GL_NV_texture_barrier");
 
 	ext_fetch = Utils::isExtensionSupported(*this, "GL_EXT_shader_framebuffer_fetch") && !isGLES2 && (!isGLESX || ext_draw_buffers_indexed) && !imageTextures;


### PR DESCRIPTION
This fixes the Majora's Mask scene for GLES where glTextureBarrier is unsupported. I added an "m_copied" variable, similar to what was done for depth texture copies, to improve performance. The "m_copied" greatly reduces the number of copies needed in the Majora's Mask scene and it still looks correct.

Tested on an Adreno 540.

To summarize this fix: If we are trying to read from the currently attached FBO texture, we execute glTextureBarrier if we can, if not, we copy the texture and read from that copy.