### PR TITLE
Fix CMake warnings presented by Android Studio

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
 
-if ((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))
-  cmake_policy(SET CMP0069 NEW)
-endif()
-
 option(EGL "Set to ON if targeting an EGL device" ${EGL})
 option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})
 option(ODROID "Set to ON if targeting an Odroid" ${ODROID})
@@ -467,11 +463,13 @@ endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 if( CMAKE_BUILD_TYPE STREQUAL "Release")
   if ((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))
+    cmake_policy(SET CMP0069 NEW)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT result)
     if(result)
       message("Interprocedural optimizations enabled")
-      set_property(TARGET ${GLideN64_DLL_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -O3")
     endif()
   endif()
 


### PR DESCRIPTION
The new Android Studio 3.6 is generating some CMake warnings that is preventing compilation. This fixes them.