### PR TITLE
Fix double free

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -519,6 +519,9 @@ void TextureCache::destroy()
 
 void TextureCache::_checkCacheSize()
 {
+	if (m_maxCacheSize == 0)
+		return;
+
 	if (m_textures.size() >= m_maxCacheSize) {
 		CachedTexture& clsTex = m_textures.back();
 		gfxContext.deleteTexture(clsTex.name);


### PR DESCRIPTION
This fixes the following segmentation fault on startup:

```
0  0x00007ffff790e355 in raise () from /usr/lib/libc.so.6
1  0x00007ffff78f7853 in abort () from /usr/lib/libc.so.6
2  0x00007ffff7951878 in __libc_message () from /usr/lib/libc.so.6
3  0x00007ffff7958d3a in malloc_printerr () from /usr/lib/libc.so.6
4  0x00007ffff7959ef4 in _int_free () from /usr/lib/libc.so.6
5  0x00007fffd65acef8 in __gnu_cxx::new_allocator<std::_List_node<CachedTexture> >::deallocate (__t=1, __p=0x7fffd6c5a190 <TextureCache::get()::cache+16>, this=0x7fffd6c5a190 <TextureCache::get()::cache+16>)
   at /usr/include/c++/10.1.0/ext/new_allocator.h:120
6  std::allocator_traits<std::allocator<std::_List_node<CachedTexture> > >::deallocate (__n=1, __p=0x7fffd6c5a190 <TextureCache::get()::cache+16>, __a=...) at /usr/include/c++/10.1.0/bits/alloc_traits.h:492
7  std::__cxx11::_List_base<CachedTexture, std::allocator<CachedTexture> >::_M_put_node (__p=0x7fffd6c5a190 <TextureCache::get()::cache+16>, this=0x7fffd6c5a190 <TextureCache::get()::cache+16>)
   at /usr/include/c++/10.1.0/bits/stl_list.h:446
8  std::__cxx11::list<CachedTexture, std::allocator<CachedTexture> >::_M_erase (__position=..., this=0x7fffd6c5a190 <TextureCache::get()::cache+16>) at /usr/include/c++/10.1.0/bits/stl_list.h:1930
9  std::__cxx11::list<CachedTexture, std::allocator<CachedTexture> >::pop_back (this=0x7fffd6c5a190 <TextureCache::get()::cache+16>) at /usr/include/c++/10.1.0/bits/stl_list.h:1247
10 TextureCache::_checkCacheSize (this=this@entry=0x7fffd6c5a180 <TextureCache::get()::cache>) at GLideN64/src/Textures.cpp:526
11 0x00007fffd65acf36 in TextureCache::_addTexture (this=this@entry=0x7fffd6c5a180 <TextureCache::get()::cache>, _crc32=1600359801) at GLideN64/src/Textures.cpp:534
12 0x00007fffd65ad5ad in TextureCache::update (this=0x7fffd6c5a180 <TextureCache::get()::cache>, _t=_t@entry=0) at GLideN64/src/Textures.cpp:1535
13 0x00007fffd65b676f in GraphicsDrawer::_updateTextures (this=this@entry=0x7fffd684d670 <DisplayWindow::get()::video+1104>) at GLideN64/src/Textures.h:112
14 0x00007fffd65b6854 in GraphicsDrawer::_updateStates (this=this@entry=0x7fffd684d670 <DisplayWindow::get()::video+1104>, _drawingState=_drawingState@entry=DrawingState::Triangle)
   at GLideN64/src/GraphicsDrawer.cpp:662
15 0x00007fffd65b6b0a in GraphicsDrawer::_prepareDrawTriangle (this=this@entry=0x7fffd684d670 <DisplayWindow::get()::video+1104>) at GLideN64/src/GraphicsDrawer.cpp:716
16 0x00007fffd65b6c1e in GraphicsDrawer::drawTriangles (this=0x7fffd684d670 <DisplayWindow::get()::video+1104>) at GLideN64/src/GraphicsDrawer.cpp:745
17 0x00007fffd659b8e6 in gSPFlushTriangles () at GLideN64/src/DisplayWindow.h:40
18 0x00007fffd659b9bb in gSP1Triangle (v0=<optimized out>, v1=<optimized out>, v2=<optimized out>) at GLideN64/src/gSP.cpp:91
19 0x00007fffd6631d90 in F3DEX2_Tri1 (w0=<optimized out>, w1=<optimized out>) at GLideN64/src/uCodes/F3DEX2.cpp:61
20 0x00007fffd65a509f in _ProcessDList () at GLideN64/src/RSP.cpp:59
21 0x00007fffd65a53c7 in RSP_ProcessDList () at GLideN64/src/RSP.cpp:180
22 0x00007fffd65afd67 in PluginAPI::ProcessDList (this=<optimized out>) at GLideN64/src/common/CommonAPIImpl_common.cpp:159
23 0x00007fffd658f426 in gln64ProcessDList () at GLideN64/src/PluginAPI.h:118
24 0x00007fffd6745825 in HleProcessDlistList (UNUSED_user_defined=<optimized out>) at mupen64plus-rsp-hle/src/plugin.c:118
25 0x00007fffd673e838 in send_dlist_to_gfx_plugin (hle=hle@entry=0x7fffdc11c0a0 <g_hle>) at mupen64plus-rsp-hle/src/hle.c:172
26 0x00007fffd673eef6 in try_fast_task_dispatching (hle=hle@entry=0x7fffdc11c0a0 <g_hle>) at mupen64plus-rsp-hle/src/hle.c:281
27 0x00007fffd673f068 in hle_execute (hle=hle@entry=0x7fffdc11c0a0 <g_hle>) at mupen64plus-rsp-hle/src/hle.c:113
28 0x00007fffd6745907 in hleDoRspCycles (Cycles=4294967295) at mupen64plus-rsp-hle/src/plugin.c:204
29 0x00007fffd66c01ec in do_SP_Task (sp=sp@entry=0x7fffdfa238c8 <g_dev+59783368>) at mupen64plus-core/src/device/rcp/rsp/rsp_core.c:278
30 0x00007fffd66c046f in update_sp_status (sp=0x7fffdfa238c8 <g_dev+59783368>, w=293) at mupen64plus-core/src/device/rcp/rsp/rsp_core.c:159
31 0x00007fffd66c049b in write_rsp_regs (opaque=<optimized out>, address=<optimized out>, value=<optimized out>, mask=<optimized out>) at mupen64plus-core/src/device/rcp/rsp/rsp_core.c:224
32 0x00007fffd66be78d in mem_write32 (mask=4294967295, value=293, address=<optimized out>, handler=<optimized out>) at ./mupen64plus-core/src/device/memory/memory.h:87
33 r4300_write_aligned_word (r4300=r4300@entry=0x7fffdc120000 <g_dev>, address=<optimized out>, value=293, mask=mask@entry=4294967295) at mupen64plus-core/src/device/r4300/r4300_core.c:353
34 0x00007fffd6719aa8 in write_word_new (pcaddr=<optimized out>, count=<optimized out>, diff=6) at mupen64plus-core/src/device/r4300/new_dynarec/new_dynarec.c:11309
35 0x00007fffdca8cbb8 in g_dev () from mupen64plus-libretro-nx/mupen64plus_next_libretro.so
36 0x0000000000000000 in ?? ()
```

Signed-off-by: Mahyar Koshkouei <mk@deltabeard.com>