### PR TITLE
Fixes build errors with clang

### DIFF
--- a/src/GLideNHQ/txWidestringWrapper.cpp
+++ b/src/GLideNHQ/txWidestringWrapper.cpp
@@ -57,14 +57,14 @@ tx_wstring & tx_wstring::operator+=(const wchar_t * wstr)
 	return *this;
 }
 
-tx_wstring tx_wstring::operator + (const tx_wstring & wstr)
+tx_wstring tx_wstring::operator+(const tx_wstring & wstr) const
 {
 	tx_wstring ans(_wstring.c_str());
 	ans.append(wstr);
 	return ans;
 }
 
-tx_wstring tx_wstring::operator+(const wchar_t * wstr)
+tx_wstring tx_wstring::operator+(const wchar_t * wstr) const
 {
 	tx_wstring ans(_wstring.c_str());
 	ans.append(wstr);

--- a/src/GLideNHQ/txWidestringWrapper.h
+++ b/src/GLideNHQ/txWidestringWrapper.h
@@ -22,8 +22,8 @@ public:
 	tx_wstring & operator=(const tx_wstring & other);
 	tx_wstring & operator+=(const tx_wstring & other);
 	tx_wstring & operator+=(const wchar_t * wstr);
-	tx_wstring operator+(const tx_wstring & wstr);
-	tx_wstring operator+(const wchar_t * wstr);
+	tx_wstring operator+(const tx_wstring & wstr) const;
+	tx_wstring operator+(const wchar_t * wstr) const;
 	const wchar_t * c_str() const;
 	bool empty() const;
 	int compare(const wchar_t * wstr);


### PR DESCRIPTION
Here is the problem: ```TxTexCache::_getFileName()``` is a const function. ```operator+``` of ```tx_wstring``` not const. This line breaks the const parameter of the function:

```tx_wstring filename = _ident + wst("_MEMORYCACHE.") + TEXCACHE_EXT;```

It breaks it because ```_ident +``` could modify the ```_ident``` member attribute since ```operator+``` is not const.