### PR TITLE
Mask RDRAM address in ProcessRDPList

### DIFF
--- a/src/RDP.cpp
+++ b/src/RDP.cpp
@@ -564,7 +564,7 @@ inline u32 READ_RDP_DATA(u32 address)
 	if (dp_status & 0x1)          // XBUS_DMEM_DMA enabled
 		return rsp_dmem[(address & 0xfff)>>2];
 	else
-		return rdram[address>>2];
+		return rdram[(address & 0xffffff)>>2];
 }
 
 void RDP_ProcessRDPList()


### PR DESCRIPTION
Avoids a crash in Donkey Kong 64 (U) [f2]

See in Angrylion:
https://github.com/ata4/angrylion-rdp-plus/blob/f7cad30db1fdfce23957fcc3c7dfc11e69aed04a/src/core/n64video/rdp/rdram.c#L7
https://github.com/ata4/angrylion-rdp-plus/blob/f7cad30db1fdfce23957fcc3c7dfc11e69aed04a/src/core/n64video/rdp/rdram.c#L88-L89

The address the game tries to use is 0xA0150000, the 0xA needs to be masked away or it crashes