### PR TITLE
FlappyBird64 requires CopyFromRDRAM

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -1,6 +1,6 @@
 ; Custom game settings
 [General]
-version=13
+version=14
 
 [TWINE]
 Good_Name=007 - The World Is Not Enough (E)(U)
@@ -71,6 +71,10 @@ frameBufferEmulation\N64DepthCompare=1
 [F1%20POLE%20POSITION%2064]
 Good_Name=F-1 Pole Position 64 (E)(U)
 frameBufferEmulation\copyToRDRAM=1
+
+[FLAPPYBIRD64]
+Good_Name=FlappyBird64
+frameBufferEmulation\copyFromRDRAM=1
 
 [GOEMON2%20DERODERO]
 Good_Name=Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (J)

--- a/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -302,9 +302,6 @@ void RDRAMtoColorBuffer::copyFromRDRAM(u32 _address, bool _bCFB)
 	if (m_pCurBuffer == nullptr || m_pCurBuffer->m_size < G_IM_SIZ_16b)
 		return;
 
-	if (m_pCurBuffer->m_startAddress == _address && gDP.colorImage.changed != 0)
-		return;
-
 	const u32 height = cutHeight(m_pCurBuffer->m_startAddress,
 		m_pCurBuffer->m_startAddress == _address ?
 			VI.real_height :


### PR DESCRIPTION
Fixes https://github.com/gonetz/GLideN64/issues/2197

With FBInfo enabled (on mupen64plus) all the display elements are shown correctly, same as Angrylion