### PR TITLE
Fix bug introduced by XXH3 commit

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1262,9 +1262,9 @@ u64 _calculateCRC(u32 _t, const TextureParams & _params, u32 _bytes)
 
 	if (gDP.otherMode.textureLUT != G_TT_NONE || gSP.textureTile[_t]->format == G_IM_FMT_CI) {
 		if (gSP.textureTile[_t]->size == G_IM_SIZ_4b)
-			crc = CRC_Calculate( crc, &gDP.paletteCRC16[gSP.textureTile[_t]->palette], 4 );
+			crc = CRC_Calculate( crc, &gDP.paletteCRC16[gSP.textureTile[_t]->palette], sizeof(u64) );
 		else if (gSP.textureTile[_t]->size == G_IM_SIZ_8b)
-			crc = CRC_Calculate( crc, &gDP.paletteCRC256, 4 );
+			crc = CRC_Calculate( crc, &gDP.paletteCRC256, sizeof(u64) );
 	}
 
 	if (config.generalEmulation.enableLOD != 0 && gSP.texture.level > 1 && _t > 0)
@@ -1356,9 +1356,9 @@ void TextureCache::_updateBackground()
 
 	if (gDP.otherMode.textureLUT != G_TT_NONE || gSP.bgImage.format == G_IM_FMT_CI) {
 		if (gSP.bgImage.size == G_IM_SIZ_4b)
-			crc = CRC_Calculate( crc, &gDP.paletteCRC16[gSP.bgImage.palette], 4 );
+			crc = CRC_Calculate( crc, &gDP.paletteCRC16[gSP.bgImage.palette], sizeof(u64) );
 		else if (gSP.bgImage.size == G_IM_SIZ_8b)
-			crc = CRC_Calculate( crc, &gDP.paletteCRC256, 4 );
+			crc = CRC_Calculate( crc, &gDP.paletteCRC256, sizeof(u64) );
 	}
 
 	u32 params[4] = {gSP.bgImage.width, gSP.bgImage.height, gSP.bgImage.format, gSP.bgImage.size};

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -712,7 +712,7 @@ void gDPLoadTLUT( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt )
 		pal = (pal + 1) & 0x0F;
 	}
 
-	gDP.paletteCRC256 = CRC_Calculate(UINT64_MAX, gDP.paletteCRC16, 64);
+	gDP.paletteCRC256 = CRC_Calculate(UINT64_MAX, gDP.paletteCRC16, sizeof(u64) * 16);
 
 	if (TFH.isInited()) {
 		const u16 start = gDP.tiles[tile].tmem - 256; // starting location in the palettes


### PR DESCRIPTION
Fixes https://github.com/gonetz/GLideN64/issues/2199

The size of gDP.paletteCRC16 and gDP.paletteCRC256 was changed from u32 to u64, but I never updated the size value for when those variables are used in future CRC calculations