### PR TITLE
[GLideNUI.vcxproj] Use $(DefaultQtVersion) to get qt version

### DIFF
--- a/projects/msvc/GLideNUI.vcxproj
+++ b/projects/msvc/GLideNUI.vcxproj
@@ -183,7 +183,7 @@ endlocal
   <ImportGroup Label="ExtensionTargets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties UicDir=".\GeneratedFiles" RccDir=".\GeneratedFiles" Qt5Version_x0020_Win32="qt-5_7_1-x86-msvc2015-static" />
+      <UserProperties UicDir=".\GeneratedFiles" RccDir=".\GeneratedFiles" Qt5Version_x0020_Win32="$(DefaultQtVersion)" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>


### PR DESCRIPTION
Fixes a problem in which the UI would fail to compile when the version was not found (qt-5_7_1-x86-msvc2015-static by default), and changing to the correct version through QT Project Settings would clear all the dependencies (possibly a bug in the Qt VS Tools addin). Changing from $(DefaultQtVersion) to any other version doesn't have this problem.