### PR TITLE
Fix black and violet outlines around transparent textures

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -1016,15 +1016,30 @@ public:
 					shaderPart +=
 						"#define TEX_OFFSET(off, tex, texCoord) texture(tex, texCoord - (off)/texSize)									\n"
 						"#define TEX_FILTER(name, tex, texCoord)												\\\n"
-						"  {																					\\\n"
+						"{																						\\\n"
 						"  mediump vec2 texSize = vec2(textureSize(tex,0));										\\\n"
 						"  mediump vec2 offset = fract(texCoord*texSize - vec2(0.5));							\\\n"
 						"  offset -= step(1.0, offset.x + offset.y);											\\\n"
 						"  lowp vec4 c0 = TEX_OFFSET(offset, tex, texCoord);									\\\n"
 						"  lowp vec4 c1 = TEX_OFFSET(vec2(offset.x - sign(offset.x), offset.y), tex, texCoord);	\\\n"
 						"  lowp vec4 c2 = TEX_OFFSET(vec2(offset.x, offset.y - sign(offset.y)), tex, texCoord);	\\\n"
+						"																						\\\n"
+						"  bool multiplyAlpha = uEnableAlphaTest == 1 || uCvgXAlpha == 1;						\\\n"
+						"  if(multiplyAlpha){																	\\\n" // Calculate premultiplied color values
+						"    c0.rgb = c0.rgb * vec3(c0.a);														\\\n"
+						"    c1.rgb = c1.rgb * vec3(c1.a);														\\\n"
+						"    c2.rgb = c2.rgb * vec3(c2.a);														\\\n"
+						"  }																					\\\n"
+						"																						\\\n"
 						"  name = c0 + abs(offset.x)*(c1-c0) + abs(offset.y)*(c2-c0); 							\\\n"
-						"  }																					\n"
+						"																						\\\n"
+						"  name.rgb = multiplyAlpha ? name.rgb / vec3(name.a) : name.rgb;						\\\n" // Divide alpha to get actual color value
+						"  if(name.a != 0.0 && name.a != 1.0){													\\\n" // Smooth alpha only if name.a is between 0.0 and 1.0
+						"    float alphaClampValue = multiplyAlpha ? 0.5 : 0.2;									\\\n" // 0.5 smooths kirby64 and zelda, 0.2 smooths CBFD and zelda text a little bit
+						"    name.a = clamp((name.a - alphaClampValue) / (1.0 - alphaClampValue), 0.0, 1.0 );	\\\n"
+						"    name.a = name.a * name.a * ( 3.0 - 2.0 * name.a );									\\\n" // actual smoothstep function
+						"  }																					\\\n"
+						"}																						\n"
 						;
 				} else {
 					shaderPart +=
@@ -1042,10 +1057,25 @@ public:
 						"  lowp vec4 p0q1 = TEX_OFFSET(vec2(offset.x, offset.y - sign(offset.y)), tex, texCoord);						\\\n"
 						"  lowp vec4 p1q1 = TEX_OFFSET(vec2(offset.x - sign(offset.x), offset.y - sign(offset.y)), tex, texCoord);		\\\n"
 						"																												\\\n"
+						"  bool multiplyAlpha = uEnableAlphaTest == 1 || uCvgXAlpha == 1;												\\\n"
+						"  if(multiplyAlpha){																							\\\n" // Calculate premultiplied color values
+						"    p0q0.rgb = p0q0.rgb * vec3(p0q0.a);																		\\\n"
+						"    p1q0.rgb = p1q0.rgb * vec3(p1q0.a);																		\\\n"
+						"    p0q1.rgb = p0q1.rgb * vec3(p0q1.a);																		\\\n"
+						"    p1q1.rgb = p1q1.rgb * vec3(p1q1.a);																		\\\n"
+						"  }																											\\\n"
+						"																												\\\n"
 						"  mediump vec2 interpolationFactor = abs(offset);																\\\n"
 						"  lowp vec4 pInterp_q0 = mix( p0q0, p1q0, interpolationFactor.x ); 											\\\n" // Interpolates top row in X direction.
 						"  lowp vec4 pInterp_q1 = mix( p0q1, p1q1, interpolationFactor.x ); 											\\\n" // Interpolates bottom row in X direction.
 						"  name = mix( pInterp_q0, pInterp_q1, interpolationFactor.y ); 												\\\n" // Interpolate in Y direction.
+						"																												\\\n"
+						"  name.rgb = multiplyAlpha ? name.rgb / vec3(name.a) : name.rgb;												\\\n" // Divide alpha to get actual color value
+						"  if(name.a != 0.0 && name.a != 1.0){																			\\\n" // Smooth alpha only if name.a is between 0.0 and 1.0
+						"    float alphaClampValue = multiplyAlpha ? 0.5 : 0.2;															\\\n" // 0.5 smooths kirby64, 0.2 smooths CBFD and zelda text a little bit
+						"    name.a = clamp((name.a - alphaClampValue) / (1.0 - alphaClampValue), 0.0, 1.0 );							\\\n"
+						"    name.a = name.a * name.a * ( 3.0 - 2.0 * name.a );															\\\n" // actual smoothstep function
+						"  }																											\\\n"
 						"}																												\n"
 						;
 				}


### PR DESCRIPTION
Use premultiplied alpha color values to remove outlines around
transparent textures if uEnableAlphaTest or uCvgXAlpha is used.

Games which look better:
-Mario Kart 64 trees
-Quest64
-Body Harvest
-Puyo Puyon Party
-Kirby64

https://github.com/gonetz/GLideN64/issues/1898