### PR TITLE
gSPInsertMatrix: fix insert fractional part if old value is negativ

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -1593,13 +1593,13 @@ void gSPInsertMatrix( u32 where, u32 num )
 		if (where < 0x20) {
 			// integer elements of the matrix to be changed
 			const s16 integer = static_cast<s16>(pData[i ^ 1]);
-			const s32 fract = static_cast<s32>(gSP.matrix.combined[0][index + i] * 65536.0f);
-			gSP.matrix.combined[0][index + i] = GetFloatMatrixElement(integer, static_cast<u16>(fract&0xFFFF));
+			const u16 fract = GetIntMatrixElement(gSP.matrix.combined[0][index + i]).second;
+			gSP.matrix.combined[0][index + i] = GetFloatMatrixElement(integer, fract);
 		} else {
 			// fractional elements of the matrix to be changed
-			const s32 integer = static_cast<s32>(gSP.matrix.combined[0][index + i]);
+			const s16 integer = GetIntMatrixElement(gSP.matrix.combined[0][index + i]).first;
 			const u16 fract = pData[i ^ 1];
-			gSP.matrix.combined[0][index + i] = GetFloatMatrixElement(static_cast<s16>(integer), fract);
+			gSP.matrix.combined[0][index + i] = GetFloatMatrixElement(integer, fract);
 		}
 	}
 }


### PR DESCRIPTION
**Example:** Matrix value is -2.5f and new fraction is 0x44 

**Current implementation of change fractional part:**
s32 integer = static_cast<s32>(-2.5f) = -2
GetFloatMatrixElement(static_cast s16 (integer), 0x44) = -1,999

**Fix:**
s32 integer = (-2.5f * 65535.0f) >> 16 = (163837) >> 16 = GetIntMatrixElement(-2.5f).first =-3
GetFloatMatrixElement(static_cast s16 (integer), 0x44) = -2,999

Fixes https://github.com/gonetz/GLideN64/issues/1863.