### PR TITLE
Fix type cast error for 64bit compilation

### DIFF
--- a/src/RSP_LoadMatrixX86.cpp
+++ b/src/RSP_LoadMatrixX86.cpp
@@ -89,7 +89,7 @@ LoadLoop:
     "    loop    LoadLoop"                       "\n\t"
     ".att_syntax prefix"                         "\n\t"
     : /* no output */
-    : "f"(recip), "S"((int)RDRAM+address), "D"(mtx), "c"(4)
+    : "f"(recip), "S"((intptr_t)RDRAM+address), "D"(mtx), "c"(4)
     : "memory" );
 #endif // WIN32_ASM
 }

--- a/src/RSP_LoadMatrixX86.cpp
+++ b/src/RSP_LoadMatrixX86.cpp
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "RSP.h"
 #include "GBI.h"
 


### PR DESCRIPTION
`RSP_LoadMatrixX86.cpp:92:28: error: cast from 'u8* {aka unsigned char*}' to 'int' loses precision [-fpermissive]
      : "f"(recip), "S"((int)RDRAM+address), "D"(mtx), "c"(4)`