### PR TITLE
copyDepthToRDRAM=0 for Pokemon Stadium

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -196,6 +196,10 @@ frameBufferEmulation\copyAuxToRDRAM=1
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\fbInfoDisabled=0
 
+[POKEMON%20STADIUM]
+Good_Name=Pokemon Stadium (U)
+frameBufferEmulation\copyDepthToRDRAM=0
+
 [POKEMON%20STADIUM%202]
 Good_Name=Pokemon Stadium 2 (E)(F)(G)(I)(J)(S)(U)
 frameBufferEmulation\copyToRDRAM=0


### PR DESCRIPTION
Fixes https://github.com/gonetz/GLideN64/issues/2290