### PR TITLE
Don't crash on failed initialization

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -81,9 +81,12 @@ void ColorBufferToRDRAM::_initFBTexture(void)
 	m_pTexture->height = VI_GetMaxBufferHeight(m_lastBufferWidth);
 	m_pTexture->textureBytes = m_pTexture->width * m_pTexture->height * fbTexFormat.colorFormatBytes;
 
+    TextureTargetParam target = Context::EglImage ? textureTarget::TEXTURE_EXTERNAL : textureTarget::TEXTURE_2D;
+
 	{
 		Context::InitTextureParams params;
 		params.handle = m_pTexture->name;
+		params.target = target;
 		params.width = m_pTexture->width;
 		params.height = m_pTexture->height;
 		params.internalFormat = fbTexFormat.colorInternalFormat;
@@ -94,7 +97,7 @@ void ColorBufferToRDRAM::_initFBTexture(void)
 	{
 		Context::TexParameters params;
 		params.handle = m_pTexture->name;
-		params.target = textureTarget::TEXTURE_2D;
+		params.target = target;
 		params.textureUnitIndex = textureIndices::Tex[0];
 		params.minFilter = textureParameters::FILTER_LINEAR;
 		params.magFilter = textureParameters::FILTER_LINEAR;
@@ -105,7 +108,7 @@ void ColorBufferToRDRAM::_initFBTexture(void)
 		bufTarget.bufferHandle = ObjectHandle(m_FBO);
 		bufTarget.bufferTarget = bufferTarget::DRAW_FRAMEBUFFER;
 		bufTarget.attachment = bufferAttachment::COLOR_ATTACHMENT0;
-		bufTarget.textureTarget = textureTarget::TEXTURE_2D;
+		bufTarget.textureTarget = target;
 		bufTarget.textureHandle = m_pTexture->name;
 		gfxContext.addFrameBufferRenderTarget(bufTarget);
 	}

--- a/src/DisplayWindow.cpp
+++ b/src/DisplayWindow.cpp
@@ -8,15 +8,18 @@
 #include "PluginAPI.h"
 #include "FrameBuffer.h"
 
-void DisplayWindow::start()
+bool DisplayWindow::start()
 {
-	_start(); // TODO: process initialization error
+	if (!_start())
+		return false;
 
 	graphics::ObjectHandle::defaultFramebuffer = _getDefaultFramebuffer();
 
 	gfxContext.init();
 	m_drawer._initData();
 	m_buffersSwapCount = 0;
+
+	return true;
 }
 
 void DisplayWindow::stop()
@@ -113,7 +116,8 @@ bool DisplayWindow::resizeWindow()
 		return false;
 	m_drawer._destroyData();
 	if (!_resizeWindow())
-		_start();
+		if(!_start())
+			return false;
 	updateScale();
 	m_drawer._initData();
 	m_bResizeWindow = false;

--- a/src/DisplayWindow.h
+++ b/src/DisplayWindow.h
@@ -7,7 +7,7 @@ class DisplayWindow
 public:
 	virtual ~DisplayWindow() {}
 
-	void start();
+	bool start();
 	void stop();
 	void restart();
 	void swapBuffers();

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -15,6 +15,7 @@ bool Context::IntegerTextures = false;
 bool Context::ClipControl = false;
 bool Context::FramebufferFetch = false;
 bool Context::TextureBarrier = false;
+bool Context::EglImage = false;
 
 Context::Context() {}
 
@@ -38,6 +39,7 @@ void Context::init()
 	ClipControl = m_impl->isSupported(SpecialFeatures::ClipControl);
 	FramebufferFetch = m_impl->isSupported(SpecialFeatures::FramebufferFetch);
 	TextureBarrier = m_impl->isSupported(SpecialFeatures::TextureBarrier);
+	EglImage = m_impl->isSupported(SpecialFeatures::EglImage);
 }
 
 void Context::destroy()

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -25,7 +25,8 @@ namespace graphics {
 		IntegerTextures,
 		ClipControl,
 		FramebufferFetch,
-		TextureBarrier
+		TextureBarrier,
+		EglImage
 	};
 
 	enum class ClampMode {
@@ -84,6 +85,7 @@ namespace graphics {
 		struct InitTextureParams {
 			ObjectHandle handle;
 			TextureUnitParam textureUnitIndex{0};
+			TextureTargetParam target = textureTarget::TEXTURE_2D;
 			u32 msaaLevel = 0;
 			u32 width = 0;
 			u32 height = 0;
@@ -291,6 +293,7 @@ namespace graphics {
 		static bool ClipControl;
 		static bool FramebufferFetch;
 		static bool TextureBarrier;
+		static bool EglImage;
 
 	private:
 		std::unique_ptr<ContextImpl> m_impl;

--- a/src/Graphics/OpenGLContext/GLFunctions.h
+++ b/src/Graphics/OpenGLContext/GLFunctions.h
@@ -328,6 +328,8 @@ void initGLFunctions();
 #define glDisablei(...) opengl::FunctionWrapper::wrDisablei(__VA_ARGS__)
 #define glEGLImageTargetTexture2DOES(...) opengl::FunctionWrapper::wrEGLImageTargetTexture2DOES(__VA_ARGS__)
 
+#define GL_TEXTURE_EXTERNAL_OES 0x8D65
+
 #include "Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.h"
 
 #endif // GLFUNCTIONS_H

--- a/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.cpp
+++ b/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.cpp
@@ -42,12 +42,12 @@ bool GraphicBufferWrapper::isPublicSupportAvailable() {
 	return apiLevel >= 26;
 }
 
-void GraphicBufferWrapper::allocate(const AHardwareBuffer_Desc *desc) {
+bool GraphicBufferWrapper::allocate(const AHardwareBuffer_Desc *desc) {
 
 	if (m_private) {
-		m_privateGraphicBuffer->reallocate(desc->width, desc->height, desc->format, desc->usage);
+		return m_privateGraphicBuffer->reallocate(desc->width, desc->height, desc->format, desc->usage);
 	} else {
-		AndroidHardwareBufferCompat::GetInstance().Allocate(desc, &m_publicGraphicBuffer);
+		return AndroidHardwareBufferCompat::GetInstance().Allocate(desc, &m_publicGraphicBuffer) == 0;
 	}
 }
 

--- a/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.h
+++ b/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.h
@@ -23,7 +23,7 @@ public:
 
     static bool isPublicSupportAvailable();
 
-	void allocate(const AHardwareBuffer_Desc* desc);
+	bool allocate(const AHardwareBuffer_Desc* desc);
 	int lock(uint64_t usage, void** out_virtual_address);
 	void release();
 	void unlock();

--- a/src/Graphics/OpenGLContext/GraphicBuffer/PublicApi/android_hardware_buffer_compat.cpp
+++ b/src/Graphics/OpenGLContext/GraphicBuffer/PublicApi/android_hardware_buffer_compat.cpp
@@ -80,10 +80,10 @@ AndroidHardwareBufferCompat &AndroidHardwareBufferCompat::GetInstance() {
     return compat;
 }
 
-void AndroidHardwareBufferCompat::Allocate(const AHardwareBuffer_Desc *desc,
+int AndroidHardwareBufferCompat::Allocate(const AHardwareBuffer_Desc *desc,
                                            AHardwareBuffer **out_buffer) {
     DCHECK(IsSupportAvailable());
-    allocate_(desc, out_buffer);
+    return allocate_(desc, out_buffer);
 }
 
 void AndroidHardwareBufferCompat::Acquire(AHardwareBuffer *buffer) {

--- a/src/Graphics/OpenGLContext/GraphicBuffer/PublicApi/android_hardware_buffer_compat.h
+++ b/src/Graphics/OpenGLContext/GraphicBuffer/PublicApi/android_hardware_buffer_compat.h
@@ -8,7 +8,7 @@
 #include "dcheck.h"
 
 extern "C" {
-using PFAHardwareBuffer_allocate = void (*)(const AHardwareBuffer_Desc *desc,
+using PFAHardwareBuffer_allocate = int (*)(const AHardwareBuffer_Desc *desc,
 											AHardwareBuffer **outBuffer) ;
 using PFAHardwareBuffer_acquire = void (*)(AHardwareBuffer *buffer) ;
 using PFAHardwareBuffer_describe = void (*)(const AHardwareBuffer *buffer,
@@ -41,7 +41,7 @@ public:
 	static bool IsSupportAvailable();
 	static AndroidHardwareBufferCompat& GetInstance();
 
-	void Allocate(const AHardwareBuffer_Desc* desc, AHardwareBuffer** outBuffer);
+	int Allocate(const AHardwareBuffer_Desc* desc, AHardwareBuffer** outBuffer);
 	void Acquire(AHardwareBuffer* buffer);
 	void Describe(const AHardwareBuffer* buffer, AHardwareBuffer_Desc* outDesc);
 	int Lock(AHardwareBuffer* buffer,

--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -75,8 +75,6 @@ void DisplayWindowMupen64plus::_setAttributes()
 
 bool DisplayWindowMupen64plus::_start()
 {
-	FunctionWrapper::setThreadedMode(config.video.threadedVideo);
-
 #ifdef EGL
 	// Normally this is initialized externally through VidExt, but if VidExt is not implemented,
 	// do this here anyways. Calling eglInitialize has no negative effect according to the spec
@@ -92,6 +90,7 @@ bool DisplayWindowMupen64plus::_start()
 	}
 #endif
 
+	FunctionWrapper::setThreadedMode(config.video.threadedVideo);
 	FunctionWrapper::CoreVideo_Init();
 	_setAttributes();
 

--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -75,21 +75,6 @@ void DisplayWindowMupen64plus::_setAttributes()
 
 bool DisplayWindowMupen64plus::_start()
 {
-#ifdef EGL
-	// Normally this is initialized externally through VidExt, but if VidExt is not implemented,
-	// do this here anyways. Calling eglInitialize has no negative effect according to the spec
-
-	EGLDisplay display;
-	if ((display = eglGetDisplay(EGL_DEFAULT_DISPLAY)) == EGL_NO_DISPLAY) {
-		LOG(LOG_ERROR, "eglGetDisplay() returned error %d", eglGetError());
-		return false;
-	}
-	if (!eglInitialize(display, nullptr, nullptr)) {
-		LOG(LOG_ERROR, "eglInitialize() returned error %d", eglGetError());
-		return false;
-	}
-#endif
-
 	FunctionWrapper::setThreadedMode(config.video.threadedVideo);
 	FunctionWrapper::CoreVideo_Init();
 	_setAttributes();

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -11,7 +11,7 @@ ColorBufferReaderWithEGLImage::ColorBufferReaderWithEGLImage(CachedTexture *_pTe
 	: graphics::ColorBufferReader(_pTexture)
 	, m_bindTexture(_bindTexture)
 	, m_image(nullptr)
-	, m_usage(AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN)
+	, m_usage(AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN|AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE)
 	, m_bufferLocked(false)
 {
 	_initBuffers();
@@ -48,11 +48,10 @@ const u8 * ColorBufferReaderWithEGLImage::_readPixels(const ReadColorBufferParam
 	void* gpuData = nullptr;
 
 	if (!_params.sync) {
-		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_2D), m_pTexture->name);
-		glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_image);
-		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_2D), ObjectHandle());
-
-		m_hardwareBuffer.lock(m_usage, &gpuData);
+		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_EXTERNAL_OES), m_pTexture->name);
+		glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, m_image);
+		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_EXTERNAL_OES), ObjectHandle());
+		m_hardwareBuffer.lock(AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, &gpuData);
 		m_bufferLocked = true;
 		_heightOffset = static_cast<u32>(_params.y0);
 		_stride = m_pTexture->width;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -499,6 +499,8 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return m_glInfo.ext_fetch;
 	case graphics::SpecialFeatures::TextureBarrier:
 		return m_glInfo.texture_barrier || m_glInfo.texture_barrierNV;
+	case graphics::SpecialFeatures::EglImage:
+		return m_glInfo.eglImage;
 	}
 	return false;
 }

--- a/src/Graphics/OpenGLContext/opengl_Parameters.cpp
+++ b/src/Graphics/OpenGLContext/opengl_Parameters.cpp
@@ -40,6 +40,7 @@ namespace graphics {
 		TextureTargetParam TEXTURE_2D(GL_TEXTURE_2D);
 		TextureTargetParam TEXTURE_2D_MULTISAMPLE(GL_TEXTURE_2D_MULTISAMPLE);
 		TextureTargetParam RENDERBUFFER(GL_RENDERBUFFER);
+		TextureTargetParam TEXTURE_EXTERNAL(GL_TEXTURE_EXTERNAL_OES);
 	}
 
 	namespace bufferTarget {

--- a/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_TextureManipulationObjectFactory.cpp
@@ -58,8 +58,8 @@ namespace opengl {
 		void init2DTexture(const graphics::Context::InitTextureParams & _params) override
 		{
 			if (_params.msaaLevel == 0) {
-				m_bind->bind(_params.textureUnitIndex, graphics::textureTarget::TEXTURE_2D, _params.handle);
-				glTexImage2D(GL_TEXTURE_2D,
+				m_bind->bind(_params.textureUnitIndex, _params.target, _params.handle);
+				glTexImage2D(GLuint(_params.target),
 							 _params.mipMapLevel,
 							 GLuint(_params.internalFormat),
 							 _params.width,
@@ -104,10 +104,10 @@ namespace opengl {
 		void init2DTexture(const graphics::Context::InitTextureParams & _params) override
 		{
 			if (_params.msaaLevel == 0) {
-				m_bind->bind(_params.textureUnitIndex, graphics::textureTarget::TEXTURE_2D, _params.handle);
+				m_bind->bind(_params.textureUnitIndex, _params.target, _params.handle);
 				if (m_handle != _params.handle) {
 					m_handle = _params.handle;
-					glTexStorage2D(GL_TEXTURE_2D,
+					glTexStorage2D(GLuint(_params.target),
 								   _params.mipMapLevels,
 								   GLenum(_params.internalFormat),
 								   _params.width,
@@ -115,7 +115,7 @@ namespace opengl {
 				}
 
 				if (_params.data != nullptr) {
-					glTexSubImage2D(GL_TEXTURE_2D,
+					glTexSubImage2D(GLuint(_params.target),
 						_params.mipMapLevel,
 						0, 0,
 						_params.width,

--- a/src/Graphics/Parameters.h
+++ b/src/Graphics/Parameters.h
@@ -40,6 +40,7 @@ namespace graphics {
 		extern TextureTargetParam TEXTURE_2D;
 		extern TextureTargetParam TEXTURE_2D_MULTISAMPLE;
 		extern TextureTargetParam RENDERBUFFER;
+		extern TextureTargetParam TEXTURE_EXTERNAL;
 	}
 
 	namespace bufferTarget {

--- a/src/MupenPlusPluginAPI.cpp
+++ b/src/MupenPlusPluginAPI.cpp
@@ -12,8 +12,7 @@ EXPORT int CALL RomOpen(void)
 	else
 		RDRAMSize = 0;
 
-	api().RomOpen();
-	return 1;
+	return api().RomOpen();
 }
 
 EXPORT m64p_error CALL PluginGetVersion(

--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -36,7 +36,7 @@ public:
 	void ProcessDList();
 	void ProcessRDPList();
 	void RomClosed();
-	void RomOpen();
+	int RomOpen();
 	void ShowCFB();
 	void UpdateScreen();
 	int InitiateGFX(const GFX_INFO & _gfxInfo);

--- a/src/common/CommonAPIImpl_common.cpp
+++ b/src/common/CommonAPIImpl_common.cpp
@@ -194,7 +194,7 @@ void PluginAPI::RomClosed()
 #endif
 }
 
-void PluginAPI::RomOpen()
+int PluginAPI::RomOpen()
 {
 	LOG(LOG_APIFUNC, "RomOpen");
 #ifdef RSPTHREAD
@@ -207,9 +207,12 @@ void PluginAPI::RomOpen()
 	RSP_Init();
 	GBI.init();
 	Config_LoadConfig();
-	dwnd().start();
+	if (!dwnd().start())
+		return 0;
 #endif
 	m_bRomOpen = true;
+
+	return 1;
 }
 
 void PluginAPI::ShowCFB()


### PR DESCRIPTION
This adds a configurable hack that should allow EGL to work on most platforms. This includes platforms that should have the mupen64plus VidExt API implemented, but don't.

Also, this fixes a crash when DisplayWindowMupen64plus::_start() fails.