### PR TITLE
Enable FBInfo for Dr Mario and FlappyBird

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -46,6 +46,7 @@ frameBufferEmulation\copyDepthToRDRAM=1
 
 [DR.MARIO%2064]
 Good_Name=Dr. Mario 64 (U)
+frameBufferEmulation\fbInfoDisabled=0
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 
@@ -75,6 +76,7 @@ frameBufferEmulation\copyToRDRAM=1
 
 [FLAPPYBIRD64]
 Good_Name=FlappyBird64
+frameBufferEmulation\fbInfoDisabled=0
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 


### PR DESCRIPTION
Having frameBufferEmulation\copyToRDRAM=0 for FlappyBird causing some incorrect screen flashing (flashes of black).

FBInfo works with both these games, and is probably a more correct way of emulating this unique situation. It will be harmless for emulators that don't support it