### PR TITLE
Use a different library name when building for Android

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,7 +164,11 @@ if(MUPENPLUSAPI)
 
   set(GLideN64_SOURCES_WIN ${GLideN64_SOURCES_UNIX}
   )
-  set(GLideN64_DLL_NAME mupen64plus-video-GLideN64)
+  if (ANDROID)
+      set(GLideN64_DLL_NAME libmupen64plus-video-GLideN64)
+  else()
+      set(GLideN64_DLL_NAME mupen64plus-video-GLideN64)
+  endif()
 else(MUPENPLUSAPI)
   if(UNIX)
     message(FATAL_ERROR "UNIX build requires MUPENPLUSAPI!")

--- a/src/getRevision.sh
+++ b/src/getRevision.sh
@@ -1,5 +1,12 @@
 SCRIPT_DIRECTORY=`dirname $0`
 rev=\"`git rev-parse --short HEAD`\"
+lastrev=$(head -n 1 $SCRIPT_DIRECTORY/Revision.h | awk -F'PLUGIN_REVISION ' {'print $2'})
+
 echo current revision $rev
-echo "#define PLUGIN_REVISION $rev" > $SCRIPT_DIRECTORY/Revision.h
-echo "#define PLUGIN_REVISION_W L$rev" >> $SCRIPT_DIRECTORY/Revision.h
+echo last build revision $lastrev
+
+if [ "$lastrev" != "$rev" ]
+then
+   echo "#define PLUGIN_REVISION $rev" > $SCRIPT_DIRECTORY/Revision.h
+   echo "#define PLUGIN_REVISION_W L$rev" >> $SCRIPT_DIRECTORY/Revision.h
+fi


### PR DESCRIPTION
Android works much more easily if a library starts with "lib".