### PR TITLE
M64P_GL_SWAP_CONTROL (and others?) requires a context, so needs to be…

### DIFF
--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -78,7 +78,6 @@ bool DisplayWindowMupen64plus::_start()
 	FunctionWrapper::setThreadedMode(config.video.threadedVideo);
 
 	FunctionWrapper::CoreVideo_Init();
-	_setAttributes();
 
 	m_bFullscreen = config.video.fullscreen > 0;
 	m_screenWidth = config.video.windowedWidth;
@@ -96,6 +95,8 @@ bool DisplayWindowMupen64plus::_start()
 	}
 	LOG(LOG_VERBOSE, "[gles2GlideN64]: Create setting videomode %dx%d", m_screenWidth, m_screenHeight);
 
+	_setAttributes();
+	
 	char caption[128];
 # ifdef _DEBUG
 	sprintf(caption, "%s debug. Revision %s", pluginName, PLUGIN_REVISION);


### PR DESCRIPTION
… after CoreVideo_SetVideoMode (which gets one)

Otherwise the plugin effectively ignores the VerticalSync mupen64plus option - it's always on.

I don't know if there's any consequences of setting these other attributes after this point, but it seems to run fine in my testing.