### PR TITLE
Fix Worms Armageddon one pixel garbage line under names and menu items

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -2288,8 +2288,8 @@ void _loadBGImage(const uObjScaleBg * _bgInfo, bool _loadScale)
 		gSP.bgImage.width = *REG.VI_WIDTH;
 		gSP.bgImage.height = (imageH * imageW) / gSP.bgImage.width;
 	} else {
-		gSP.bgImage.width = imageW - imageW%2;
-		gSP.bgImage.height = imageH - imageH%2;
+		gSP.bgImage.width = imageW & 0xFFFFFFFE;
+		gSP.bgImage.height = imageH - 1;
 	}
 	gSP.bgImage.format = _bgInfo->imageFmt;
 	gSP.bgImage.size = _bgInfo->imageSiz;


### PR DESCRIPTION
There is a one pixel garbage line under every menu item and under every worm name . If gSP.bgImage.height is imageH - 1 there is no garbage. I have tested this fix with multiple games and have not seen any regression.

I also replaced imageW modulo operation with & 0xFFFFFFFE.