### PR TITLE
Fix performance with radeonsi.

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithBufferStorage.cpp
@@ -31,7 +31,7 @@ void ColorBufferReaderWithBufferStorage::_initBuffers()
 	for (u32 index = 0; index < m_numPBO; ++index) {
 		m_bindBuffer->bind(Parameter(GL_PIXEL_PACK_BUFFER), ObjectHandle(m_PBO[index]));
 		m_fence[index] = 0;
-		glBufferStorage(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, nullptr, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
+		glBufferStorage(GL_PIXEL_PACK_BUFFER, m_pTexture->textureBytes, nullptr, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT | GL_CLIENT_STORAGE_BIT);
 		m_PBOData[index] = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, m_pTexture->textureBytes, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
 	}
 


### PR DESCRIPTION
This takes `Donkey Kong 64` from 12 fps to full speed with framebuffer emulation enabled.

I recently upgraded my Nvidia GTX 780 Ti card to an AMD RX Vega 56 and while everything was much faster, GLideN64 became far slower with most games. After a lot of help from #radeon @ freenode I found the bottleneck with perf.
```
    67.80%  libc-2.28.so                   [.] __memcpy_ssse3
     5.33%  [kernel]                       [k] deactivate_slab.isra.69
     3.75%  [processor]                    [k] init_module
     3.25%  [amdgpu]                       [k] amdgpu_mm_rreg
     0.65%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f6e
     0.53%  [kernel]                       [k] apic_timer_interrupt
     0.46%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f61
     0.38%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f6b
     0.37%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f76
     0.32%  [kernel]                       [k] native_load_gs_index
     0.29%  [kernel]                       [k] __switch_to
     0.27%  mupen64plus-video-GLideN64.so  [.] ColorBufferToRDRAM::_RGBAtoRGBA16
     0.27%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f5d
     0.23%  [kernel]                       [k] _raw_spin_lock_irqsave
     0.22%  [kernel]                       [k] _raw_spin_lock
     0.22%  mupen64plus-video-GLideN64.so  [.] ColorBufferToRDRAM::_copy
     0.20%  [kernel]                       [k] __x86_indirect_thunk_rax
     0.20%  [kernel]                       [k] check_preemption_disabled
     0.20%  [kernel]                       [k] __sched_text_start
     0.18%  [kernel]                       [k] read_tsc
     0.17%  mupen64plus-video-GLideN64.so  [.] FrameBuffer::isValid
     0.16%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f54
     0.16%  [kernel]                       [k] entry_SYSCALL_64
     0.14%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f64
     0.14%  [kernel]                       [k] ___slab_alloc.constprop.82
     0.13%  [kernel]                       [k] native_sched_clock
     0.13%  [kernel]                       [k] menu_select
     0.13%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f72
     0.13%  [kernel]                       [k] preempt_count_add
     0.13%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f45
     0.12%  mupen64plus-video-GLideN64.so  [.] CRC_Calculate
     0.12%  libspeexdsp.so.1.5.0           [.] 0x0000000000009f2b
```
More specifically its this single `memcpy`.

https://github.com/gonetz/GLideN64/blob/f7a4cf0c7532c27f73106ce3a9f33841ae0af68f/src/Graphics/ColorBufferReader.cpp#L55

The committed change was suggested which takes GLideN64 back to full speed on my system.

My very basic understanding is that without this its reading that memcpy with VRAM which is very slow and that there is no reason to not add this.