### PR TITLE
Background Textures: Fix cut off textures, texture fragments and seams

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1394,6 +1394,8 @@ void TextureCache::_updateBackground()
 		assert(currentTex.height == gSP.bgImage.height);
 		assert(currentTex.format == gSP.bgImage.format);
 		assert(currentTex.size == gSP.bgImage.size);
+		currentTex.clampS = gSP.bgImage.clampS;
+		currentTex.clampT = gSP.bgImage.clampT;
 
 		activateTexture(0, &currentTex);
 		m_hits++;
@@ -1419,8 +1421,8 @@ void TextureCache::_updateBackground()
 	pCurrent->maskT = 0;
 	pCurrent->mirrorS = 0;
 	pCurrent->mirrorT = 0;
-	pCurrent->clampS = 0;
-	pCurrent->clampT = 0;
+	pCurrent->clampS = gSP.bgImage.clampS;
+	pCurrent->clampT = gSP.bgImage.clampT;
 	pCurrent->line = 0;
 	pCurrent->tMem = 0;
 	pCurrent->frameBufferTexture = CachedTexture::fbNone;

--- a/src/gSP.h
+++ b/src/gSP.h
@@ -110,6 +110,7 @@ struct gSPInfo
 	{
 		u32 address, width, height, format, size, palette;
 		f32 imageX, imageY, scaleW, scaleH;
+		u8 clampS, clampT;
 	} bgImage;
 
 	u32 geometryMode;

--- a/src/uCodes/S2DEX.cpp
+++ b/src/uCodes/S2DEX.cpp
@@ -407,14 +407,14 @@ struct ObjCoordinates
 		lrs = uls + std::min(imageW, frameW * scaleW) - 1;
 		lrt = ult + std::min(imageH, frameH * scaleH) - 1;
 
+		gSP.bgImage.clampS = lrs <= (imageW - 1) ? 1 : 0 ;
+		gSP.bgImage.clampT = lrt <= (imageH - 1) ? 1 : 0 ;
+
 		// G_CYC_COPY (gSPBgRectCopy()) does not allow texture filtering
 		if (gDP.otherMode.cycleType != G_CYC_COPY) {
 			// Correct texture coordinates -0.5f and +0.5 if G_OBJRM_BILERP 
 			// bilinear interpolation is set
-			if ((gSP.objRendermode&G_OBJRM_BILERP) != 0 &&
-				((gDP.otherMode.textureFilter == G_TF_BILERP) ||											// Kirby Crystal Shards
-				(gDP.otherMode.textureFilter == G_TF_POINT && (gSP.objRendermode&G_OBJRM_NOTXCLAMP) != 0)) // Worms Armageddon
-				) {
+			if (gDP.otherMode.textureFilter == G_TF_BILERP) {
 				uls -= 0.5f;
 				ult -= 0.5f;
 				lrs += 0.5f;
@@ -443,7 +443,8 @@ struct ObjCoordinates
 		uly = frameY;
 		lrx = ulx + (lrs - uls) / scaleW;
 		lry = uly + (lrt - ult) / scaleH;
-		if ((gSP.objRendermode&G_OBJRM_BILERP) == 0) {
+		if (((gSP.objRendermode&G_OBJRM_BILERP) == 0 && gDP.otherMode.textureFilter != G_TF_BILERP) ||
+			((gSP.objRendermode&G_OBJRM_BILERP) != 0 && gDP.otherMode.textureFilter == G_TF_POINT && (gSP.objRendermode&G_OBJRM_NOTXCLAMP) != 0)) {
 			lrx += 1.0f / scaleW;
 			lry += 1.0f / scaleH;
 		}


### PR DESCRIPTION
- Fix cut off textures in hamster64 and RE2. Enable coord correction if
gDP.otherMode.textureFilter == G_TF_BILERP.
- Fix seams in hamster64 and texture fragments in starcraft64. Enable
texture clamp if lrs/lrt <= (imageW/imageH - 1).

![___________64-033](https://user-images.githubusercontent.com/6412699/46758003-00959d80-cccc-11e8-9521-d996fd3343cc.png)
![___________64-035](https://user-images.githubusercontent.com/6412699/46757898-c4623d00-cccb-11e8-9189-defdba73f36c.png)
Claire is not cut off in the middle:
![resident_evil_ii-005](https://user-images.githubusercontent.com/6412699/46757915-ccba7800-cccb-11e8-9147-4a408e64fb28.png)
![starcraft_64-019](https://user-images.githubusercontent.com/6412699/46757929-d5ab4980-cccb-11e8-9261-78a0de271e3c.png)
![starcraft_64-018](https://user-images.githubusercontent.com/6412699/46757974-f07dbe00-cccb-11e8-8a77-4d3679d04c0f.png)

Highres has no seams (texture borders do not look so good):
![___________64-032](https://user-images.githubusercontent.com/6412699/46758026-0d19f600-cccc-11e8-8c41-7319cd83079c.png)
![starcraft_64-014](https://user-images.githubusercontent.com/6412699/46758073-28850100-cccc-11e8-9330-c2d904d40a39.png)
![resident_evil_ii-002](https://user-images.githubusercontent.com/6412699/46758080-3044a580-cccc-11e8-9d9b-ae1b70a9d42f.png)


