### PR TITLE
Use bool value for 3-Point or bilinear filtering selection again

### DIFF
--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -57,7 +57,7 @@ bool Config_SetDefault()
 	assert(res == M64ERR_SUCCESS);
 
 	//#Texture Settings
-	res = ConfigSetDefaultInt(g_configVideoGliden64, "bilinearMode", config.texture.bilinearMode, "Bilinear filtering mode (0=N64 3point, 1=standard)");
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "bilinearMode", config.texture.bilinearMode, "Bilinear filtering mode (0=N64 3point, 1=standard)");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "enableHalosRemoval", config.texture.enableHalosRemoval, "Remove halos around filtered textures.");
 	assert(res == M64ERR_SUCCESS);
@@ -369,7 +369,7 @@ void Config_LoadConfig()
 	config.frameBufferEmulation.nativeResFactor = ConfigGetParamInt(g_configVideoGliden64, "UseNativeResolutionFactor");
 
 	//#Texture Settings
-	config.texture.bilinearMode = ConfigGetParamInt(g_configVideoGliden64, "bilinearMode");
+	config.texture.bilinearMode = ConfigGetParamBool(g_configVideoGliden64, "bilinearMode");
 	config.texture.maxAnisotropy = ConfigGetParamInt(g_configVideoGliden64, "MaxAnisotropy");
 	config.texture.enableHalosRemoval = ConfigGetParamBool(g_configVideoGliden64, "enableHalosRemoval");
 	//#Emulation Settings


### PR DESCRIPTION
With the new enableHalosRemoval option we only need to select bilinear
filtering or 3-point filtering with a bool value.

Reverts https://github.com/gonetz/GLideN64/commit/164b1056b3b5446824e419a7721a5c
4e455f28c6 partly.