### PR TITLE
Fix NEON build

### DIFF
--- a/src/3DMath.cpp
+++ b/src/3DMath.cpp
@@ -1,6 +1,5 @@
 #include <math.h>
 #include "3DMath.h"
-#include "GBI.h"
 
 void MultMatrix(float m0[4][4], float m1[4][4], float dest[4][4])
 {
@@ -143,16 +142,4 @@ void CopyMatrix( float m0[4][4], float m1[4][4] )
 #else
 	memcpy( m0, m1, 16 * sizeof( float ) );
 #endif // WIN32_ASM
-}
-
-float GetFloatMatrixElement(s16 _int, u16 _fract)
-{
-	const s32 element = (_int << 16) | _fract;
-	return _FIXED2FLOAT(element, 16);
-}
-
-std::pair<s16, u16> GetIntMatrixElement(f32 _elem)
-{
-	const s32 value = static_cast<s32>(_elem * 65536.0f);
-	return std::pair<s16, u16>(static_cast<s16>(value >> 16), static_cast<u16>(value & 0xFFFF));
 }

--- a/src/3DMath.h
+++ b/src/3DMath.h
@@ -4,6 +4,7 @@
 #include <memory.h>
 #include <string.h>
 #include <Types.h>
+#include "GBI.h"
 
 void MultMatrix(float m0[4][4], float m1[4][4], float dest[4][4]);
 void MultMatrix2(float m0[4][4], float m1[4][4]);
@@ -39,7 +40,16 @@ inline float DotProduct(const float v0[3], const float v1[3])
 	return dot;
 }
 
-float GetFloatMatrixElement(s16 _int, u16 _fract);
-std::pair<s16, u16> GetIntMatrixElement(f32 _elem);
+inline float GetFloatMatrixElement(s16 _int, u16 _fract)
+{
+	const s32 element = (_int << 16) | _fract;
+	return _FIXED2FLOAT(element, 16);
+}
+
+inline std::pair<s16, u16> GetIntMatrixElement(f32 _elem)
+{
+	const s32 value = static_cast<s32>(_elem * 65536.0f);
+	return std::pair<s16, u16>(static_cast<s16>(value >> 16), static_cast<u16>(value & 0xFFFF));
+}
 
 #endif


### PR DESCRIPTION
Fixes the NEON build by putting common methods between NEON and non NEON in the header file of 3DMath.