### PR TITLE
rpi: limit m_maxCacheSize to fix texture corruption

### DIFF
--- a/src/Textures.h
+++ b/src/Textures.h
@@ -101,7 +101,7 @@ private:
 	s32 m_curUnpackAlignment;
 	bool m_toggleDumpTex;
 #ifdef VC
-	const size_t m_maxCacheSize = 3500;
+	const size_t m_maxCacheSize = 1500;
 #else
 	const size_t m_maxCacheSize = 8000;
 #endif


### PR DESCRIPTION
Limit m_maxCachSize to fix texture corruption in Yoshi’s Story. I have
tested values between 1500 and 3500. Everything >= 1800
produces texture corruption after a short time.