### PR TITLE
Add custom setting for 1080 Snowboarding

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -1,10 +1,14 @@
 ; Custom game settings
 [General]
-version=13
+version=14
 
 [TWINE]
 Good_Name=007 - The World Is Not Enough (E)(U)
 frameBufferEmulation\N64DepthCompare=1
+
+[1080%20Snowboarding]
+Good_Name=1080 Snowboarding
+frameBufferEmulation\copyToRDRAM=2
 
 [BIOFREAKS]
 Good_Name=Bio F.R.E.A.K.S. (E)(U)


### PR DESCRIPTION
After the title screens the intro is completely corrupted and the game is not playable unless `copyColorToRDRAM` is set to `Async` in mupen64plus_next. I think this is the same setting.

I'm a bit unsure whether the header is important in the ini file and also whether it needs `(U)` etc. I haven't tested but I would guess it needs to be applied to all versions.