### PR TITLE
Fix Worms Armageddon

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -2072,8 +2072,9 @@ struct ObjCoordinates
 
 		ulx = frameX;
 		uly = frameY;
-		lrx = frameX + min(imageW/scaleW, frameW);
-		lry = frameY + min(imageH/scaleH, frameH);
+		// Lower right X position is 'X + widthX / scaleW - one_scaled_texelW'
+		lrx = frameX + min(imageW/scaleW, frameW) - 1.0f/scaleW;
+		lry = frameY + min(imageH/scaleH, frameH) - 1.0f/scaleH;
 
 		uls = imageX;
 		ult = imageY;


### PR DESCRIPTION
https://github.com/gonetz/GLideN64/commit/feb0e53034d54095464687dbae1785 causes glitches in Worms Armageddon. (https://github.com/gonetz/GLideN64/pull/1847)

This is a modification of https://github.com/gonetz/GLideN64/commit/feb0e53034d54095464687dbae17854c9dc3caa6 to fix Worms Armageddon. If upper left "ul" value is "zero" lower right "lr" value = "scaled width" - "one scaled texel".

**Example:**
Width = 10.0f, scale is 1.0f
urx = 0.0f;
lrx = 0.0f + 10.0f/1.0f - 1.0f/1.0f = 9.0f
Resulting range is 0-9 for a 10 texel width frame.