### PR TITLE
Fix BAR Fog with N64 Depth Compare

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x1FU;
+		const u32 m_formatVersion = 0x20U;
 		const u32 m_keysFormatVersion = 0x04;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -52,8 +52,7 @@ void GLInfo::init() {
 		imageTextures = (numericVersion >= 31);
 		msaa = numericVersion >= 31;
 	} else {
-		imageTextures = ((numericVersion >= 43) || (Utils::isExtensionSupported(*this, "GL_ARB_shader_image_load_store") &&
-				Utils::isExtensionSupported(*this, "GL_ARB_compute_shader")));
+		imageTextures = (numericVersion >= 42) || Utils::isExtensionSupported(*this, "GL_ARB_shader_image_load_store");
 		msaa = true;
 	}
 


### PR DESCRIPTION
This fixes depth based fog when N64 Depth Compare is enabled. It allows fetching the depth value from the Image Texture (or color attachment associated with the depth image texture).