### PR TITLE
Fix too small threaded OpenGL buffers in some games

### DIFF
--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_WrappedFunctions.cpp
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_WrappedFunctions.cpp
@@ -2,8 +2,8 @@
 
 namespace opengl {
 
-	std::vector<char> GlDrawArraysUnbufferedCommand::m_attribsData(2 * 1024 * 1024, 0);
-	std::vector<char> GlDrawElementsUnbufferedCommand::m_attribsData(2 * 1024 * 1024, 0);
+	std::vector<char> GlDrawArraysUnbufferedCommand::m_attribsData(15 * 1024 * 1024, 0);
+	std::vector<char> GlDrawElementsUnbufferedCommand::m_attribsData(15 * 1024 * 1024, 0);
 	GLenum GlMapBufferRangeWriteAsyncCommand::m_targetTemp;
 	GLintptr GlMapBufferRangeWriteAsyncCommand::m_offsetTemp;
 	GLsizeiptr GlMapBufferRangeWriteAsyncCommand::m_lengthTemp;


### PR DESCRIPTION
This is the issue for which @m4xw found a fix for as reported here:

https://github.com/gonetz/GLideN64/issues/2249