### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,14 @@ GLideN64
 
 A new generation, open-source graphics plugin for N64 emulators.
 
-Find WIP builds [here](https://github.com/gonetz/GLideN64/issues/2037). WIP
-builds have the latest features and fixes, and are generally stable, but may
-introduce bugs and have incomplete translations.
-
-Continuous integration build history:
-* for mupen64plus for Windows:
-https://ci.appveyor.com/project/gonetz/gliden64/history
-* for mupen64plus for Linux and MacOsX:
-https://travis-ci.org/gonetz/GLideN64/builds
-
-To get CI builds for mupen64plus for Windows: open build history, select build, click to ARTIFACTS:
-you will get link to mupen64plus-video-GLideN64.dll
-
-Windows build status for master branch:
+Windows latest build status for master branch:
 [![Build status](https://ci.appveyor.com/api/projects/status/vx18fie77cgq23i8/branch/master?svg=true)](https://ci.appveyor.com/project/gonetz/gliden64/branch/master)
 
-Linux and MacOsX build status for master branch:
+Linux and MacOsX latest build status for master branch:
 [![Build Status](https://travis-ci.org/gonetz/GLideN64.svg?branch=master)](https://travis-ci.org/gonetz/GLideN64)
+
+To get Continuous Integration (CI) builds for mupen64plus and zilmar-spec emulators for Windows: click the build status icon, then select "Artifacts".
+You will get a zip containing both builds. Choose the between the 32-bit and 64-bit version depending on your emulator version.
+If you want to download an earlier build, go to "History" and select the build you want.
+
+CI builds have the latest features and fixes, and are generally stable, but may introduce bugs and have incomplete translations.


### PR DESCRIPTION
Updated description to reflect the changes in CI builds, with the recent addition of zilmar-spec builds. Remove reference to WIP build thread since it's been deprecated in favor of CI builds.