### PR TITLE
[INI] Remove Dithering Noise from Paint Studio & add Paint Studio prototype

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -31,13 +31,14 @@ Good_Name=Castlevania - Legacy Of Darkness (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 
 [DMPJ]
-Good_Name=Mario Paint Studio (64dd disk)
+Good_Name=Mario Artist Paint Studio (J) (64DD)
+frameBufferEmulation\copyAuxToRDRAM=1
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\nativeResFactor=1
-frameBufferEmulation\copyAuxToRDRAM=1
+generalEmulation\rdramImageDitheringMode=0
 
 [DMTJ]
-Good_Name=Mario Artist Talent Studio (64dd disk)
+Good_Name=Mario Artist Talent Studio (J) (64DD)
 frameBufferEmulation\copyAuxToRDRAM=1
 
 [DONKEY%20KONG%2064]
@@ -254,6 +255,12 @@ frameBufferEmulation\copyToRDRAM=0
 Good_Name=Star Twins (J)
 frameBufferEmulation\fbInfoDisabled=0
 frameBufferEmulation\copyAuxToRDRAM=1
+
+[TEST]
+Good_Name=Mario Artist Paint Studio (J) (1999-02-11 Prototype) (64DD)
+frameBufferEmulation\copyAuxToRDRAM=1
+frameBufferEmulation\copyFromRDRAM=1
+generalEmulation\rdramImageDitheringMode=0
 
 [TETRISPHERE]
 Good_Name=Tetrisphere (U)


### PR DESCRIPTION
When you use stamps or anything that you copy in Paint Studio, the canvas darkens on every paste on the canvas. Disabling dithering fixes the problem.