### PR TITLE
Make the hybrid texture filter optional through configuration

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -43,6 +43,7 @@ void Config::resetToDefaults()
 	generalEmulation.enableCustomSettings = 1;
 	generalEmulation.enableShadersStorage = 1;
 	generalEmulation.enableLegacyBlending = 0;
+	generalEmulation.enableHybridFilter = 1;
 	generalEmulation.hacks = 0;
 #if defined(OS_ANDROID) || defined(OS_IOS)
 	generalEmulation.enableFragmentDepthWrite = 0;

--- a/src/Config.h
+++ b/src/Config.h
@@ -53,6 +53,7 @@ struct Config
 		u32 enableCustomSettings;
 		u32 enableShadersStorage;
 		u32 enableLegacyBlending;
+		u32 enableHybridFilter;
 		u32 enableFragmentDepthWrite;
 		u32 enableBlitScreenWorkaround;
 		u32 hacks;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -10,6 +10,7 @@
 #include <Graphics/ObjectHandle.h>
 #include <Graphics/ShaderProgram.h>
 #include <Graphics/OpenGLContext/opengl_CachedFunctions.h>
+#include <Config.h>
 #include "glsl_SpecialShadersFactory.h"
 #include "glsl_ShaderPart.h"
 #include "glsl_FXAA.h"
@@ -448,17 +449,7 @@ namespace glsl {
 	public:
 		TexrectCopy(const opengl::GLInfo & _glinfo)
 		{
-			if (_glinfo.isGLES2) {
-				m_part =
-					"IN mediump vec2 vTexCoord0;							\n"
-					"uniform sampler2D uTex0;								\n"
-					"OUT lowp vec4 fragColor;								\n"
-					"														\n"
-					"void main()											\n"
-					"{														\n"
-					"	fragColor = texture2D(uTex0, vTexCoord0);			\n"
-					;
-			} else {
+			if (config.generalEmulation.enableHybridFilter) {
 				m_part = getHybridTextureFilter();
 				m_part +=
 					"IN mediump vec2 vTexCoord0;				\n"
@@ -467,6 +458,16 @@ namespace glsl {
 					"void main()								\n"
 					"{											\n"
 					"	fragColor = hybridFilter(vTexCoord0);	\n"
+					;
+			} else {
+				m_part =
+					"IN mediump vec2 vTexCoord0;							\n"
+					"uniform sampler2D uTex0;								\n"
+					"OUT lowp vec4 fragColor;								\n"
+					"														\n"
+					"void main()											\n"
+					"{														\n"
+					"	fragColor = texture2D(uTex0, vTexCoord0);			\n"
 					;
 			}
 		}
@@ -479,19 +480,7 @@ namespace glsl {
 	public:
 		TexrectColorAndDepthCopy(const opengl::GLInfo & _glinfo)
 		{
-			if (_glinfo.isGLES2) {
-				m_part =
-					"IN mediump vec2 vTexCoord0;							\n"
-					"uniform sampler2D uTex0;								\n"
-					"uniform sampler2D uTex1;								\n"
-					"OUT lowp vec4 fragColor;								\n"
-					"														\n"
-					"void main()											\n"
-					"{														\n"
-					"	fragColor = texture2D(uTex0, vTexCoord0);			\n"
-					"	gl_FragDepth = texture2D(uTex1, vTexCoord0).r;		\n"
-					;
-			} else {
+			if (config.generalEmulation.enableHybridFilter) {
 				m_part = getHybridTextureFilter();
 				m_part +=
 					"IN mediump vec2 vTexCoord0;						\n"
@@ -502,6 +491,18 @@ namespace glsl {
 					"{													\n"
 					"	fragColor = hybridFilter(vTexCoord0);			\n"
 					"	gl_FragDepth = texture2D(uTex1, vTexCoord0).r;	\n"
+					;
+			} else {
+				m_part =
+					"IN mediump vec2 vTexCoord0;							\n"
+					"uniform sampler2D uTex0;								\n"
+					"uniform sampler2D uTex1;								\n"
+					"OUT lowp vec4 fragColor;								\n"
+					"														\n"
+					"void main()											\n"
+					"{														\n"
+					"	fragColor = texture2D(uTex0, vTexCoord0);			\n"
+					"	gl_FragDepth = texture2D(uTex1, vTexCoord0).r;		\n"
 					;
 			}
 		}

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -95,8 +95,10 @@ void GLInfo::init() {
 
 	imageTextures = imageTextures && (fragment_interlock || fragment_interlockNV || fragment_ordering);
 
-	if (isGLES2)
+	if (isGLES2) {
 		config.generalEmulation.enableFragmentDepthWrite = 0;
+		config.generalEmulation.enableHybridFilter = 0;
+	}
 
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -77,6 +77,8 @@ bool Config_SetDefault()
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableLegacyBlending", config.generalEmulation.enableLegacyBlending, "Do not use shaders to emulate N64 blending modes. Works faster on slow GPU. Can cause glitches.");
 	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableHybridFilter", config.generalEmulation.enableHybridFilter, "Enable hybrid integer scaling filter, this can be slow with low-end GPUs");
+	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableFragmentDepthWrite", config.generalEmulation.enableFragmentDepthWrite, "Enable writing of fragment depth. Some mobile GPUs do not support it, thus it made optional. Leave enabled.");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableCustomSettings", config.generalEmulation.enableCustomSettings, "Use GLideN64 per-game settings.");
@@ -397,6 +399,7 @@ void Config_LoadConfig()
 	config.generalEmulation.enableHWLighting = ConfigGetParamBool(g_configVideoGliden64, "EnableHWLighting");
 	config.generalEmulation.enableShadersStorage = ConfigGetParamBool(g_configVideoGliden64, "EnableShadersStorage");
 	config.generalEmulation.enableLegacyBlending = ConfigGetParamBool(g_configVideoGliden64, "EnableLegacyBlending");
+	config.generalEmulation.enableHybridFilter = ConfigGetParamBool(g_configVideoGliden64, "EnableHybridFilter");
 	config.generalEmulation.enableFragmentDepthWrite = ConfigGetParamBool(g_configVideoGliden64, "EnableFragmentDepthWrite");
 	config.generalEmulation.enableCustomSettings = ConfigGetParamBool(g_configVideoGliden64, "EnableCustomSettings");
 #if defined(OS_ANDROID) || defined(OS_IOS)


### PR DESCRIPTION
I'm getting a lot of complaints saying that GLideN64 is running a lot slower now. This is probably because of the new hybrid texture filter. I'm guessing that weak GLES 3 devices are having problems running it with acceptable performance.

I'm thinking the best solution is to make it optional, but enabled by default. Then in my front end, I can disable it by default and only allow it through configuration.

Also, I left it always disabled for GLES 2.0