### PR TITLE
Add RDRAM dithering: Dither image if RGBA16 is written to RDRAM

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -258,7 +258,7 @@ u16 ColorBufferToRDRAM::_RGBAtoRGBA16(u32 _c, u32 x, u32 y) {
 	union RGBA c;
 	c.raw = _c;
 	
-	if(gDP.otherMode.colorDither <= 1) {
+	if(gDP.otherMode.colorDither <= 1 && config.frameBufferEmulation.nativeResFactor != 1 && config.generalEmulation.enableDithering == 0) {
 		s32 threshold = 0;
 		
 		switch(gDP.otherMode.colorDither){

--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -234,17 +234,51 @@ bool ColorBufferToRDRAM::_prepareCopy(u32& _startAddress)
 	return true;
 }
 
-u8 ColorBufferToRDRAM::_RGBAtoR8(u8 _c) {
+// Precalculated 4x4 bayer matrix values for 5Bit
+const s32 thresholdMapBayer [4][4] = {
+	{-4,  2, -3,  4 },
+	{ 0, -2,  2, -1 },
+	{-3,  3, -4,  3 },
+	{ 1, -1,  1, -2 }
+};
+
+// Precalculated 4x4 magic square matrix values for 5Bit
+const s32 thresholdMapMagicSquare [4][4] = {
+	{-4,  2,  2, -1 },
+	{ 3, -2, -3,  1 },
+	{-3,  0,  4, -2 },
+	{ 3, -1, -4,  1 }
+};
+
+u8 ColorBufferToRDRAM::_RGBAtoR8(u8 _c, u32 x, u32 y) {
 	return _c;
 }
 
-u16 ColorBufferToRDRAM::_RGBAtoRGBA16(u32 _c) {
-	RGBA c;
+u16 ColorBufferToRDRAM::_RGBAtoRGBA16(u32 _c, u32 x, u32 y) {
+	union RGBA c;
 	c.raw = _c;
-	return ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | (c.a == 0 ? 0 : 1);
+	
+	if(gDP.otherMode.colorDither <= 1) {
+		s32 threshold = 0;
+		
+		switch(gDP.otherMode.colorDither){
+			case G_CD_BAYER:
+				threshold = thresholdMapBayer[x & 3][y & 3];
+				break;
+			case G_CD_MAGICSQ:
+				threshold = thresholdMapMagicSquare[x & 3][y & 3];
+				break;
+		}
+		
+		c.r = (u8)std::max(std::min((s32)c.r + threshold, 255), 0);
+		c.g = (u8)std::max(std::min((s32)c.g + threshold, 255), 0);
+		c.b = (u8)std::max(std::min((s32)c.b + threshold, 255), 0);
+	}
+		
+	return ((c.r >> 3) << 11) | ((c.g >> 3) << 6) | ((c.b >> 3) << 1) | (c.a == 0 ? 0 : 1);	
 }
 
-u32 ColorBufferToRDRAM::_RGBAtoRGBA32(u32 _c) {
+u32 ColorBufferToRDRAM::_RGBAtoRGBA32(u32 _c, u32 x, u32 y) {
 	RGBA c;
 	c.raw = _c;
 	return (c.r << 24) | (c.g << 16) | (c.b << 8) | c.a;

--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -258,7 +258,9 @@ u16 ColorBufferToRDRAM::_RGBAtoRGBA16(u32 _c, u32 x, u32 y) {
 	union RGBA c;
 	c.raw = _c;
 	
-	if(gDP.otherMode.colorDither <= 1 && config.frameBufferEmulation.nativeResFactor != 1 && config.generalEmulation.enableDithering == 0) {
+	if(gDP.otherMode.colorDither <= 1 && 
+		((config.frameBufferEmulation.nativeResFactor != 1 	&& config.generalEmulation.ditheringMode >= 3) 
+		|| config.generalEmulation.ditheringMode < 3)) {
 		s32 threshold = 0;
 		
 		switch(gDP.otherMode.colorDither){

--- a/src/BufferCopy/ColorBufferToRDRAM.h
+++ b/src/BufferCopy/ColorBufferToRDRAM.h
@@ -49,9 +49,9 @@ private:
 	u32 _getRealWidth(u32 _viWidth);
 
 	// Convert pixel from video memory to N64 buffer format.
-	static u8 _RGBAtoR8(u8 _c);
-	static u16 _RGBAtoRGBA16(u32 _c);
-	static u32 _RGBAtoRGBA32(u32 _c);
+	static u8 _RGBAtoR8(u8 _c, u32 x, u32 y);
+	static u16 _RGBAtoRGBA16(u32 _c, u32 x, u32 y);
+	static u32 _RGBAtoRGBA32(u32 _c, u32 x, u32 y);
 
 	graphics::ObjectHandle m_FBO;
 	FrameBuffer * m_pCurFrameBuffer;

--- a/src/BufferCopy/DepthBufferToRDRAM.cpp
+++ b/src/BufferCopy/DepthBufferToRDRAM.cpp
@@ -205,7 +205,7 @@ bool DepthBufferToRDRAM::_prepareCopy(u32& _startAddress, bool _copyChunk)
 	return true;
 }
 
-u16 DepthBufferToRDRAM::_FloatToUInt16(f32 _z)
+u16 DepthBufferToRDRAM::_FloatToUInt16(f32 _z, u32 x, u32 y)
 {
 	static const u16 * const zLUT = depthBufferList().getZLUT();
 	u32 idx = 0x3FFFF;

--- a/src/BufferCopy/DepthBufferToRDRAM.h
+++ b/src/BufferCopy/DepthBufferToRDRAM.h
@@ -30,7 +30,7 @@ private:
 	bool _copy(u32 _startAddress, u32 _endAddress);
 
 	// Convert pixel from video memory to N64 depth buffer format.
-	static u16 _FloatToUInt16(f32 _z);
+	static u16 _FloatToUInt16(f32 _z, u32 x, u32 y);
 
 	graphics::ObjectHandle m_FBO;
 	std::unique_ptr<graphics::PixelReadBuffer> m_pbuf;

--- a/src/BufferCopy/WriteToRDRAM.h
+++ b/src/BufferCopy/WriteToRDRAM.h
@@ -5,7 +5,7 @@
 #include "../Types.h"
 
 template <typename TSrc, typename TDst>
-void writeToRdram(TSrc* _src, TDst* _dst, TDst(*converter)(TSrc _c), TSrc _testValue, u32 _xor, u32 _width, u32 _height, u32 _numPixels, u32 _startAddress, u32 _bufferAddress, u32 _bufferSize)
+void writeToRdram(TSrc* _src, TDst* _dst, TDst(*converter)(TSrc _c, u32 x, u32 y), TSrc _testValue, u32 _xor, u32 _width, u32 _height, u32 _numPixels, u32 _startAddress, u32 _bufferAddress, u32 _bufferSize)
 {
 	u32 chunkStart = ((_startAddress - _bufferAddress) >> (_bufferSize - 1)) % _width;
 	if (chunkStart % 2 != 0) {
@@ -21,7 +21,7 @@ void writeToRdram(TSrc* _src, TDst* _dst, TDst(*converter)(TSrc _c), TSrc _testV
 		for (u32 x = chunkStart; x < _width; ++x) {
 			c = _src[x];
 			if (c != _testValue)
-				_dst[numStored ^ _xor] = converter(c);
+				_dst[numStored ^ _xor] = converter(c, x, y);
 			++numStored;
 		}
 		++y;
@@ -33,7 +33,7 @@ void writeToRdram(TSrc* _src, TDst* _dst, TDst(*converter)(TSrc _c), TSrc _testV
 		for (u32 x = 0; x < _width && numStored < _numPixels; ++x) {
 			c = _src[x + y *_width];
 			if (c != _testValue)
-				_dst[(x + dsty*_width) ^ _xor] = converter(c);
+				_dst[(x + dsty*_width) ^ _xor] = converter(c, x, y);
 			++numStored;
 		}
 		++dsty;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -39,6 +39,8 @@ void Config::resetToDefaults()
 
 	generalEmulation.enableLOD = 1;
 	generalEmulation.enableNoise = 1;
+	generalEmulation.enableDithering = 0;
+	generalEmulation.ditheringMode = 0;
 	generalEmulation.enableHWLighting = 0;
 	generalEmulation.enableCustomSettings = 1;
 	generalEmulation.enableShadersStorage = 1;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -39,8 +39,7 @@ void Config::resetToDefaults()
 
 	generalEmulation.enableLOD = 1;
 	generalEmulation.enableNoise = 1;
-	generalEmulation.enableDithering = 0;
-	generalEmulation.ditheringMode = 0;
+	generalEmulation.ditheringMode = 1;
 	generalEmulation.enableHWLighting = 0;
 	generalEmulation.enableCustomSettings = 1;
 	generalEmulation.enableShadersStorage = 1;

--- a/src/Config.h
+++ b/src/Config.h
@@ -5,7 +5,7 @@
 #include "Types.h"
 
 #define CONFIG_WITH_PROFILES 23U
-#define CONFIG_VERSION_CURRENT 27U
+#define CONFIG_VERSION_CURRENT 28U
 
 #define BILINEAR_3POINT   0
 #define BILINEAR_STANDARD 1
@@ -48,6 +48,8 @@ struct Config
 
 	struct {
 		u32 enableNoise;
+		u32 enableDithering;
+		u32 ditheringMode;
 		u32 enableLOD;
 		u32 enableHWLighting;
 		u32 enableCustomSettings;

--- a/src/Config.h
+++ b/src/Config.h
@@ -48,7 +48,6 @@ struct Config
 
 	struct {
 		u32 enableNoise;
-		u32 enableDithering;
 		u32 ditheringMode;
 		u32 enableLOD;
 		u32 enableHWLighting;

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -41,6 +41,8 @@ void _loadSettings(QSettings & settings)
 
 	settings.beginGroup("generalEmulation");
 	config.generalEmulation.enableNoise = settings.value("enableNoise", config.generalEmulation.enableNoise).toInt();
+	config.generalEmulation.enableDithering = settings.value("enableDithering", config.generalEmulation.enableDithering).toInt();
+	config.generalEmulation.ditheringMode = settings.value("ditheringMode", config.generalEmulation.ditheringMode).toInt();
 	config.generalEmulation.enableLOD = settings.value("enableLOD", config.generalEmulation.enableLOD).toInt();
 	config.generalEmulation.enableHWLighting = settings.value("enableHWLighting", config.generalEmulation.enableHWLighting).toInt();
 	config.generalEmulation.enableShadersStorage = settings.value("enableShadersStorage", config.generalEmulation.enableShadersStorage).toInt();

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -41,7 +41,6 @@ void _loadSettings(QSettings & settings)
 
 	settings.beginGroup("generalEmulation");
 	config.generalEmulation.enableNoise = settings.value("enableNoise", config.generalEmulation.enableNoise).toInt();
-	config.generalEmulation.enableDithering = settings.value("enableDithering", config.generalEmulation.enableDithering).toInt();
 	config.generalEmulation.ditheringMode = settings.value("ditheringMode", config.generalEmulation.ditheringMode).toInt();
 	config.generalEmulation.enableLOD = settings.value("enableLOD", config.generalEmulation.enableLOD).toInt();
 	config.generalEmulation.enableHWLighting = settings.value("enableHWLighting", config.generalEmulation.enableHWLighting).toInt();

--- a/src/Graphics/CombinerProgram.cpp
+++ b/src/Graphics/CombinerProgram.cpp
@@ -13,6 +13,8 @@ namespace graphics {
 		vecOptions.push_back(config.texture.enableHalosRemoval);
 		vecOptions.push_back(config.generalEmulation.enableHWLighting);
 		vecOptions.push_back(config.generalEmulation.enableNoise);
+		vecOptions.push_back(config.generalEmulation.enableDithering);
+		vecOptions.push_back(config.generalEmulation.ditheringMode);
 		vecOptions.push_back(config.generalEmulation.enableLOD);
 		vecOptions.push_back(config.frameBufferEmulation.N64DepthCompare == Config::dcFast ? 1 : 0);
 		vecOptions.push_back(config.frameBufferEmulation.N64DepthCompare == Config::dcCompatible ? 1 : 0);

--- a/src/Graphics/CombinerProgram.cpp
+++ b/src/Graphics/CombinerProgram.cpp
@@ -13,7 +13,6 @@ namespace graphics {
 		vecOptions.push_back(config.texture.enableHalosRemoval);
 		vecOptions.push_back(config.generalEmulation.enableHWLighting);
 		vecOptions.push_back(config.generalEmulation.enableNoise);
-		vecOptions.push_back(config.generalEmulation.enableDithering);
 		vecOptions.push_back(config.generalEmulation.ditheringMode);
 		vecOptions.push_back(config.generalEmulation.enableLOD);
 		vecOptions.push_back(config.frameBufferEmulation.N64DepthCompare == Config::dcFast ? 1 : 0);

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -698,8 +698,38 @@ public:
 	{
 		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
 			m_part =
-				"  if (uColorDitherMode == 2) colorNoiseDither(snoise(), clampedColor.rgb);	\n"
-				"  if (uAlphaDitherMode == 2) alphaNoiseDither(snoise(), clampedColor.a);	\n"
+				"  if (uColorDitherMode == 2) {												\n"
+				"    colorNoiseDither(snoiseRGB(), clampedColor.rgb);						\n"
+				"    quantize(clampedColor.rgb);											\n"
+				"  }																		\n"
+				"  if (uAlphaDitherMode == 2) alphaNoiseDither(snoiseA(), clampedColor.a);\n"
+				;
+		}
+		if (!_glinfo.isGLES2 && config.generalEmulation.enableDithering != 0) {
+			m_part +=
+				"  mediump mat4 threshold;													\n"
+				"  if (uColorDitherMode < 2) {												\n"
+				     // Try to eep dithering visible even at higher resolutions
+				"    lowp float divider = 1.0 + step(3.0, uScreenScale.x);					\n"
+				"    mediump ivec2 position = ivec2(mod((gl_FragCoord.xy - 0.5) / divider,4.0));\n"
+				"  																			\n"
+				"    lowp mat4 bayer = mat4( 0.0, 0.75, 0.1875, 0.9375,						\n"
+				"                            0.5, 0.25, 0.6875, 0.4375,						\n"
+				"                            0.125, 0.875, 0.0625, 0.8125,					\n"
+				"                            0.625, 0.375, 0.5625, 0.3125);					\n"
+				"    lowp mat4 mSquare = mat4( 0.0, 0.6875, 0.75, 0.4375,					\n"
+				"                              0.875, 0.3125, 0.125, 0.5625, 				\n"
+				"                              0.1875, 0.5, 0.9375, 0.25,					\n"
+				"                              0.8125, 0.375, 0.0625, 0.625);				\n"
+				"  																			\n"
+				"    lowp float bayerThreshold = bayer[position.x][position.y];				\n"
+				"    lowp float mSquareThreshold = mSquare[position.x][position.y];			\n"
+				"  																			\n"
+				"    lowp float threshold = mix(bayerThreshold,mSquareThreshold,float(uColorDitherMode));\n"
+				"    colorDither(threshold, clampedColor.rgb);								\n"
+					// 16 Bit quantization
+				"    quantize(clampedColor.rgb);											\n"
+				"  }																		\n"
 				;
 		}
 	}
@@ -883,8 +913,14 @@ public:
 	ShaderFragmentHeaderNoise(const opengl::GLInfo & _glinfo)
 	{
 		m_part =
-			"lowp float snoise();\n";
+			"lowp float snoise();\n"
 		;
+		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
+			m_part +=
+			"lowp vec3 snoiseRGB();\n"
+			"lowp float snoiseA();\n"
+			;
+		}
 	}
 };
 
@@ -973,8 +1009,18 @@ public:
 	{
 		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
 			m_part =
-				"void colorNoiseDither(in lowp float _noise, inout lowp vec3 _color);\n"
-				"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha);\n";
+				"void colorNoiseDither(in lowp vec3 _noise, inout lowp vec3 _color);\n"
+				"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha);\n"
+			;
+		}
+		if (!_glinfo.isGLES2 && config.generalEmulation.enableDithering != 0) {
+			m_part +=
+				"void colorDither(in lowp float _threshold, inout lowp vec3 _color);\n"
+			;
+		}
+		if (!_glinfo.isGLES2 && (config.generalEmulation.enableNoise != 0 || config.generalEmulation.enableDithering != 0)) {
+			m_part +=
+				"void quantize(inout lowp vec3 _color);\n"
 			;
 		}
 	}
@@ -1568,11 +1614,39 @@ public:
 				;
 			} else {
 				m_part =
-					"uniform sampler2D uTexNoise;		\n"
+					"uniform sampler2D uTexNoise;							\n"
 					"lowp float snoise()									\n"
 					"{														\n"
 					"  ivec2 coord = ivec2(gl_FragCoord.xy/uScreenScale);	\n"
 					"  return texelFetch(uTexNoise, coord, 0).r;			\n"
+					"}														\n"
+					"lowp vec3 snoiseRGB()									\n"
+					"{														\n"
+					"  mediump vec2 texSize = vec2(640.0, 580.0);			\n"
+					// multiplier for higher res noise effect
+					"  lowp float mult = 1.0 + step(2.0, uScreenScale.x);	\n"
+					"														\n"
+					"	mediump vec2 coordR = mult * ((gl_FragCoord.xy)/uScreenScale/texSize);\n"
+					"	mediump vec2 coordG = mult * ((gl_FragCoord.xy + vec2( 0.0, texSize.y / 2.0 ))/uScreenScale/texSize);\n"
+					"	mediump vec2 coordB = mult * ((gl_FragCoord.xy + vec2( texSize.x / 2.0,  0.0))/uScreenScale/texSize);\n"
+					"														\n"
+					// Only red channel of noise texture contains noise. 
+					"  lowp float r = texture(uTexNoise,coordR).r;			\n"
+					"  lowp float g = texture(uTexNoise,coordG).r;			\n"
+					"  lowp float b = texture(uTexNoise,coordB).r;			\n"
+					"														\n"
+					"  return vec3(r,g,b);									\n"
+					"}														\n"
+					"lowp float snoiseA()									\n"
+					"{														\n"
+					"  mediump vec2 texSize = vec2(640.0, 580.0);			\n"
+					// multiplier for higher res noise effect
+					"  lowp float mult = 1.0 + step(2.0, uScreenScale.x);	\n"
+					"														\n"
+					"	mediump vec2 coord = mult * ((gl_FragCoord.xy)/uScreenScale/texSize);\n"
+					"														\n"
+					// Only red channel of noise texture contains noise. 
+					"  return texture(uTexNoise,coord).r;					\n"
 					"}														\n"
 					;
 			}
@@ -1587,23 +1661,42 @@ public:
 	{
 		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
 			m_part =
-				"void colorNoiseDither(in lowp float _noise, inout lowp vec3 _color)	\n"
+				"void colorNoiseDither(in lowp vec3 _noise, inout lowp vec3 _color)\n"
 				"{															\n"
-				"    mediump vec3 tmpColor = _color*255.0;					\n"
-				"    mediump ivec3 iColor = ivec3(tmpColor);				\n"
-				//"    iColor &= 248;										\n" // does not work with HW lighting enabled (why?!)
-				"    iColor |= ivec3(tmpColor*_noise)&7;					\n"
-				"    _color = vec3(iColor)/255.0;							\n"
+				"    mediump vec3 threshold = 7.0 / 255.0 * (_noise - 0.5);\n"
+				"    _color = clamp(_color + threshold,0.0,1.0);			\n"
 				"}															\n"
-				"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha)	\n"
+				"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha)\n"
 				"{															\n"
-				"    mediump float tmpAlpha = _alpha*255.0;					\n"
-				"    mediump int iAlpha = int(tmpAlpha);					\n"
-				//"    iAlpha &= 248;											\n" // causes issue #518. need further investigation
-				"    iAlpha |= int(tmpAlpha*_noise)&7;						\n"
-				"    _alpha = float(iAlpha)/255.0;							\n"
+				"    mediump float threshold = 7.0 / 255.0 * (_noise - 0.5);\n"
+				"    _alpha = clamp(_alpha + threshold,0.0,1.0);			\n"
 				"}															\n"
 			;
+		}
+		if (!_glinfo.isGLES2 && config.generalEmulation.enableDithering != 0) {
+			m_part +=
+				"void colorDither(in lowp float _threshold, inout lowp vec3 _color)\n"
+				"{															\n"
+				"    lowp vec3 threshold = vec3(7.0 / 255.0 * (_threshold - 0.5));\n"
+				"    _color = clamp(_color + threshold,0.0,1.0);			\n"
+				"}															\n"
+			;
+		}
+		if (!_glinfo.isGLES2 && (config.generalEmulation.enableNoise != 0 || config.generalEmulation.enableDithering != 0)) {
+			if (config.generalEmulation.ditheringMode == 1 ) {
+				m_part +=
+					"void quantize(inout lowp vec3 _color)\n"
+					"{															\n"
+					"     _color.rgb = round(_color.rgb * 32.0)/32.0;			\n"
+					"}															\n"
+				;
+			}
+			else
+			{
+				m_part +=
+					"void quantize(inout lowp vec3 _color){}\n"
+				;
+			}
 		}
 	}
 };

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -696,41 +696,59 @@ class ShaderCallDither : public ShaderPart
 public:
 	ShaderCallDither(const opengl::GLInfo & _glinfo)
 	{
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
-			m_part =
-				"  if (uColorDitherMode == 2) {												\n"
-				"    colorNoiseDither(snoiseRGB(), clampedColor.rgb);						\n"
-				"    quantize(clampedColor.rgb);											\n"
-				"  }																		\n"
-				"  if (uAlphaDitherMode == 2) alphaNoiseDither(snoiseA(), clampedColor.a);\n"
+		if (!_glinfo.isGLES2) {
+			if (config.generalEmulation.ditheringMode >= 1) {
+				m_part =
+					"  if (uColorDitherMode == 2) {												\n"
+					"    colorNoiseDither(snoiseRGB(), clampedColor.rgb);						\n"
+					"    quantizeRGB(clampedColor.rgb);											\n"
+					"  }																		\n"
+					"  if (uAlphaDitherMode == 2) {												\n"
+					"    alphaNoiseDither(snoiseA(), clampedColor.a);							\n"
+					"    quantizeA(clampedColor.a);												\n"
+					"  }																		\n"
 				;
-		}
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableDithering != 0) {
-			m_part +=
-				"  mediump mat4 threshold;													\n"
-				"  if (uColorDitherMode < 2) {												\n"
-				     // Try to eep dithering visible even at higher resolutions
-				"    lowp float divider = 1.0 + step(3.0, uScreenScale.x);					\n"
-				"    mediump ivec2 position = ivec2(mod((gl_FragCoord.xy - 0.5) / divider,4.0));\n"
-				"  																			\n"
-				"    lowp mat4 bayer = mat4( 0.0, 0.75, 0.1875, 0.9375,						\n"
-				"                            0.5, 0.25, 0.6875, 0.4375,						\n"
-				"                            0.125, 0.875, 0.0625, 0.8125,					\n"
-				"                            0.625, 0.375, 0.5625, 0.3125);					\n"
-				"    lowp mat4 mSquare = mat4( 0.0, 0.6875, 0.75, 0.4375,					\n"
-				"                              0.875, 0.3125, 0.125, 0.5625, 				\n"
-				"                              0.1875, 0.5, 0.9375, 0.25,					\n"
-				"                              0.8125, 0.375, 0.0625, 0.625);				\n"
-				"  																			\n"
-				"    lowp float bayerThreshold = bayer[position.x][position.y];				\n"
-				"    lowp float mSquareThreshold = mSquare[position.x][position.y];			\n"
-				"  																			\n"
-				"    lowp float threshold = mix(bayerThreshold,mSquareThreshold,float(uColorDitherMode));\n"
-				"    colorDither(threshold, clampedColor.rgb);								\n"
-					// 16 Bit quantization
-				"    quantize(clampedColor.rgb);											\n"
-				"  }																		\n"
+			}
+			if (config.generalEmulation.ditheringMode >= 3) {
+				m_part +=
+					// Try to keep dithering visible even at higher resolutions
+					"  lowp float divider = 1.0 + step(3.0, uScreenScale.x);					\n"
+					"  mediump ivec2 position = ivec2(mod((gl_FragCoord.xy - 0.5) / divider,4.0));\n"
+					"  																			\n"
+					"  lowp mat4 bayer = mat4( 0.0, 0.75, 0.1875, 0.9375,						\n"
+					"                            0.5, 0.25, 0.6875, 0.4375,						\n"
+					"                            0.125, 0.875, 0.0625, 0.8125,					\n"
+					"                            0.625, 0.375, 0.5625, 0.3125);					\n"
+					"  lowp mat4 mSquare = mat4( 0.0, 0.6875, 0.75, 0.4375,						\n"
+					"                              0.875, 0.3125, 0.125, 0.5625, 				\n"
+					"                              0.1875, 0.5, 0.9375, 0.25,					\n"
+					"                              0.8125, 0.375, 0.0625, 0.625);				\n"
+					"  																			\n"
+					"  lowp float bayerThreshold = bayer[position.x][position.y];				\n"
+					"  lowp float mSquareThreshold = mSquare[position.x][position.y];			\n"
+					"  																			\n"
+					"  if (uColorDitherMode < 2) {												\n"
+					"    lowp float threshold = mix(mSquareThreshold,bayerThreshold,float(uColorDitherMode));\n"
+					"    colorNoiseDither(vec3(threshold), clampedColor.rgb);					\n"
+						// 16 Bit quantization
+					"    quantizeRGB(clampedColor.rgb);											\n"
+					"  }																		\n"
+					"  if (uAlphaDitherMode < 2) {												\n"
+					"    lowp float thresholdPattern = mix(mSquareThreshold,bayerThreshold,clamp(float(uColorDitherMode),0.0,1.0));\n"
+					"    thresholdPattern = mix(thresholdPattern,mSquareThreshold,clamp(float(uColorDitherMode - 1),0.0,1.0));\n" // uColorDitherMode = 2
+					"    thresholdPattern = mix(thresholdPattern,bayerThreshold,clamp(float(uColorDitherMode - 2),0.0,1.0));\n" // uColorDitherMode = 3
+					"  																			\n"
+					"    lowp float thresholdNotPattern = mix(bayerThreshold,mSquareThreshold,clamp(float(uColorDitherMode),0.0,1.0));\n"
+					"    thresholdNotPattern = mix(thresholdNotPattern,bayerThreshold,clamp(float(uColorDitherMode - 1),0.0,1.0));\n" // uColorDitherMode = 2
+					"    thresholdNotPattern = mix(thresholdNotPattern,mSquareThreshold,clamp(float(uColorDitherMode - 2),0.0,1.0));\n" // uColorDitherMode = 3
+					"  																			\n"
+					"    lowp float threshold = mix(thresholdNotPattern, thresholdPattern,float(uAlphaDitherMode));\n"
+					"    alphaNoiseDither(threshold, clampedColor.a);							\n"
+						// 16 Bit quantization
+					"    quantizeA(clampedColor.a);												\n"
+					"  }																		\n"
 				;
+			}
 		}
 	}
 };
@@ -915,12 +933,6 @@ public:
 		m_part =
 			"lowp float snoise();\n"
 		;
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
-			m_part +=
-			"lowp vec3 snoiseRGB();\n"
-			"lowp float snoiseA();\n"
-			;
-		}
 	}
 };
 
@@ -1007,21 +1019,17 @@ class ShaderFragmentHeaderDither : public ShaderPart
 public:
 	ShaderFragmentHeaderDither(const opengl::GLInfo & _glinfo)
 	{
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
-			m_part =
-				"void colorNoiseDither(in lowp vec3 _noise, inout lowp vec3 _color);\n"
-				"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha);\n"
-			;
-		}
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableDithering != 0) {
-			m_part +=
-				"void colorDither(in lowp float _threshold, inout lowp vec3 _color);\n"
-			;
-		}
-		if (!_glinfo.isGLES2 && (config.generalEmulation.enableNoise != 0 || config.generalEmulation.enableDithering != 0)) {
-			m_part +=
-				"void quantize(inout lowp vec3 _color);\n"
-			;
+		if (!_glinfo.isGLES2) {
+			if(config.generalEmulation.ditheringMode >= 1) {
+				m_part =
+					"void colorNoiseDither(in lowp vec3 _noise, inout lowp vec3 _color);\n"
+					"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha);\n"
+					"void quantizeRGB(inout lowp vec3 _color);\n"
+					"void quantizeA(inout lowp float _alpha);\n"
+					"lowp vec3 snoiseRGB();\n"
+					"lowp float snoiseA();\n"
+				;
+			}
 		}
 	}
 };
@@ -1601,6 +1609,11 @@ public:
 				"  return 0.5;			\n"
 				"}						\n"
 				;
+			if (config.generalEmulation.ditheringMode >= 1) {
+				m_part +=
+					"uniform sampler2D uTexNoise;							\n"
+				;
+			}
 		} else {
 			if (_glinfo.isGLES2) {
 				m_part =
@@ -1620,6 +1633,30 @@ public:
 					"  ivec2 coord = ivec2(gl_FragCoord.xy/uScreenScale);	\n"
 					"  return texelFetch(uTexNoise, coord, 0).r;			\n"
 					"}														\n"
+				;
+			}
+		}
+	}
+};
+
+class ShaderDither : public ShaderPart
+{
+public:
+	ShaderDither(const opengl::GLInfo & _glinfo)
+	{
+		if (!_glinfo.isGLES2) {
+			if( config.generalEmulation.ditheringMode >= 1 ) {
+				m_part =
+					"void colorNoiseDither(in lowp vec3 _noise, inout lowp vec3 _color)\n"
+					"{															\n"
+					"    mediump vec3 threshold = 7.0 / 255.0 * (_noise - 0.5);\n"
+					"    _color = clamp(_color + threshold,0.0,1.0);			\n"
+					"}															\n"
+					"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha)\n"
+					"{															\n"
+					"    mediump float threshold = 7.0 / 255.0 * (_noise - 0.5);\n"
+					"    _alpha = clamp(_alpha + threshold,0.0,1.0);			\n"
+					"}															\n"
 					"lowp vec3 snoiseRGB()									\n"
 					"{														\n"
 					"  mediump vec2 texSize = vec2(640.0, 580.0);			\n"
@@ -1648,54 +1685,25 @@ public:
 					// Only red channel of noise texture contains noise. 
 					"  return texture(uTexNoise,coord).r;					\n"
 					"}														\n"
+				;
+				if ( config.generalEmulation.ditheringMode == 2 || config.generalEmulation.ditheringMode == 4 ) {
+					m_part +=
+						"void quantizeRGB(inout lowp vec3 _color)\n"
+						"{															\n"
+						"     _color.rgb = round(_color.rgb * 32.0)/32.0;			\n"
+						"}															\n"
+						"void quantizeA(inout lowp float _alpha)\n"
+						"{															\n"
+						"     _alpha = round(_alpha * 32.0)/32.0;					\n"
+						"}															\n"
 					;
-			}
-		}
-	}
-};
-
-class ShaderDither : public ShaderPart
-{
-public:
-	ShaderDither(const opengl::GLInfo & _glinfo)
-	{
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableNoise != 0) {
-			m_part =
-				"void colorNoiseDither(in lowp vec3 _noise, inout lowp vec3 _color)\n"
-				"{															\n"
-				"    mediump vec3 threshold = 7.0 / 255.0 * (_noise - 0.5);\n"
-				"    _color = clamp(_color + threshold,0.0,1.0);			\n"
-				"}															\n"
-				"void alphaNoiseDither(in lowp float _noise, inout lowp float _alpha)\n"
-				"{															\n"
-				"    mediump float threshold = 7.0 / 255.0 * (_noise - 0.5);\n"
-				"    _alpha = clamp(_alpha + threshold,0.0,1.0);			\n"
-				"}															\n"
-			;
-		}
-		if (!_glinfo.isGLES2 && config.generalEmulation.enableDithering != 0) {
-			m_part +=
-				"void colorDither(in lowp float _threshold, inout lowp vec3 _color)\n"
-				"{															\n"
-				"    lowp vec3 threshold = vec3(7.0 / 255.0 * (_threshold - 0.5));\n"
-				"    _color = clamp(_color + threshold,0.0,1.0);			\n"
-				"}															\n"
-			;
-		}
-		if (!_glinfo.isGLES2 && (config.generalEmulation.enableNoise != 0 || config.generalEmulation.enableDithering != 0)) {
-			if (config.generalEmulation.ditheringMode == 1 ) {
-				m_part +=
-					"void quantize(inout lowp vec3 _color)\n"
-					"{															\n"
-					"     _color.rgb = round(_color.rgb * 32.0)/32.0;			\n"
-					"}															\n"
-				;
-			}
-			else
-			{
-				m_part +=
-					"void quantize(inout lowp vec3 _color){}\n"
-				;
+				}
+				else {
+					m_part +=
+						"void quantizeRGB(inout lowp vec3 _color){}\n"
+						"void quantizeA(inout lowp float _alpha){}\n"
+					;
+				}
 			}
 		}
 	}

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -1042,7 +1042,7 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 												  const CombinerKey & _key,
 												  UniformGroups & _uniforms)
 {
-	if (config.generalEmulation.enableNoise != 0)
+	if (config.generalEmulation.enableNoise != 0 || config.generalEmulation.ditheringMode > 0)
 		_uniforms.emplace_back(new UNoiseTex(_program));
 
 	if (!m_glInfo.isGLES2) {

--- a/src/NoiseTexture.cpp
+++ b/src/NoiseTexture.cpp
@@ -106,7 +106,7 @@ void NoiseTexture::_fillTextureData()
 
 void NoiseTexture::init()
 {
-	if (config.generalEmulation.enableNoise == 0)
+	if (config.generalEmulation.enableNoise == 0 && config.generalEmulation.ditheringMode == 0)
 		return;
 
 	if (m_texData[0].empty())
@@ -161,7 +161,7 @@ void NoiseTexture::destroy()
 
 void NoiseTexture::update()
 {
-	if (m_DList == dwnd().getBuffersSwapCount() || config.generalEmulation.enableNoise == 0)
+	if (m_DList == dwnd().getBuffersSwapCount() || (config.generalEmulation.enableNoise == 0 && config.generalEmulation.ditheringMode == 0))
 		return;
 
 	u32 rand_value(0U);

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -69,9 +69,7 @@ bool Config_SetDefault()
 	//#Emulation Settings
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableNoise", config.generalEmulation.enableNoise, "Enable color noise emulation.");
 	assert(res == M64ERR_SUCCESS);
-	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableDithering", config.generalEmulation.enableDithering, "Enable dithering emulation.");
-	assert(res == M64ERR_SUCCESS);
-	res = ConfigSetDefaultBool(g_configVideoGliden64, "DitheringMode", config.generalEmulation.ditheringMode, "Dithering mode. (false=32Bit colors, true=16Bit quantization like original hardware)");
+	res = ConfigSetDefaultInt(g_configVideoGliden64, "DitheringMode", config.generalEmulation.ditheringMode, "Dithering mode. (0=disable, 1=only noise dithering (default), 2=noise dithering with 16bit quantization,3=noise and ordered grid dithering, 4=dithering with 16bit quantization)");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableLOD", config.generalEmulation.enableLOD, "Enable LOD emulation.");
 	assert(res == M64ERR_SUCCESS);
@@ -276,8 +274,6 @@ void Config_LoadCustomConfig()
 
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableNoise", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.generalEmulation.enableNoise = atoi(value);
-	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableDithering", value, sizeof(value));
-	if (result == M64ERR_SUCCESS) config.generalEmulation.enableDithering = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\ditheringMode", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.generalEmulation.ditheringMode = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableLOD", value, sizeof(value));
@@ -403,8 +399,7 @@ void Config_LoadConfig()
 	config.texture.enableHalosRemoval = ConfigGetParamBool(g_configVideoGliden64, "enableHalosRemoval");
 	//#Emulation Settings
 	config.generalEmulation.enableNoise = ConfigGetParamBool(g_configVideoGliden64, "EnableNoise");
-	config.generalEmulation.enableDithering = ConfigGetParamBool(g_configVideoGliden64, "EnableDithering");
-	config.generalEmulation.ditheringMode = ConfigGetParamBool(g_configVideoGliden64, "DitheringMode");
+	config.generalEmulation.ditheringMode = ConfigGetParamInt(g_configVideoGliden64, "DitheringMode");
 	config.generalEmulation.enableLOD = ConfigGetParamBool(g_configVideoGliden64, "EnableLOD");
 	config.generalEmulation.enableHWLighting = ConfigGetParamBool(g_configVideoGliden64, "EnableHWLighting");
 	config.generalEmulation.enableShadersStorage = ConfigGetParamBool(g_configVideoGliden64, "EnableShadersStorage");

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -69,6 +69,10 @@ bool Config_SetDefault()
 	//#Emulation Settings
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableNoise", config.generalEmulation.enableNoise, "Enable color noise emulation.");
 	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableDithering", config.generalEmulation.enableDithering, "Enable dithering emulation.");
+	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "DitheringMode", config.generalEmulation.ditheringMode, "Dithering mode. (false=32Bit colors, true=16Bit quantization like original hardware)");
+	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableLOD", config.generalEmulation.enableLOD, "Enable LOD emulation.");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableHWLighting", config.generalEmulation.enableHWLighting, "Enable hardware per-pixel lighting.");
@@ -272,6 +276,10 @@ void Config_LoadCustomConfig()
 
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableNoise", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.generalEmulation.enableNoise = atoi(value);
+	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableDithering", value, sizeof(value));
+	if (result == M64ERR_SUCCESS) config.generalEmulation.enableDithering = atoi(value);
+	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\ditheringMode", value, sizeof(value));
+	if (result == M64ERR_SUCCESS) config.generalEmulation.ditheringMode = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableLOD", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.generalEmulation.enableLOD = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "generalEmulation\\enableHWLighting", value, sizeof(value));
@@ -395,6 +403,8 @@ void Config_LoadConfig()
 	config.texture.enableHalosRemoval = ConfigGetParamBool(g_configVideoGliden64, "enableHalosRemoval");
 	//#Emulation Settings
 	config.generalEmulation.enableNoise = ConfigGetParamBool(g_configVideoGliden64, "EnableNoise");
+	config.generalEmulation.enableDithering = ConfigGetParamBool(g_configVideoGliden64, "EnableDithering");
+	config.generalEmulation.ditheringMode = ConfigGetParamBool(g_configVideoGliden64, "DitheringMode");
 	config.generalEmulation.enableLOD = ConfigGetParamBool(g_configVideoGliden64, "EnableLOD");
 	config.generalEmulation.enableHWLighting = ConfigGetParamBool(g_configVideoGliden64, "EnableHWLighting");
 	config.generalEmulation.enableShadersStorage = ConfigGetParamBool(g_configVideoGliden64, "EnableShadersStorage");


### PR DESCRIPTION
ColorbufferToRDRAM RGBA to RGBA16 conversion produces color banding.
Implement dithering according to n64 documentation to hide color
banding.

https://github.com/gonetz/GLideN64/issues/2173