### PR TITLE
Fix egl intel

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -36,9 +36,9 @@ void ColorBufferReaderWithEGLImage::_initBuffers()
 		m_image = eglCreateImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_NO_CONTEXT,
 			EGL_NATIVE_BUFFER_ANDROID, m_hardwareBuffer.getClientBuffer(), eglImgAttrs);
 
-		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_EXTERNAL_OES), m_pTexture->name);
-		glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, m_image);
-		m_bindTexture->bind(graphics::Parameter(0), graphics::Parameter(GL_TEXTURE_EXTERNAL_OES), ObjectHandle());
+		m_bindTexture->bind(graphics::Parameter(0), textureTarget::TEXTURE_EXTERNAL, m_pTexture->name);
+		glEGLImageTargetTexture2DOES(GLenum(textureTarget::TEXTURE_EXTERNAL), m_image);
+		m_bindTexture->bind(graphics::Parameter(0), textureTarget::TEXTURE_EXTERNAL, ObjectHandle());
 	}
 }
 

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -3,6 +3,8 @@
 #include "opengl_Utils.h"
 #include "opengl_GLInfo.h"
 #include <regex>
+#include <Graphics/Parameters.h>
+
 #ifdef EGL
 #include <EGL/egl.h>
 #endif
@@ -167,6 +169,10 @@ void GLInfo::init() {
 	        ( (isGLES2 && GraphicBufferWrapper::isSupportAvailable()) || (isGLESX && GraphicBufferWrapper::isPublicSupportAvailable()) ) &&
 		    (renderer != Renderer::PowerVR);
 #endif
+
+	if (renderer == Renderer::Intel) {
+		graphics::textureTarget::TEXTURE_EXTERNAL = GL_TEXTURE_2D;
+	}
 
 	eglImageFramebuffer = eglImage && !isGLES2;
 


### PR DESCRIPTION
I discovered just now in my chromebook which run Android  apps, that EGL image is not working correctly with Intel GPUs. This pull request corrects that.

Mainly, it seems that Intel GPUs prefer GL_TEXTURE_2D over GL_TEXTURE_EXTERNAL_OES.