### PR TITLE
Text drawer destroy

### DIFF
--- a/src/GLideNUI-wtl/Settings.cpp
+++ b/src/GLideNUI-wtl/Settings.cpp
@@ -105,6 +105,8 @@ void _loadSettings(GlSettings & settings)
 
 	settings.beginGroup("font");
 	config.font.name = settings.value("name", config.font.name.c_str()).toString();
+	if (config.font.name.empty())
+		config.font.name = "arial.ttf";
 	config.font.size = settings.value("size", config.font.size).toInt();
 	GlColor fontColor = settings.value("color", GlColor(config.font.color[0], config.font.color[1], config.font.color[2])).toGlColor();
 	config.font.color[0] = fontColor.Red();

--- a/src/GLideNUI-wtl/config-osd.cpp
+++ b/src/GLideNUI-wtl/config-osd.cpp
@@ -239,13 +239,13 @@ void COsdTab::LoadSettings(bool /*blockCustomSettings*/)
 		m_OsdColor.SetColor(config.font.color[0], config.font.color[1], config.font.color[2]);
 		m_OsdPreview.SetColor(config.font.color[0], config.font.color[1], config.font.color[2]);
 	}
-	
-	m_PosTopLeft.SetChecked(config.onScreenDisplay.pos == Config::posTopLeft); 
-	m_PosTop.SetChecked(config.onScreenDisplay.pos == Config::posTopCenter); 
+
+	m_PosTopLeft.SetChecked(config.onScreenDisplay.pos == Config::posTopLeft);
+	m_PosTop.SetChecked(config.onScreenDisplay.pos == Config::posTopCenter);
 	m_PosTopRight.SetChecked(config.onScreenDisplay.pos == Config::posTopRight);
 	m_PosBottomLeft.SetChecked(config.onScreenDisplay.pos == Config::posBottomLeft);
 	m_PosBottom.SetChecked(config.onScreenDisplay.pos == Config::posBottomCenter);
-	m_PosBottomRight.SetChecked(config.onScreenDisplay.pos == Config::posBottomRight); 
+	m_PosBottomRight.SetChecked(config.onScreenDisplay.pos == Config::posBottomRight);
 
 	CButton(GetDlgItem(IDC_CHK_FPS)).SetCheck(config.onScreenDisplay.fps != 0 ? BST_CHECKED : BST_UNCHECKED);
 	CButton(GetDlgItem(IDC_CHK_VIS)).SetCheck(config.onScreenDisplay.vis != 0 ? BST_CHECKED : BST_UNCHECKED);
@@ -291,6 +291,8 @@ void COsdTab::SaveSettings()
 
 std::wstring COsdTab::GetSelectedFont()
 {
+	if (!m_FontsLoaded)
+		return ToUTF16(config.font.name.c_str());
 	HTREEITEM hItem = m_Fonts.GetSelectedItem();
 	if (hItem == NULL)
 		return L"";

--- a/src/GLideNUI-wtl/config-osd.cpp
+++ b/src/GLideNUI-wtl/config-osd.cpp
@@ -272,7 +272,11 @@ void COsdTab::SaveSettings()
 	config.onScreenDisplay.internalResolution = CButton(GetDlgItem(IDC_INTERNAL_RESOLUTION)).GetCheck() == BST_CHECKED ? 1 : 0;
 	config.onScreenDisplay.renderingResolution = CButton(GetDlgItem(IDC_RENDERING_RESOLUTION)).GetCheck() == BST_CHECKED ? 1 : 0;
 
-	config.font.name = FromUTF16(GetSelectedFont().c_str());
+	std::string SelectedFont = FromUTF16(GetSelectedFont().c_str());
+	if (!SelectedFont.empty())
+		config.font.name = SelectedFont;
+	if (config.font.name.empty())
+		config.font.name = "arial.ttf";
 	config.font.size = m_FontSizeSpin.GetPos();
 
 	config.font.color[0] = m_OsdColor.Red();

--- a/src/TextDrawer.cpp
+++ b/src/TextDrawer.cpp
@@ -257,7 +257,9 @@ void TextDrawer::destroy()
 	m_atlas.reset();
 	m_program.reset();
 	FT_Done_Face(g_face);
+	g_face = NULL;
 	FT_Done_FreeType(g_ft);
+	g_ft = NULL;
 }
 
 /**


### PR DESCRIPTION
Make sure that config.font.name is not empty

as well as make sure g_face and g_ft are reset to null after delete