### PR TITLE
Allow to set custom platform toolset from commands

### DIFF
--- a/projects/msvc/GLideN64.vcxproj
+++ b/projects/msvc/GLideN64.vcxproj
@@ -63,7 +63,7 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/projects/msvc/GLideNUI-wtl.vcxproj
+++ b/projects/msvc/GLideNUI-wtl.vcxproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolSet>$(DefaultPlatformToolset)</PlatformToolSet>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
     <CharacterSet>NotSet</CharacterSet>
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/projects/msvc/GLideNUI.vcxproj
+++ b/projects/msvc/GLideNUI.vcxproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolSet>$(DefaultPlatformToolset)</PlatformToolSet>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
     <CharacterSet>NotSet</CharacterSet>
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/projects/msvc/libGLideNHQ.vcxproj
+++ b/projects/msvc/libGLideNHQ.vcxproj
@@ -32,7 +32,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolSet>$(DefaultPlatformToolset)</PlatformToolSet>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/projects/msvc/osal.vcxproj
+++ b/projects/msvc/osal.vcxproj
@@ -30,7 +30,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolSet>$(DefaultPlatformToolset)</PlatformToolSet>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/projects/msvc/ticpp.vcxproj
+++ b/projects/msvc/ticpp.vcxproj
@@ -44,7 +44,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolSet>$(DefaultPlatformToolset)</PlatformToolSet>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/projects/msvc/ts2lang.vcxproj
+++ b/projects/msvc/ts2lang.vcxproj
@@ -30,7 +30,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolSet>$(DefaultPlatformToolset)</PlatformToolSet>
+    <PlatformToolSet Condition="'$(PlatformToolset)'=='' or '$(PlatformToolset)'=='v100'">$(DefaultPlatformToolset)</PlatformToolSet>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Example in VS2019 with support for VS2017 and Windows Server 2003 x64:
```
msbuild projects\msvc\GLideNUI.vcxproj /m /p:Configuration=Release;Platform=x64;PlatformToolset=v141_xp
msbuild projects\msvc\GLideN64.sln /m /p:Configuration=Release_qt;Platform=x64;PlatformToolset=v141_xp
```