### PR TITLE
GLideNUI-wtl: fix read game prilfe setting in init

### DIFF
--- a/src/GLideNUI-wtl/ConfigDlg.cpp
+++ b/src/GLideNUI-wtl/ConfigDlg.cpp
@@ -326,7 +326,7 @@ void CConfigDlg::Init(bool reInit, bool blockCustomSettings) {
 	m_blockReInit = true;
 	bool CustomSettings = m_EmulationTab != NULL && CButton(m_EmulationTab->GetDlgItem(IDC_CHK_USE_PER_GAME)).GetCheck() == BST_CHECKED;
 
-	if (reInit && m_romName != NULL && CustomSettings && CButton(m_EmulationTab->GetDlgItem(IDC_GAME_PROFILE)).GetCheck() == BST_CHECKED) {
+	if (reInit && m_romName != NULL && CustomSettings && CButton(GetDlgItem(IDC_GAME_PROFILE)).GetCheck() == BST_CHECKED) {
 		loadCustomRomSettings(m_strIniPath.c_str(), m_romName);
 	} else if (reInit) {
 		loadSettings(m_strIniPath.c_str());


### PR DESCRIPTION
game profile is not in emulation, was fixed in other places, this was missing and this fixes a missing case.