### PR TITLE
More WTL fixes

### DIFF
--- a/src/GLideNUI-wtl/ConfigDlg.cpp
+++ b/src/GLideNUI-wtl/ConfigDlg.cpp
@@ -43,13 +43,15 @@ LRESULT CConfigDlg::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lPar
 	HICON hIconSmall = AtlLoadIconImage(IDI_APPICON, LR_DEFAULTCOLOR, ::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON));
 	SetIcon(hIconSmall, FALSE);
 
+	m_FrameBufferTab = new CFrameBufferTab();
+	m_VideoTab = new CVideoTab(*this, *m_FrameBufferTab, m_strIniPath.c_str());
 	m_EmulationTab = new CEmulationTab(*this);
 	m_OsdTab = new COsdTab();
 
 	m_Tabs.Attach(GetDlgItem(IDC_TABS));
-	AddTab(TAB_VIDEO, new CVideoTab(*this, m_strIniPath.c_str()));
+	AddTab(TAB_VIDEO, m_VideoTab);
 	AddTab(TAB_EMULATION, m_EmulationTab);
-	AddTab(TAB_FRAME_BUFFER, new CFrameBufferTab);
+	AddTab(TAB_FRAME_BUFFER, m_FrameBufferTab);
 	AddTab(TAB_TEXTURE_ENHANCEMENT, new CTextureEnhancementTab);
 	AddTab(TAB_OSD, m_OsdTab);
 #ifdef DEBUG_DUMP

--- a/src/GLideNUI-wtl/ConfigDlg.cpp
+++ b/src/GLideNUI-wtl/ConfigDlg.cpp
@@ -220,8 +220,8 @@ void CConfigDlg::SaveSettings() {
 	for (size_t i = 0; i < m_TabWindows.size(); i++)
 		m_TabWindows[i]->SaveSettings();
     
-    if (config.generalEmulation.enableCustomSettings && CButton(m_EmulationTab->GetDlgItem(IDC_GAME_PROFILE)).GetCheck() == BST_CHECKED && m_romName != nullptr)
-        saveCustomRomSettings(m_strIniPath.c_str(), m_romName);
+	if (config.generalEmulation.enableCustomSettings && CButton(GetDlgItem(IDC_GAME_PROFILE)).GetCheck() == BST_CHECKED && m_romName != nullptr)
+		saveCustomRomSettings(m_strIniPath.c_str(), m_romName);
     else
         writeSettings(m_strIniPath.c_str());
     

--- a/src/GLideNUI-wtl/ConfigDlg.h
+++ b/src/GLideNUI-wtl/ConfigDlg.h
@@ -6,6 +6,8 @@
 #include "resource.h"
 #include <vector>
 
+class CFrameBufferTab;
+class CVideoTab;
 class CEmulationTab;
 class COsdTab;
 
@@ -61,6 +63,8 @@ protected:
 	std::string m_strIniPath;
 	const char * m_romName;
 	bool m_blockReInit;
+	CFrameBufferTab * m_FrameBufferTab;
+	CVideoTab * m_VideoTab;
 	CEmulationTab * m_EmulationTab;
 	COsdTab * m_OsdTab;
 	uint32_t m_TabLeft, m_ProfileLeft;

--- a/src/GLideNUI-wtl/config-video.cpp
+++ b/src/GLideNUI-wtl/config-video.cpp
@@ -47,11 +47,12 @@ static u32 powof(u32 dim)
 	return i;
 }
 
-CVideoTab::CVideoTab(CConfigDlg & Dlg, const char * strIniPath) :
+CVideoTab::CVideoTab(CConfigDlg & Dlg, CFrameBufferTab & FrameBufferTab, const char * strIniPath) :
 	CConfigTab(IDD_TAB_VIDEO),
 	m_strIniPath(strIniPath),
 	m_LangList(GetLanguageList(strIniPath)),
-	m_Dlg(Dlg)
+	m_Dlg(Dlg),
+	m_FrameBufferTab(FrameBufferTab)
 {
 }
 
@@ -376,9 +377,9 @@ void CVideoTab::LoadSettings(bool /*blockCustomSettings*/) {
 	}
 
 	CComboBox(GetDlgItem(IDC_CMB_PATTERN)).SetCurSel(config.generalEmulation.rdramImageDitheringMode);
-	CButton(GetDlgItem(IDC_CHK_APPLY_TO_OUTPUT)).SetCheck(config.generalEmulation.enableDitheringPattern == 0 ? BST_CHECKED : BST_UNCHECKED);
-	CButton(GetDlgItem(IDC_CHK_5BIT_QUANTIZATION)).SetCheck(config.generalEmulation.enableDitheringQuantization == 0 ? BST_CHECKED : BST_UNCHECKED);
-	CButton(GetDlgItem(IDC_CHK_HIRES_NOISE)).SetCheck(config.generalEmulation.enableHiresNoiseDithering == 0 ? BST_CHECKED : BST_UNCHECKED);
+	CButton(GetDlgItem(IDC_CHK_APPLY_TO_OUTPUT)).SetCheck(config.generalEmulation.enableDitheringPattern != 0 ? BST_CHECKED : BST_UNCHECKED);
+	CButton(GetDlgItem(IDC_CHK_5BIT_QUANTIZATION)).SetCheck(config.generalEmulation.enableDitheringQuantization != 0 ? BST_CHECKED : BST_UNCHECKED);
+	CButton(GetDlgItem(IDC_CHK_HIRES_NOISE)).SetCheck(config.generalEmulation.enableHiresNoiseDithering != 0 ? BST_CHECKED : BST_UNCHECKED);
 
 	CComboBox translationsComboBox(GetDlgItem(IDC_CMB_LANGUAGE));
 	translationsComboBox.SetCurSel(-1);
@@ -443,7 +444,12 @@ void CVideoTab::SaveSettings()
 	);
 
 	config.video.fxaa = CButton(GetDlgItem(IDC_FXAA_RADIO)).GetCheck() == BST_CHECKED ? 1 : 0;
-	config.video.multisampling = pow2(m_AliasingSlider.GetPos());
+	config.video.multisampling =
+		(CButton(GetDlgItem(IDC_FXAA_RADIO)).GetCheck() == BST_CHECKED
+			|| CComboBox(m_FrameBufferTab.GetDlgItem(IDC_CMB_N64_DEPTH_COMPARE)).GetCurSel() != 0
+			|| CButton(GetDlgItem(IDC_NOAA_RADIO)).GetCheck() == BST_CHECKED
+			) ? 0
+		: pow2(m_AliasingSlider.GetPos());
 	config.texture.maxAnisotropy = m_AnisotropicSlider.GetPos();
 
 	if (CButton(GetDlgItem(IDC_BILINEAR_3POINT)).GetCheck() == BST_CHECKED)

--- a/src/GLideNUI-wtl/config-video.h
+++ b/src/GLideNUI-wtl/config-video.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "config-tab.h"
 #include "config-overscan.h"
+#include "config-framebuffer.h"
 #include "wtl-BitmapPicture.h"
 #include "wtl-tooltip.h"
 #include "resource.h"
@@ -12,6 +13,7 @@
 #include <regex>
 
 class CConfigDlg;
+class CFrameBufferTab;
 
 class CVideoTab :
 	public CConfigTab,
@@ -33,7 +35,7 @@ public:
 		REFLECT_NOTIFICATIONS()
 	END_MSG_MAP()
 
-	CVideoTab(CConfigDlg & Dlg, const char * strIniPath);
+	CVideoTab(CConfigDlg & Dlg, CFrameBufferTab & FrameBufferTab, const char * strIniPath);
 	~CVideoTab();
 
 	BOOL OnInitDialog(CWindow /*wndFocus*/, LPARAM /*lInitParam*/);
@@ -57,4 +59,5 @@ public:
 	std::string m_strIniPath;
 	LanguageList m_LangList;
 	CConfigDlg & m_Dlg;
+	CFrameBufferTab & m_FrameBufferTab;
 };


### PR DESCRIPTION
- Custom ini saving wasn't really fixed by 29bd0d10ab356d2de60a30005e468091b9eb4619. This PR fixes it

- MSAA now checks for value of FXAA and Depth Compare combobox before saving, adapted the same logic from Qt version