### PR TITLE
[INI] Add custom settings for Mario Artist games

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -75,6 +75,20 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Mahjong Master (J)
 frameBufferEmulation\N64DepthCompare=1
 
+[DMPJ]
+Good_Name=Mario Artist Paint Studio (J)
+frameBufferEmulation\nativeResFactor=1
+frameBufferEmulation\copyAuxToRDRAM=1
+frameBufferEmulation\copyFromRDRAM=1
+
+[DMGJ]
+Good_Name=Mario Artist Polygon Studio (J)
+frameBufferEmulation\copyAuxToRDRAM=1
+
+[DMTJ]
+Good_Name=Mario Artist Talent Studio (J)
+frameBufferEmulation\copyAuxToRDRAM=1
+
 [MARIOGOLF64]
 Good_Name=Mario Golf (E)(J)(U)
 frameBufferEmulation\copyDepthToRDRAM=0


### PR DESCRIPTION
Not perfect but makes them working as best as possible.

Only works with Project64 because of how game names are handled, they don't have the same kind of header at all, so Project64 forges them instead for retrocompatibility reasons.