### PR TITLE
Null free

### DIFF
--- a/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -72,6 +72,7 @@ void RDRAMtoColorBuffer::destroy()
 		m_pTexture = nullptr;
 	}
 	free(m_pbuf);
+    m_pbuf = nullptr;
 }
 
 void RDRAMtoColorBuffer::addAddress(u32 _address, u32 _size)

--- a/src/BufferCopy/RDRAMtoColorBuffer.cpp
+++ b/src/BufferCopy/RDRAMtoColorBuffer.cpp
@@ -72,7 +72,7 @@ void RDRAMtoColorBuffer::destroy()
 		m_pTexture = nullptr;
 	}
 	free(m_pbuf);
-    m_pbuf = nullptr;
+	m_pbuf = nullptr;
 }
 
 void RDRAMtoColorBuffer::addAddress(u32 _address, u32 _size)

--- a/src/PaletteTexture.cpp
+++ b/src/PaletteTexture.cpp
@@ -72,6 +72,7 @@ void PaletteTexture::destroy()
 	textureCache().removeFrameBufferTexture(m_pTexture);
 	m_pTexture = nullptr;
 	free(m_pbuf);
+    m_pbuf = nullptr;
 }
 
 void PaletteTexture::update()

--- a/src/PaletteTexture.cpp
+++ b/src/PaletteTexture.cpp
@@ -72,7 +72,7 @@ void PaletteTexture::destroy()
 	textureCache().removeFrameBufferTexture(m_pTexture);
 	m_pTexture = nullptr;
 	free(m_pbuf);
-    m_pbuf = nullptr;
+	m_pbuf = nullptr;
 }
 
 void PaletteTexture::update()


### PR DESCRIPTION
fix a possible double free, if destroy was called twice then the free was calling on the old address.

Make sure it is set back to null after being freed