### PR TITLE
Fixes crashing in project 64 graphics plugin dialog with release build

### DIFF
--- a/projects/msvc/GLideNUI.vcxproj
+++ b/projects/msvc/GLideNUI.vcxproj
@@ -88,7 +88,7 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <Optimization>MaxSpeed</Optimization>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>qtpcre.lib;qtmain.lib;qwindows.lib;qico.lib;qtharfbuzzng.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;Qt5PlatformSupport.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
With at least MS visual studio 2017, the qt dialog crashes when built in release mode. I was able to track this down to "whole program optimization", so I disabled that and doesn't crash any more.