### PR TITLE
GLideNUI-wtl: in loading language, replacing new line was only replac…

### DIFF
--- a/src/GLideNUI-wtl/Language.cpp
+++ b/src/GLideNUI-wtl/Language.cpp
@@ -268,7 +268,7 @@ LANG_STR GetNextLangString(FILE * file)
 
 	std::string::size_type pos = text.find("\\n");
 	while (pos != std::string::npos) {
-		text.replace(pos, 1, "\n");
+		text.replace(pos, 2, "\n");
 		pos = text.find("\\n", pos + 1);
 	}
 	return LANG_STR(StringID, text);


### PR DESCRIPTION
When loading the language string it finds "\n" and replace it with \n, it was replacing 1 character so it was replacing "\", not "\n" as it should be.

So change it to replace 2 characters "\n"