### PR TITLE
Shaders cleanup

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -622,7 +622,7 @@ public:
 	ShaderSignExtendColorC()
 	{
 		m_part =
-			" color1 = WRAP(color1, -1.00, 1.01); \n"
+			" color1 = WRAP(color1, -1.01, 1.01); \n"
 			;
 	}
 };
@@ -633,7 +633,7 @@ public:
 	ShaderSignExtendAlphaC()
 	{
 		m_part =
-			" alpha1 = WRAP(alpha1, -1.00, 1.01); \n"
+			" alpha1 = WRAP(alpha1, -1.01, 1.01); \n"
 			;
 	}
 };
@@ -654,7 +654,7 @@ public:
 	ShaderSignExtendColorABD()
 	{
 		m_part =
-			" color1 = WRAP(color1, -0.50, 1.51); \n"
+			" color1 = WRAP(color1, -0.51, 1.51); \n"
 			;
 	}
 };
@@ -665,7 +665,7 @@ public:
 	ShaderSignExtendAlphaABD()
 	{
 		m_part =
-			"  alpha1 = WRAP(alpha1, -0.50,1.51); \n"
+			"  alpha1 = WRAP(alpha1, -0.51,1.51); \n"
 			;
 	}
 };

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -1251,22 +1251,22 @@ public:
 		m_part =
 			"void main() \n"
 			"{			 \n"
-		;
+			;
 		if (!_glinfo.isGLES2) {
 			m_part +=
 				"  highp float fragDepth = writeDepth();	\n"
-			;
+				;
 		}
 		m_part +=
 			"  lowp vec4 vec_color;				\n"
 			"  lowp float alpha1;				\n"
 			"  lowp vec3 color1, input_color;	\n"
-		;
+			;
 		m_part += "#define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low) \n"; // Return wrapped value of x in interval [low, high)
 		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * floor(((x)-(low))/((high)-(low)))  \n"; // Perhaps more compatible?
-		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * (ceil(((x)-(low))/((high)-(low))) - 1.0) \n"; // Return wrapped value of x in interval (low,high]
-
+		// m_part += "#define WRAP(x, low, high) (x) + ((high)-(low)) * (1.0-step(low,x)) - ((high)-(low)) * step(high,x) \n"; // Step based version. Only wraps correctly if input is in the range [low-(high-low), high + (high-low)). Similar to old code.
 	}
+
 };
 
 class ShaderFragmentMain2Cycle : public ShaderPart
@@ -1290,7 +1290,7 @@ public:
 		;
 		m_part += "#define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low) \n"; // Return wrapped value of x in interval [low, high)
 		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * floor(((x)-(low))/((high)-(low)))  \n"; // Perhaps more compatible?
-		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * (ceil(((x)-(low))/((high)-(low))) - 1.0) \n"; // Return wrapped value of x in interval (low,high]
+		// m_part += "#define WRAP(x, low, high) (x) + (2.0) * (1.0-step(low,x)) - (2.0) * step(high,x) \n"; // Step based version. Only wraps correctly if input is in the range [low-(high-low), high + (high-low)). Similar to old code.
 	}
 };
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -603,7 +603,7 @@ public:
 	ShaderClamp()
 	{
 		m_part =
-			"  lowp vec4 wrappedColor = cmbRes + 2.0 * step(cmbRes, vec4(-0.51)) - 2.0*step(vec4(1.51), cmbRes); \n"
+			"  lowp vec4 wrappedColor = WRAP(cmbRes, -0.51, 1.51); \n"
 			"  lowp vec4 clampedColor = clamp(wrappedColor, 0.0, 1.0); \n"
 			;
 	}
@@ -622,7 +622,7 @@ public:
 	ShaderSignExtendColorC()
 	{
 		m_part =
-			"  color1 = color1 - 2.0*(vec3(1.0) - step(color1, vec3(1.0)));	\n"
+			" color1 = WRAP(color1, -1.00, 1.01); \n"
 			;
 	}
 };
@@ -633,7 +633,7 @@ public:
 	ShaderSignExtendAlphaC()
 	{
 		m_part =
-			"  alpha1 = alpha1 - 2.0*(1.0 - step(alpha1, 1.0));					\n"
+			" alpha1 = WRAP(alpha1, -1.00, 1.01); \n"
 			;
 	}
 };
@@ -654,7 +654,7 @@ public:
 	ShaderSignExtendColorABD()
 	{
 		m_part =
-			"  color1 = color1 + 2.0*step(color1, vec3(-0.51)) - 2.0*step(vec3(1.51), color1); \n"
+			" color1 = WRAP(color1, -0.50, 1.51); \n"
 			;
 	}
 };
@@ -665,7 +665,7 @@ public:
 	ShaderSignExtendAlphaABD()
 	{
 		m_part =
-			"  alpha1 = alpha1 + 2.0*step(alpha1, -0.51) - 2.0*step(1.51, alpha1); \n"
+			"  alpha1 = WRAP(alpha1, -0.50,1.51); \n"
 			;
 	}
 };
@@ -1262,6 +1262,10 @@ public:
 			"  lowp float alpha1;				\n"
 			"  lowp vec3 color1, input_color;	\n"
 		;
+		m_part += "#define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low) \n"; // Return wrapped value of x in interval [low, high)
+		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * floor(((x)-(low))/((high)-(low)))  \n"; // Perhaps more compatible?
+		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * (ceil(((x)-(low))/((high)-(low))) - 1.0) \n"; // Return wrapped value of x in interval (low,high]
+
 	}
 };
 
@@ -1284,6 +1288,9 @@ public:
 			"  lowp float alpha1, alpha2;				\n"
 			"  lowp vec3 color1, color2, input_color;	\n"
 		;
+		m_part += "#define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low) \n"; // Return wrapped value of x in interval [low, high)
+		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * floor(((x)-(low))/((high)-(low)))  \n"; // Perhaps more compatible?
+		// m_part += "#define WRAP(x, low, high) (x) - ((high)-(low)) * (ceil(((x)-(low))/((high)-(low))) - 1.0) \n"; // Return wrapped value of x in interval (low,high]
 	}
 };
 


### PR DESCRIPTION
Cleanup combiner and blender shaders. It uses macros to make code neater, but the operations are almost the same. In theory, there should be no changes to image or performance.
I changed the problematic `equal` function for two `step` functions. If anyone can test if there are no problems on Mac would be great.

Do not merge. Cleanup needed.
I placed the `WRAP` function there because I didn't find an appropriate place. Any suggestions as to where it may go? 
Blender code looks almost as old code left as reference. Worth keeping it?