### PR TITLE
Kirby 64 and other ini fixes

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -160,6 +160,10 @@ Good_Name=Pokemon Stadium Kin Gin (J)
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
 
+[PUZZLE%20LEAGUE%20N64]
+Good_Name=Pokemon Puzzle League (E)(F)(G)(U)
+texture\enableHalosRemoval=1
+
 [ROCKMAN%20DASH]
 Good_Name=Rockman Dash - Hagane no Boukenshin (J)
 graphics2D\correctTexrectCoords=2

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -100,7 +100,7 @@ frameBufferEmulation\copyAuxToRDRAM=1
 
 [KIRBY64]
 Good_Name=Kirby 64 - The Crystal Shards (E)(J)(U)
-texture\enableHalosRemoval=1
+graphics2D\enableNativeResTexrects=1
 
 [MARIOGOLF64]
 Good_Name=Mario Golf (E)(J)(U)

--- a/ini/GLideN64.ini
+++ b/ini/GLideN64.ini
@@ -48,10 +48,3 @@ txSaveCache=1
 name=arial.ttf
 size=18
 color=@Variant(\0\0\0\x43\x1\xff\xff\xb5\xb5\xe6\xe6\x1d\x1d\0\0)
-
-[bloomFilter]
-enable=0
-thresholdLevel=4
-blendMode=0
-blurAmount=10
-blurStrength=20


### PR DESCRIPTION
The stars in space look wrong due to halos removal
![GLideN64_Kirby64_000](https://user-images.githubusercontent.com/7278372/68365256-6336b400-00ed-11ea-809f-0d8158b0ed7f.png)

I noticed native texrects removes the white outline around textures without causing other issues.
![GLideN64_Kirby64_001](https://user-images.githubusercontent.com/7278372/68365266-6a5dc200-00ed-11ea-841d-fef4afbd24b0.png)
![GLideN64_Kirby64_002](https://user-images.githubusercontent.com/7278372/68365292-76e21a80-00ed-11ea-88ee-b443a6fc2501.png)

Unlike Mario Golf, Kirby 64 is not a resource intensive game so performance hit in android should be minimal I assume.

Also: removed obsolete section in main ini.