### PR TITLE
Remove FB Attachment caching

### DIFF
--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -121,9 +121,9 @@ ObjectHandle Context::createTexture(Parameter _target)
 	return m_impl->createTexture(_target);
 }
 
-void Context::deleteTexture(ObjectHandle _name, bool _isFBTexture)
+void Context::deleteTexture(ObjectHandle _name)
 {
-	m_impl->deleteTexture(_name, _isFBTexture);
+	m_impl->deleteTexture(_name);
 }
 
 void Context::init2DTexture(const InitTextureParams & _params)

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -79,7 +79,7 @@ namespace graphics {
 
 		ObjectHandle createTexture(Parameter _target);
 
-		void deleteTexture(ObjectHandle _name, bool _isFBTexture);
+		void deleteTexture(ObjectHandle _name);
 
 		struct InitTextureParams {
 			ObjectHandle handle;

--- a/src/Graphics/ContextImpl.h
+++ b/src/Graphics/ContextImpl.h
@@ -27,7 +27,7 @@ namespace graphics {
 		virtual void clearDepthBuffer() = 0;
 		virtual void setPolygonOffset(f32 _factor, f32 _units) = 0;
 		virtual ObjectHandle createTexture(Parameter _target) = 0;
-		virtual void deleteTexture(ObjectHandle _name, bool _isFBTexture) = 0;
+		virtual void deleteTexture(ObjectHandle _name) = 0;
 		virtual void init2DTexture(const Context::InitTextureParams & _params) = 0;
 		virtual void update2DTexture(const Context::UpdateTextureDataParams & _params) = 0;
 		virtual void setTextureParameters(const Context::TexParameters & _parameters) = 0;

--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -77,16 +77,10 @@ private:
 class AddFramebufferTexture2D : public AddFramebufferRenderTarget
 {
 public:
-	AddFramebufferTexture2D(CachedBindFramebuffer * _bind, FramebufferAttachments * _fbattachments) : m_bind(_bind), m_fbattachments(_fbattachments) {}
+	AddFramebufferTexture2D(CachedBindFramebuffer * _bind) : m_bind(_bind) {}
 
 	void addFrameBufferRenderTarget(const graphics::Context::FrameBufferRenderTarget & _params) override
 	{
-		FramebufferAttachments::const_iterator iter = m_fbattachments->find(u32(_params.bufferHandle));
-		if (iter != m_fbattachments->end() && iter->second == u32(_params.textureHandle))
-			return;
-
-		(*m_fbattachments)[u32(_params.bufferHandle)] = u32(_params.textureHandle);
-
 		m_bind->bind(_params.bufferTarget, _params.bufferHandle);
 		if (_params.textureTarget == graphics::textureTarget::RENDERBUFFER) {
 			glFramebufferRenderbuffer(GLenum(_params.bufferTarget),
@@ -104,7 +98,6 @@ public:
 
 private:
 	CachedBindFramebuffer * m_bind;
-	FramebufferAttachments * m_fbattachments;
 };
 
 class AddNamedFramebufferTexture : public AddFramebufferRenderTarget
@@ -441,7 +434,7 @@ AddFramebufferRenderTarget * BufferManipulationObjectFactory::getAddFramebufferR
 	if (AddNamedFramebufferTexture::Check(m_glInfo))
 		return new AddNamedFramebufferTexture;
 
-	return new AddFramebufferTexture2D(m_cachedFunctions.getCachedBindFramebuffer(), m_cachedFunctions.getFBAttachments());
+	return new AddFramebufferTexture2D(m_cachedFunctions.getCachedBindFramebuffer());
 }
 
 BlitFramebuffers * BufferManipulationObjectFactory::getBlitFramebuffers() const

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.cpp
@@ -171,7 +171,6 @@ void CachedFunctions::reset()
 		it.second.reset();
 
 	m_texparams.clear();
-	m_fbattachments.clear();
 	m_bindTexture.reset();
 	m_bindFramebuffer.reset();
 	m_bindRenderbuffer.reset();
@@ -274,11 +273,6 @@ CachedUseProgram * CachedFunctions::getCachedUseProgram()
 CachedTextureUnpackAlignment * CachedFunctions::getCachedTextureUnpackAlignment()
 {
 	return &m_unpackAlignment;
-}
-
-FramebufferAttachments * CachedFunctions::getFBAttachments()
-{
-	return &m_fbattachments;
 }
 
 TextureParams * CachedFunctions::getTexParams()

--- a/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
+++ b/src/Graphics/OpenGLContext/opengl_CachedFunctions.h
@@ -241,7 +241,6 @@ namespace opengl {
 		GLfloat maxAnisotropy;
 	};
 
-	typedef std::unordered_map<u32, u32> FramebufferAttachments;
 	typedef std::unordered_map<u32, texture_params> TextureParams;
 
 	/*---------------CachedFunctions-------------*/
@@ -286,15 +285,12 @@ namespace opengl {
 
 		CachedTextureUnpackAlignment * getCachedTextureUnpackAlignment();
 
-		FramebufferAttachments * getFBAttachments();
-
 		TextureParams * getTexParams();
 
 	private:
 		typedef std::unordered_map<u32, CachedEnable> EnableParameters;
 
 		TextureParams m_texparams;
-		FramebufferAttachments m_fbattachments;
 		EnableParameters m_enables;
 		CachedBindTexture m_bindTexture;
 		CachedBindFramebuffer m_bindFramebuffer;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -202,21 +202,11 @@ graphics::ObjectHandle ContextImpl::createTexture(graphics::Parameter _target)
 	return m_createTexture->createTexture(_target);
 }
 
-void ContextImpl::deleteTexture(graphics::ObjectHandle _name, bool _isFBTexture)
+void ContextImpl::deleteTexture(graphics::ObjectHandle _name)
 {
 	u32 glName(_name);
 	glDeleteTextures(1, &glName);
 	m_init2DTexture->reset(_name);
-
-	if (_isFBTexture) {
-		FramebufferAttachments * fbAtt =  m_cachedFunctions->getFBAttachments();
-		for (auto iter = fbAtt->begin(); iter != fbAtt->end(); ++iter) {
-			if (iter->second == u32(_name)) {
-				fbAtt->erase(iter);
-				break;
-			}
-		}
-	}
 
 	m_cachedFunctions->getTexParams()->erase(u32(_name));
 }
@@ -307,7 +297,6 @@ void ContextImpl::deleteFramebuffer(graphics::ObjectHandle _name)
 	if (fbo != 0) {
 		glDeleteFramebuffers(1, &fbo);
 		m_cachedFunctions->getCachedBindFramebuffer()->reset();
-		m_cachedFunctions->getFBAttachments()->erase(u32(_name));
 	}
 }
 

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -56,7 +56,7 @@ namespace opengl {
 
 		graphics::ObjectHandle createTexture(graphics::Parameter _target) override;
 
-		void deleteTexture(graphics::ObjectHandle _name, bool _isFBTexture) override;
+		void deleteTexture(graphics::ObjectHandle _name) override;
 
 		void init2DTexture(const graphics::Context::InitTextureParams & _params) override;
 

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -527,12 +527,12 @@ void TextureCache::destroy()
 	current[0] = current[1] = nullptr;
 
 	for (Textures::const_iterator cur = m_textures.cbegin(); cur != m_textures.cend(); ++cur)
-		gfxContext.deleteTexture(cur->name, false);
+		gfxContext.deleteTexture(cur->name);
 	m_textures.clear();
 	m_lruTextureLocations.clear();
 
 	for (FBTextures::const_iterator cur = m_fbTextures.cbegin(); cur != m_fbTextures.cend(); ++cur)
-		gfxContext.deleteTexture(cur->second.name, true);
+		gfxContext.deleteTexture(cur->second.name);
 	m_fbTextures.clear();
 }
 
@@ -540,7 +540,7 @@ void TextureCache::_checkCacheSize()
 {
 	if (m_textures.size() >= m_maxCacheSize) {
 		CachedTexture& clsTex = m_textures.back();
-		gfxContext.deleteTexture(clsTex.name, false);
+		gfxContext.deleteTexture(clsTex.name);
 		m_lruTextureLocations.erase(clsTex.crc);
 		m_textures.pop_back();
 	}
@@ -564,7 +564,7 @@ void TextureCache::removeFrameBufferTexture(CachedTexture * _pTexture)
 		return;
 	FBTextures::const_iterator iter = m_fbTextures.find(u32(_pTexture->name));
 	assert(iter != m_fbTextures.cend());
-	gfxContext.deleteTexture(ObjectHandle(iter->second.name), true);
+	gfxContext.deleteTexture(ObjectHandle(iter->second.name));
 	m_fbTextures.erase(iter);
 }
 
@@ -1448,7 +1448,7 @@ void TextureCache::_clear()
 	current[0] = current[1] = nullptr;
 
 	for (auto cur = m_textures.cbegin(); cur != m_textures.cend(); ++cur) {
-		gfxContext.deleteTexture(cur->name, false);
+		gfxContext.deleteTexture(cur->name);
 	}
 	m_textures.clear();
 	m_lruTextureLocations.clear();
@@ -1546,7 +1546,7 @@ void TextureCache::update(u32 _t)
 			return;
 		}
 
-		gfxContext.deleteTexture(currentTex.name, false);
+		gfxContext.deleteTexture(currentTex.name);
 		m_lruTextureLocations.erase(locations_iter);
 		m_textures.erase(iter);
 	}


### PR DESCRIPTION
Reverts https://github.com/gonetz/GLideN64/commit/b81dd6a673373f4c85b86b9a135229665ddde624 and https://github.com/gonetz/GLideN64/commit/91ab96d514e946f46e60e5f9e0b2238e3120386f

Fixes https://github.com/m64p/mupen64plus-GLideN64/issues/72

This optimization was causing flickering in Pokemon Stadium. May potentially fix https://github.com/gonetz/GLideN64/issues/1804 as well