### PR TITLE
Threaded opengl improvement

### DIFF
--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.h
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.h
@@ -34,10 +34,17 @@ public:
 
 	explicit RingBufferPool(size_t _poolSize);
 
+	// Create a buffer pool. This method will block if there is not enough space until
+	// enough space has been freed from a seperate thread. If a buffer bigger than the
+	// maximum is allocated, then a run time exception will be thrown
 	PoolBufferPointer createPoolBuffer(const char* _buffer, size_t _bufferSize);
 
+	// Retrieves a buffer from the buffer pool, will return a nullptr if an invalid
+	// buffer is provided
 	const char* getBufferFromPool(PoolBufferPointer _poolBufferPointer);
 
+	// Removes the give buffer from the pool, no action will be taken if the provided
+	// buffer is not valid
 	void removeBufferFromPool(PoolBufferPointer _poolBufferPointer);
 
 private:
@@ -47,6 +54,8 @@ private:
 	std::mutex m_mutex;
 	std::atomic<bool> m_full;
 	std::condition_variable_any m_condition;
+	size_t m_maxBufferPoolSize;
+	static const size_t m_startBufferPoolSize = 1024 * 100;
 };
 
 }

--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Command.cpp
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Command.cpp
@@ -5,8 +5,8 @@
 
 namespace opengl {
 
-	// 15MB memory pool
-	RingBufferPool OpenGlCommand::m_ringBufferPool(1024 * 1024 * 15 );
+	// Max memory pool size
+	RingBufferPool OpenGlCommand::m_ringBufferPool(1024 * 1024 * 200 );
 
 	void OpenGlCommand::performCommandSingleThreaded()
 	{


### PR DESCRIPTION
Instead of dead locking if we try to allocate a buffer that is too big for the ring buffer pool, this will throw an exception instead.

Also, the ring buffer pool no longer has a set size, instead a maximum size is provided, and it will grow up to the maximum size as needed.