### PR TITLE
Fix issues with threaded OpenGL when debug is enabled

### DIFF
--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_WrappedFunctions.h
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_WrappedFunctions.h
@@ -4750,7 +4750,7 @@ class ShutdownCommand : public OpenGlCommand
 {
 public:
 	ShutdownCommand() :
-		OpenGlCommand(false, false, "Shutdown")
+		OpenGlCommand(false, false, "Shutdown", false)
 	{
 	}
 

--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.cpp
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.cpp
@@ -58,14 +58,22 @@ namespace opengl {
 
 	void FunctionWrapper::setThreadedMode(u32 _threaded)
 	{
+#ifdef GL_DEBUG
+		m_threaded_wrapper = true;
+		m_shutdown = false;
+#else
 		if (_threaded == 1) {
 			m_threaded_wrapper = true;
 			m_shutdown = false;
 			m_commandExecutionThread = std::thread(&FunctionWrapper::commandLoop);
-		} else {
+
+		}
+		else {
 			m_threaded_wrapper = false;
 			m_shutdown = true;
 		}
+#endif
+
 	}
 
 	void FunctionWrapper::wrBlendFunc(GLenum sfactor, GLenum dfactor)
@@ -1404,10 +1412,12 @@ namespace opengl {
 
 		m_shutdown = true;
 
+#ifndef GL_DEBUG
 		if (m_threaded_wrapper) {
 			m_condition.notify_all();
 			m_commandExecutionThread.join();
 		}
+#endif
 	}
 
 	void FunctionWrapper::windowsSwapBuffers()

--- a/src/Graphics/OpenGLContext/windows/WindowsWGL.cpp
+++ b/src/Graphics/OpenGLContext/windows/WindowsWGL.cpp
@@ -10,8 +10,6 @@ bool WindowsWGL::start()
 {
 	int pixelFormat;
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST1\n");
-
 	PIXELFORMATDESCRIPTOR pfd = {
 		sizeof(PIXELFORMATDESCRIPTOR),    // size of this pfd
 		1,                                // version number
@@ -32,70 +30,55 @@ bool WindowsWGL::start()
 		0,                                // reserved
 		0, 0, 0                           // layer masks ignored
 	};
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST2\n");
 
 	if (hWnd == NULL)
 		hWnd = GetActiveWindow();
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST3\n");
 	if ((hDC = GetDC(hWnd)) == NULL) {
 		MessageBox(hWnd, L"Error while getting a device context!", pluginNameW, MB_ICONERROR | MB_OK);
 		return false;
 	}
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST4\n");
 	if ((pixelFormat = ChoosePixelFormat(hDC, &pfd)) == 0) {
 		MessageBox(hWnd, L"Unable to find a suitable pixel format!", pluginNameW, MB_ICONERROR | MB_OK);
 		stop();
 		return false;
 	}
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST5\n");
 	if ((SetPixelFormat(hDC, pixelFormat, &pfd)) == FALSE) {
 		MessageBox(hWnd, L"Error while setting pixel format!", pluginNameW, MB_ICONERROR | MB_OK);
 		stop();
 		return false;
 	}
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST6\n");
 	if ((hRC = wglCreateContext(hDC)) == NULL) {
 		MessageBox(hWnd, L"Error while creating OpenGL context!", pluginNameW, MB_ICONERROR | MB_OK);
 		stop();
 		return false;
 	}
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST7\n");
 	if ((wglMakeCurrent(hDC, hRC)) == FALSE) {
 		MessageBox(hWnd, L"Error while making OpenGL context current!", pluginNameW, MB_ICONERROR | MB_OK);
 		stop();
 		return false;
 	}
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST7.1\n");
 	initGLFunctions();
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST7.2\n");
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST8\n");
 	PFNWGLGETEXTENSIONSSTRINGARBPROC wglGetExtensionsStringARB =
 		(PFNWGLGETEXTENSIONSSTRINGARBPROC)wglGetProcAddress("wglGetExtensionsStringARB");
 
-	LOG(LOG_APIFUNC, "WindowsWGL::start TEST9\n");
 	if (wglGetExtensionsStringARB != NULL) {
 		const char * wglextensions = wglGetExtensionsStringARB(hDC);
-		LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.1\n");
 
 		if (strstr(wglextensions, "WGL_ARB_create_context_profile") != nullptr) {
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.1.1\n");
 			PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribsARB =
 				(PFNWGLCREATECONTEXTATTRIBSARBPROC)wglGetProcAddress("wglCreateContextAttribsARB");
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.2\n");
 
 			GLint majorVersion = 0;
 			ptrGetIntegerv(GL_MAJOR_VERSION, &majorVersion);
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.3\n");
 			GLint minorVersion = 0;
 			ptrGetIntegerv(GL_MINOR_VERSION, &minorVersion);
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.4\n");
 
 			const int attribList[] =
 			{
@@ -106,21 +89,16 @@ bool WindowsWGL::start()
 			};
 
 			HGLRC coreHrc = wglCreateContextAttribsARB(hDC, 0, attribList);
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.5\n");
 			if (coreHrc != NULL) {
 				wglDeleteContext(hRC);
 				wglMakeCurrent(hDC, coreHrc);
 				hRC = coreHrc;
 			}
 		}
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.1.1\n");
 
 		if (strstr(wglextensions, "WGL_EXT_swap_control") != nullptr) {
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.6\n");
 			PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.7\n");
 			wglSwapIntervalEXT(config.video.verticalSync);
-			LOG(LOG_APIFUNC, "WindowsWGL::start TEST9.8\n");
 		}
 	}
 

--- a/src/common/CommonAPIImpl_common.cpp
+++ b/src/common/CommonAPIImpl_common.cpp
@@ -172,8 +172,12 @@ void PluginAPI::ProcessRDPList()
 
 void PluginAPI::RomClosed()
 {
-	LOG(LOG_APIFUNC, "RomClosed\n");
+	if (!m_bRomOpen)
+		return;
+
 	m_bRomOpen = false;
+
+	LOG(LOG_APIFUNC, "RomClosed\n");
 #ifdef RSPTHREAD
 	_callAPICommand(RomClosedCommand(
 					&m_rspThreadMtx,


### PR DESCRIPTION
This should fix https://github.com/gonetz/GLideN64/issues/2040 assuming that this was happening with GL_DEBUG enabled.

Also, protect against RomClosed being called more than once.