### PR TITLE
Protect against addressing nullptr

### DIFF
--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -896,7 +896,8 @@ void gDPFullSync()
 	frameBufferList().updateCurrentBufferEndAddress();
 
 	FrameBuffer * pCurrentBuffer = frameBufferList().getCurrent();
-	pCurrentBuffer->copyDepthTexture();
+	if (pCurrentBuffer != nullptr)
+		pCurrentBuffer->copyDepthTexture();
 	if ((config.frameBufferEmulation.copyToRDRAM != Config::ctDisable || (config.generalEmulation.hacks & hack_subscreen) != 0) &&
 		!FBInfo::fbInfo.isSupported() &&
 		pCurrentBuffer != nullptr &&


### PR DESCRIPTION
If you run Perfect Dark and watch this pointer, you'll see that it is a nullptr right at the launch of the game. Putting this is place to protect against crashes.