### PR TITLE
Enabled FBInfo for Rat Attack

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -1,6 +1,6 @@
 ; Custom game settings
 [General]
-version=12
+version=13
 
 [TWINE]
 Good_Name=007 - The World Is Not Enough (E)(U)
@@ -186,6 +186,10 @@ frameBufferEmulation\copyDepthToRDRAM=0
 [PUZZLE%20LEAGUE%20N64]
 Good_Name=Pokemon Puzzle League (E)(F)(G)(U)
 texture\enableHalosRemoval=1
+
+[RAT%20ATTACK]
+Good_Name=Rat Attack
+frameBufferEmulation\fbInfoDisabled=0
 
 [ROCKMAN%20DASH]
 Good_Name=Rockman Dash - Hagane no Boukenshin (J)


### PR DESCRIPTION
I finally got this game working with mupen64plus. Strangely, unless FBInfo is enabled the game will lock up before trying to go in-game, sometimes complaining about an unknown opcode.