### PR TITLE
Fix broken Android compilation with updated xxHash

### DIFF
--- a/src/Neon/CRC_OPT_NEON.cpp
+++ b/src/Neon/CRC_OPT_NEON.cpp
@@ -1,5 +1,5 @@
 #include "CRC.h"
-#include "xxHash/xxhash.h"
+#include "xxHash/xxh3.h"
 #include <arm_neon.h>
 
 #define CRC32_POLYNOMIAL	 0x04C11DB7
@@ -49,16 +49,10 @@ u32 CRC_Calculate_Strict(u32 crc, const void *buffer, u32 count) {
 #define PRIME32_4	668265263U
 #define PRIME32_5	374761393U
 
-#if defined(_MSC_VER)
-#  define XXH_rotl32(x,r) _rotl(x,r)
-#else
-#  define XXH_rotl32(x, r) ((x << r) | (x >> (32 - r)))
-#endif
-
-u32 ReliableHash32NEON(const void *input, size_t len, u32 seed) {
+u64 ReliableHash32NEON(const void *input, size_t len, u64 seed) {
 	if (((uintptr_t) input & 3) != 0) {
 		// Cannot handle misaligned data. Fall back to XXH32.
-		return XXH32(input, len, seed);
+		return XXH3_64bits_withSeed(input, len, seed);
 	}
 
 	const u8 *p = (const u8 *) input;


### PR DESCRIPTION
The update of xxHash broke Android compilation, this fixes it. 

Also, I see that the updated xxHash may have some Neon optimizations already, I don't know if they are faster than the existing optimizations or how to make sure they are enabled, so until that gets figured out, we can just fix this one.