### PR TITLE
Mask VI_ORIGIN address

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -591,7 +591,7 @@ void FrameBufferList::setBufferChanged(f32 _maxY)
 void FrameBufferList::clearBuffersChanged()
 {
 	gDP.colorImage.changed = FALSE;
-	FrameBuffer * pBuffer = frameBufferList().findBuffer(*REG.VI_ORIGIN);
+	FrameBuffer * pBuffer = frameBufferList().findBuffer(*REG.VI_ORIGIN & 0xffffff);
 	if (pBuffer != nullptr)
 		pBuffer->m_changed = false;
 }
@@ -1159,7 +1159,7 @@ bool FrameBufferList::RdpUpdate::update(RdpUpdateResult & _result)
 	_result.vi_maxhpass = hres_clamped ? 0 : 7;
 	_result.vi_width = _SHIFTR(*REG.VI_WIDTH, 0, 12);
 	_result.vi_lowerfield = lowerfield;
-	_result.vi_origin = _SHIFTR(*REG.VI_ORIGIN, 0, 24);
+	_result.vi_origin = _SHIFTR(*REG.VI_ORIGIN, 0, 24) & 0xffffff;
 	_result.vi_fsaa = (*REG.VI_STATUS & 512) == 0;
 	_result.vi_divot = (*REG.VI_STATUS & 16) != 0;
 	return true;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -674,7 +674,7 @@ namespace glsl {
 
 		void activate() override {
 			FXAAShaderBase::activate();
-			FrameBuffer * pBuffer = frameBufferList().findBuffer(*REG.VI_ORIGIN);
+			FrameBuffer * pBuffer = frameBufferList().findBuffer(*REG.VI_ORIGIN & 0xffffff);
 			if (pBuffer != nullptr && pBuffer->m_pTexture != nullptr &&
 				(m_width != pBuffer->m_pTexture->width || m_height != pBuffer->m_pTexture->height)) {
 				m_width = pBuffer->m_pTexture->width;

--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -82,7 +82,7 @@ void VI_UpdateSize()
 //	const int fsaa = ((*REG.VI_STATUS) >> 8) & 3;
 //	const int divot = ((*REG.VI_STATUS) >> 4) & 1;
 	FrameBufferList & fbList = frameBufferList();
-	FrameBuffer * pBuffer = fbList.findBuffer(VI.lastOrigin);
+	FrameBuffer * pBuffer = fbList.findBuffer(VI.lastOrigin & 0xffffff);
 	DepthBuffer * pDepthBuffer = pBuffer != nullptr ? pBuffer->m_pDepthBuffer : nullptr;
 	if (config.frameBufferEmulation.enable &&
 		((interlacedPrev != VI.interlaced) ||
@@ -131,7 +131,7 @@ void VI_UpdateScreen()
 
 	if (config.frameBufferEmulation.enable) {
 
-		FrameBuffer * pBuffer = frameBufferList().findBuffer(*REG.VI_ORIGIN);
+		FrameBuffer * pBuffer = frameBufferList().findBuffer(*REG.VI_ORIGIN & 0xffffff);
 		if (pBuffer == nullptr) {
 			gDP.changed |= CHANGED_CPU_FB_WRITE;
 		} else if (!FBInfo::fbInfo.isSupported() &&
@@ -166,7 +166,7 @@ void VI_UpdateScreen()
 					}
 					const u32 size = *REG.VI_STATUS & 3;
 					if (VI.height > 0 && size > G_IM_SIZ_8b  && VI.width > 0)
-						frameBufferList().saveBuffer(*REG.VI_ORIGIN, G_IM_FMT_RGBA, size, VI.width, true);
+						frameBufferList().saveBuffer(*REG.VI_ORIGIN & 0xffffff, G_IM_FMT_RGBA, size, VI.width, true);
 				}
 			}
 //			if ((((*REG.VI_STATUS) & 3) > 0) && (gDP.colorImage.changed || bCFB)) { // Does not work in release build!!!
@@ -175,12 +175,12 @@ void VI_UpdateScreen()
 					VI_UpdateSize();
 					bVIUpdated = true;
 				}
-				FrameBuffer_CopyFromRDRAM(*REG.VI_ORIGIN, bCFB);
+				FrameBuffer_CopyFromRDRAM(*REG.VI_ORIGIN & 0xffffff, bCFB);
 			}
 			frameBufferList().renderBuffer();
 			frameBufferList().clearBuffersChanged();
 			VI.lastOrigin = *REG.VI_ORIGIN;
-		} 
+		}
 	} else {
 		if (gDP.changed & CHANGED_COLORBUFFER) {
 			frameBufferList().renderBuffer();


### PR DESCRIPTION
This is a similar fix as https://github.com/gonetz/GLideN64/commit/3f55f30ea2feab4f9d561aa977aa8d1a67bf2ee5 but for VI addresses

Fixes https://github.com/gonetz/GLideN64/issues/1770, also fixes 64doom, a homebrew doom port (https://doomwiki.org/wiki/64Doom)

The PeterLemon ROMs are shaky, but Angrylion does this as well (unless you turn off VI filtering)