### PR TITLE
[appveyor] Add Zilmar-spec

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2017
+
 version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
@@ -5,28 +7,51 @@ branches:
   only:
   - master
 skip_branch_with_pr: true
-configuration: Release_mupenplus
-platform:
-  - win32
-  - x64
+
 environment:
-  N64PluginsDir: C:\projects\gliden64\build\zilmar-spec\
-  Mupen64PluginsDir: C:\projects\gliden64\build\mupen64plus\
-  Mupen64PluginsDir_x64: C:\projects\gliden64\build\mupen64plus_x64\
-build:
-  project: projects\msvc\GLideN64.sln
-  parallel: true
-  verbosity: normal
+  N64PluginsDir: C:\projects\gliden64\build\Zilmar-spec\
+  N64PluginsDir_x64: C:\projects\gliden64\build\Zilmar-spec_x64\
+  Mupen64PluginsDir: C:\projects\gliden64\build\Mupen64Plus\
+  Mupen64PluginsDir_x64: C:\projects\gliden64\build\Mupen64Plus_x64\
+  QTDIR_x86: C:\Static_Qt_x86
+  QTDIR_x64: C:\Static_Qt_x64
+  QT_BUILD_BASE_URL: https://github.com/tim241/GLideN64/releases/download/qt_build/
+  QT_BUILD_x86: qt-5_7_1-x86-msvc2017-static
+  QT_BUILD_x64: qt-5_7_1-x64-msvc2017-static
+
+before_build:
+  - curl -L -o %QT_BUILD_x86%.7z %QT_BUILD_BASE_URL%/%QT_BUILD_x86%.7z
+  - curl -L -o %QT_BUILD_x64%.7z %QT_BUILD_BASE_URL%/%QT_BUILD_x64%.7z
+  - 7z x -o%QTDIR_x86% %QT_BUILD_x86%.7z
+  - 7z x -o%QTDIR_x64% %QT_BUILD_x64%.7z
+
+build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - set QTDIR=%QTDIR_x64%\%QT_BUILD_x64%
+  - msbuild projects/msvc/GLideNUI.vcxproj /p:Configuration=Release;Platform=x64
+  - msbuild projects/msvc/GLideN64.sln /p:Configuration=Release;Platform=x64
+  - set QTDIR=%QTDIR_x86%\%QT_BUILD_x86%
+  - msbuild projects/msvc/GLideNUI.vcxproj /p:Configuration=Release;Platform=Win32
+  - msbuild projects/msvc/GLideN64.sln /p:Configuration=Release;Platform=Win32
+  - msbuild projects/msvc/GLideN64.sln /p:Configuration=Release_mupenplus;Platform=x64
+  - msbuild projects/msvc/GLideN64.sln /p:Configuration=Release_mupenplus;Platform=Win32
+
+after_build:
+  - copy ini\GLideN64.custom.ini %N64PluginsDir_x64%
+  - copy translations\*.* %N64PluginsDir_x64%
+  - copy ini\GLideN64.custom.ini %N64PluginsDir%
+  - copy translations\*.* %N64PluginsDir%
+  - copy ini\GLideN64.custom.ini %Mupen64PluginsDir_x64%\
+  - copy ini\GLideN64.custom.ini %Mupen64PluginsDir%\
+  - del /Q %N64PluginsDir_x64%\*.lib %N64PluginsDir_x64%\*.exp
+  - del /Q %N64PluginsDir%\*.lib %N64PluginsDir%\*.exp
+  - del /Q %Mupen64PluginsDir_x64%\*.lib %Mupen64PluginsDir_x64%\*.exp
+  - del /Q %Mupen64PluginsDir%\*.lib %Mupen64PluginsDir%\*.exp
+  - cd C:\projects\gliden64\build
+  - ps: $env:revision = git describe --always
+  - set archive_name=GLideN64-%revision%.7z
+  - 7z a %archive_name% *
+
 artifacts:
-- path: build\mupen64plus\mupen64plus-video-GLideN64.dll
-  name: mupen64plus-video-GLideN64.dll
-- path: build\mupen64plus_x64\mupen64plus-video-GLideN64.dll
-  name: mupen64plus-video-GLideN64.dll
-deploy:
-- provider: GitHub
-  release: GLideN64-mupen64plus-win32-v$(APPVEYOR_REPO_COMMIT)
-  description: Win32 release build of GLideN64 for mupen64plus, commit $(APPVEYOR_REPO_COMMIT)
-  auth_token:
-    secure: 5fZs6/e+QeeOs6CkKnyHULqkFyEIhK/aJ61IFtLoPYwTQDcb6nG8sqs5KA+XohP5
-  on:
-    DEPLOY_GITHUB: ON
+  - path: build\$(archive_name)
+    name: GLideN64


### PR DESCRIPTION
This is still WIP at the moment

personally I'd prefer to put the whole `build_script` stuff in a batch script and just call that from the `appveyor.yml`, I'm not sure what you'd prefer however.

Also are you fine with the packaging changes? This'll package it like the WIP builds you publish

also note the `QT_BUILD_BASE_URL` variable, I uploaded the static qt builds (vs2017 x86 & x64) to github releases because downloading files from google drive is kinda hard without an external tool(which also needs to be maintained), so if you'd like full control over the static qt builds I recommend you make a `qt_build` release with the static qt builds and just change the variable