### PR TITLE
Enable FBInfo for a few games

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -108,6 +108,10 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Mario Artist Polygon Studio (J)
 frameBufferEmulation\copyAuxToRDRAM=1
 
+[KEN%20GRIFFEY%20SLUGFEST]
+Good_Name=Ken Griffey Jr.'s Slugfest
+frameBufferEmulation\fbInfoDisabled=0
+
 [KIRBY64]
 Good_Name=Kirby 64 - The Crystal Shards (E)(J)(U)
 graphics2D\enableNativeResTexrects=1
@@ -131,6 +135,10 @@ graphics2D\correctTexrectCoords=2
 [MEGAMAN%2064]
 Good_Name=Mega Man 64 (Proto)
 graphics2D\correctTexrectCoords=2
+
+[MLB%20FEATURING%20K%20G%20JR]
+Good_Name=Major League Baseball Featuring Ken Griffey Jr.
+frameBufferEmulation\fbInfoDisabled=0
 
 [MYSTICAL%20NINJA2%20SG]
 Good_Name=Mystical Ninja 2 Starring Goemon (E)
@@ -163,6 +171,7 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=Pokemon Snap (U)
 frameBufferEmulation\copyAuxToRDRAM=1
 frameBufferEmulation\copyToRDRAM=1
+frameBufferEmulation\fbInfoDisabled=0
 
 [POKEMON%20STADIUM%202]
 Good_Name=Pokemon Stadium 2 (E)(F)(G)(I)(J)(S)(U)


### PR DESCRIPTION
See https://github.com/gonetz/GLideN64/issues/1664

FBInfo is needed for Ken Griffey Jr.'s Slugfest and Major League Baseball Featuring Ken Griffey Jr. to display correctly.

Also, with Pokemon Snap, it allows the red dot to appear, and Prof. Oak's check still works.

I believe this should be safe, since emulators that don't support FBInfo will just ignore it. It's currently enabled for Jet Force Gemini in the custom.ini already