### PR TITLE
Correct filtering of video window

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -650,12 +650,12 @@ void Debugger::_drawFrameBuffer(FrameBuffer * _pBuffer)
 	blitParams.dstY1 = dstCoord[3];
 	blitParams.dstWidth = wnd.getScreenWidth();
 	blitParams.dstHeight = wnd.getScreenHeight() + wnd.getHeightOffset();
-	blitParams.filter = config.generalEmulation.enableHybridFilter > 0 ?
+	const bool downscale = blitParams.srcWidth >= blitParams.dstWidth || blitParams.srcHeight >= blitParams.dstHeight;
+	blitParams.filter = downscale || config.generalEmulation.enableHybridFilter > 0 ?
 		textureParameters::FILTER_LINEAR :
-		textureParameters::FILTER_NEAREST;
+		textureParameters::FILTER_NEAREST; //upscale; hybridFilter disabled
 	blitParams.mask = blitMask::COLOR_BUFFER;
 	blitParams.tex[0] = pBufferTexture;
-	const bool downscale = blitParams.srcWidth >= blitParams.dstWidth && blitParams.srcHeight >= blitParams.dstHeight;
 	blitParams.combiner = downscale ? CombinerInfo::get().getTexrectDownscaleCopyProgram() :
 		CombinerInfo::get().getTexrectUpscaleCopyProgram();
 	blitParams.readBuffer = readBuffer;

--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -1026,12 +1026,12 @@ void FrameBufferList::_renderScreenSizeBuffer()
 	blitParams.dstY1 = dstCoord[3];
 	blitParams.dstWidth = screenWidth;
 	blitParams.dstHeight = screenHeight + wndHeightOffset;
-	blitParams.filter = config.generalEmulation.enableHybridFilter > 0 ?
+	const bool downscale = blitParams.srcWidth >= blitParams.dstWidth || blitParams.srcHeight >= blitParams.dstHeight;
+	blitParams.filter = downscale || config.generalEmulation.enableHybridFilter > 0 ?
 		textureParameters::FILTER_LINEAR :
-		textureParameters::FILTER_NEAREST;
+		textureParameters::FILTER_NEAREST; //upscale; hybridFilter disabled
 	blitParams.mask = blitMask::COLOR_BUFFER;
 	blitParams.tex[0] = pBufferTexture;
-	const bool downscale = blitParams.srcWidth >= blitParams.dstWidth && blitParams.srcHeight >= blitParams.dstHeight;
 	blitParams.combiner = downscale ? CombinerInfo::get().getTexrectDownscaleCopyProgram() :
 		CombinerInfo::get().getTexrectUpscaleCopyProgram();
 	blitParams.readBuffer = pFilteredBuffer->m_FBO;
@@ -1354,12 +1354,10 @@ void FrameBufferList::OverscanBuffer::draw(u32 _fullHeight, bool _PAL)
 	blitParams.dstHeight = wnd.getScreenHeight() + wnd.getHeightOffset();
 	blitParams.mask = blitMask::COLOR_BUFFER;
 	blitParams.tex[0] = m_pTexture;
-	const bool downscale = config.frameBufferEmulation.nativeResFactor != 1 &&
-		blitParams.srcWidth >= blitParams.dstWidth &&
-		blitParams.srcHeight >= blitParams.dstHeight;
-	blitParams.filter = downscale || config.generalEmulation.enableHybridFilter == 0 ?
-		textureParameters::FILTER_NEAREST :
-		textureParameters::FILTER_LINEAR;
+	const bool downscale = blitParams.srcWidth >= blitParams.dstWidth || blitParams.srcHeight >= blitParams.dstHeight;
+	blitParams.filter = downscale || config.generalEmulation.enableHybridFilter > 0 ?
+		textureParameters::FILTER_LINEAR :
+		textureParameters::FILTER_NEAREST; //upscale; hybridFilter disabled
 	if (config.frameBufferEmulation.copyDepthToMainDepthBuffer != 0) {
 		blitParams.tex[1] = m_pDepthTexture;
 		blitParams.combiner = downscale ? CombinerInfo::get().getTexrectColorAndDepthDownscaleCopyProgram() :
@@ -1531,12 +1529,10 @@ void FrameBufferList::renderBuffer()
 	blitParams.dstHeight = m_overscan.getBufferHeight();
 	blitParams.mask = blitMask::COLOR_BUFFER;
 	blitParams.tex[0] = pBufferTexture;
-	const bool downscale = config.frameBufferEmulation.nativeResFactor != 1 &&
-							blitParams.srcWidth >= blitParams.dstWidth &&
-							blitParams.srcHeight >= blitParams.dstHeight;
-	blitParams.filter = downscale || config.generalEmulation.enableHybridFilter == 0 ?
-		textureParameters::FILTER_NEAREST :
-		textureParameters::FILTER_LINEAR;
+	const bool downscale = blitParams.srcWidth >= blitParams.dstWidth || blitParams.srcHeight >= blitParams.dstHeight;
+	blitParams.filter = downscale || config.generalEmulation.enableHybridFilter > 0 ?
+		textureParameters::FILTER_LINEAR :
+		textureParameters::FILTER_NEAREST; //upscale; hybridFilter disabled
 	if (config.frameBufferEmulation.copyDepthToMainDepthBuffer != 0) {
 		blitParams.tex[1] = pBuffer->m_pDepthTexture;
 		blitParams.combiner = downscale ? CombinerInfo::get().getTexrectColorAndDepthDownscaleCopyProgram() :

--- a/src/GLideNUI-wtl/Settings.cpp
+++ b/src/GLideNUI-wtl/Settings.cpp
@@ -48,6 +48,9 @@ void _loadSettings(GlSettings & settings)
 	config.generalEmulation.enableLOD = settings.value("enableLOD", config.generalEmulation.enableLOD).toInt();
 	config.generalEmulation.enableHWLighting = settings.value("enableHWLighting", config.generalEmulation.enableHWLighting).toInt();
 	config.generalEmulation.enableShadersStorage = settings.value("enableShadersStorage", config.generalEmulation.enableShadersStorage).toInt();
+	config.generalEmulation.enableLegacyBlending = settings.value("enableLegacyBlending", config.generalEmulation.enableLegacyBlending).toInt();			 //ini only
+	config.generalEmulation.enableHybridFilter = settings.value("enableHybridFilter", config.generalEmulation.enableHybridFilter).toInt();					 //ini only
+	config.generalEmulation.enableFragmentDepthWrite = settings.value("enableFragmentDepthWrite", config.generalEmulation.enableFragmentDepthWrite).toInt(); //ini only
 	config.generalEmulation.enableCustomSettings = settings.value("enableCustomSettings", config.generalEmulation.enableCustomSettings).toInt();
 	settings.endGroup();
 
@@ -229,6 +232,9 @@ void writeSettings(const char * _strIniFolder)
 		settings.setValue("enableLOD", config.generalEmulation.enableLOD);
 		settings.setValue("enableHWLighting", config.generalEmulation.enableHWLighting);
 		settings.setValue("enableShadersStorage", config.generalEmulation.enableShadersStorage);
+		settings.setValue("enableLegacyBlending", config.generalEmulation.enableLegacyBlending);		 //ini only
+		settings.setValue("enableHybridFilter", config.generalEmulation.enableHybridFilter);			 //ini only
+		settings.setValue("enableFragmentDepthWrite", config.generalEmulation.enableFragmentDepthWrite); //ini only
 		settings.setValue("enableCustomSettings", config.generalEmulation.enableCustomSettings);
 		settings.endGroup();
 

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -47,6 +47,9 @@ void _loadSettings(QSettings & settings)
 	config.generalEmulation.enableLOD = settings.value("enableLOD", config.generalEmulation.enableLOD).toInt();
 	config.generalEmulation.enableHWLighting = settings.value("enableHWLighting", config.generalEmulation.enableHWLighting).toInt();
 	config.generalEmulation.enableShadersStorage = settings.value("enableShadersStorage", config.generalEmulation.enableShadersStorage).toInt();
+	config.generalEmulation.enableLegacyBlending = settings.value("enableLegacyBlending", config.generalEmulation.enableLegacyBlending).toInt();			 //ini only
+	config.generalEmulation.enableHybridFilter = settings.value("enableHybridFilter", config.generalEmulation.enableHybridFilter).toInt();					 //ini only
+	config.generalEmulation.enableFragmentDepthWrite = settings.value("enableFragmentDepthWrite", config.generalEmulation.enableFragmentDepthWrite).toInt(); //ini only
 	config.generalEmulation.enableCustomSettings = settings.value("enableCustomSettings", config.generalEmulation.enableCustomSettings).toInt();
 	settings.endGroup();
 
@@ -222,6 +225,9 @@ void writeSettings(const QString & _strIniFolder)
 	settings.setValue("enableLOD", config.generalEmulation.enableLOD);
 	settings.setValue("enableHWLighting", config.generalEmulation.enableHWLighting);
 	settings.setValue("enableShadersStorage", config.generalEmulation.enableShadersStorage);
+	settings.setValue("enableLegacyBlending", config.generalEmulation.enableLegacyBlending);		 //ini only
+	settings.setValue("enableHybridFilter", config.generalEmulation.enableHybridFilter);			 //ini only
+	settings.setValue("enableFragmentDepthWrite", config.generalEmulation.enableFragmentDepthWrite); //ini only
 	settings.setValue("enableCustomSettings", config.generalEmulation.enableCustomSettings);
 	settings.endGroup();
 


### PR DESCRIPTION
Fixes #2311

Commit d7d68c46 (current master)

**Native resolution, Hybrid filter ON**
![GLideN64_GOLDENEYE_000](https://user-images.githubusercontent.com/7278372/88635059-0d83ac80-d06c-11ea-8591-1c487618a47a.png)

This PR
![GLideN64_GOLDENEYE_001](https://user-images.githubusercontent.com/7278372/88635130-29874e00-d06c-11ea-9477-6128bc9738ae.png)

**Native resolution, Hybrid filter ON, overscan**
![GLideN64_GOLDENEYE_004](https://user-images.githubusercontent.com/7278372/88635728-e11c6000-d06c-11ea-9a26-12f54e582f22.png)

**Native resolution, Hybrid filter OFF, overscan**
![GLideN64_GOLDENEYE_002](https://user-images.githubusercontent.com/7278372/88635369-6d7a5300-d06c-11ea-8371-192f26ba2c63.png)

**Native resolution, Hybrid filter OFF**
![GLideN64_GOLDENEYE_003](https://user-images.githubusercontent.com/7278372/88635515-9569b680-d06c-11ea-88a8-e9e762f8f34b.png)


Commit d7d68c46 (current master)
4x native resolution Hybrid filter ON
![GLideN64_MarioTennis_000](https://user-images.githubusercontent.com/7278372/88635873-0f01a480-d06d-11ea-8e65-81e9f6729e60.png)

This PR
![GLideN64_MarioTennis_001](https://user-images.githubusercontent.com/7278372/88636024-407a7000-d06d-11ea-9500-2f59da3e118d.png)







