### PR TITLE
Fix IPO build on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.9)
 
 option(EGL "Set to ON if targeting an EGL device" ${EGL})
 option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})
@@ -462,15 +462,12 @@ if( CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 if( CMAKE_BUILD_TYPE STREQUAL "Release")
-  if ((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))
-    cmake_policy(SET CMP0069 NEW)
-    include(CheckIPOSupported)
-    check_ipo_supported(RESULT result)
-    if(result)
-      message("Interprocedural optimizations enabled")
-      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-      set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -O3")
-    endif()
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT result)
+  if(result)
+    message("Interprocedural optimizations enabled")
+    set_property(TARGET ${GLideN64_DLL_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -O3")
   endif()
 
   SET_TARGET_PROPERTIES(


### PR DESCRIPTION
@fzurita can you let me know if this works on Android?

The changes to the cmake file disabled IPO for Windows and Linux for me.

This change bumps the required cmake version to 3.9, 3.9 came out in 2017, I think most Linux distros (and Android) use it now.