### PR TITLE
Fix threaded OpenGL lockup when trying to remove invalid buffer

### DIFF
--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.cpp
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.cpp
@@ -139,10 +139,12 @@ const char* RingBufferPool::getBufferFromPool(PoolBufferPointer _poolBufferPoint
 
 void RingBufferPool::removeBufferFromPool(PoolBufferPointer _poolBufferPointer)
 {
-	std::unique_lock<std::mutex> lock(m_mutex);
-	m_inUseStartOffset = _poolBufferPointer.m_offset + _poolBufferPointer.m_realSize;
-	m_full = false;
-	m_condition.notify_one();
+	if (_poolBufferPointer.isValid()) {
+		std::unique_lock<std::mutex> lock(m_mutex);
+		m_inUseStartOffset = _poolBufferPointer.m_offset + _poolBufferPointer.m_realSize;
+		m_full = false;
+		m_condition.notify_one();
+	}
 }
 
 }


### PR DESCRIPTION
This should fix the lockup you are experiencing here:

https://github.com/gonetz/GLideN64/issues/2064

I don't know about that crash though since I can't recreate it.