### PR TITLE
Fix: Replace ":" with "-" in Rom Names for textures

### DIFF
--- a/src/GLideNHQ/TxFilter.cpp
+++ b/src/GLideNHQ/TxFilter.cpp
@@ -129,6 +129,11 @@ TxFilter::TxFilter(int maxwidth,
 	if (ident && wcscmp(ident, wst("DEFAULT")) != 0)
 		_ident.assign(ident);
 
+	/* replace : in rom names with -*/
+	std::wstring replace = L"-";
+	for (size_t pos = _ident.find(':'); pos != std::string::npos; pos = _ident.find(':', pos))
+		_ident.replace(pos, 1, replace);
+
 	if (TxMemBuf::getInstance()->init(_maxwidth, _maxheight)) {
 		if (!_tex1)
 			_tex1 = TxMemBuf::getInstance()->get(0);


### PR DESCRIPTION
Replace colons with dashes to fix rom dumping for games like "Turok 3: Shadow of Oblivion". Reuses code from Config_mupenplus.cpp to replace characters in _ident.

I have tested both dumping and loading with Turok 2, Turok 3, and Turok Rage Wars. Everything seems to work fine.

I've kept the replacement quite literal, e.g. "Turok: Rage Wars" becomes "Turok- Rage Wars", so perhaps adding a space would be good.

This should close the following issue: https://github.com/gonetz/GLideN64/issues/2062