### PR TITLE
remove hack_texrect_shade_alpha

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -228,7 +228,6 @@ struct Config
 #define hack_blurPauseScreen		(1<<2)  //Game copies frame buffer to depth buffer area, CPU blurs it. That image is used as background for pause screen.
 #define hack_clearAloneDepthBuffer	(1<<3)  //Force clear depth buffer if there is no frame buffer for it. Multiplayer in GE and PD.
 #define hack_StarCraftBackgrounds	(1<<4)  //StarCraft special check for frame buffer usage.
-#define hack_texrect_shade_alpha	(1<<5)  //Set vertex alpha to 1 when texrect alpha combiner uses shade. Pokemon Stadium 2
 #define hack_subscreen				(1<<6)  //Fix subscreen delay in Zelda OOT and Doubutsu no Mori
 #define hack_blastCorps				(1<<7)  //Blast Corps black polygons
 #define hack_rectDepthBufferCopyPD	(1<<8)  //Copy depth buffer only when game need it. Optimized for PD

--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -305,9 +305,6 @@ void RSP_Init()
 		config.generalEmulation.hacks |= hack_clearAloneDepthBuffer;
 	else if (strstr(RSP.romname, (const char *)"STARCRAFT 64") != nullptr)
 		config.generalEmulation.hacks |= hack_StarCraftBackgrounds;
-	else if (strstr(RSP.romname, (const char *)"POKEMON STADIUM 2") != nullptr ||
-			 strstr(RSP.romname, (const char *)"Bottom of the 9th") != nullptr)
-		config.generalEmulation.hacks |= hack_texrect_shade_alpha;
 	else if (strstr(RSP.romname, (const char *)"THE LEGEND OF ZELDA") != nullptr ||
 			 strstr(RSP.romname, (const char *)"ZELDA MASTER QUEST") != nullptr)
 		config.generalEmulation.hacks |= hack_subscreen | hack_ZeldaMonochrome;

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -863,13 +863,6 @@ void gDPTextureRectangle(f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, s16 s, s1
 	if (s == 0x4000 && (gDP.colorImage.width + gSP.textureTile[0]->uls < 512))
 		s = 0;
 
-	gDP.rectColor = gDPInfo::Color();
-	if (gDP.otherMode.cycleType < G_CYC_COPY) {
-		if ((config.generalEmulation.hacks & hack_texrect_shade_alpha) != 0 &&
-			gDP.combine.mA0 == G_ACMUX_0 && gDP.combine.aA0 == G_ACMUX_SHADE)
-			gDP.rectColor.a = 1.0f;
-	}
-
 	GraphicsDrawer & drawer = dwnd().getDrawer();
 	GraphicsDrawer::TexturedRectParams params(ulx, uly, lrx, lry, dsdx, dtdy, s, t,
 		flip, false, true, frameBufferList().getCurrent());


### PR DESCRIPTION
This hack was added for #721 and Bottom of the 9th title screen. It is not needed anymore.