### PR TITLE
Removed GLES version check for glBufferStorage, allowing for any device that supports it.

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -67,7 +67,7 @@ void ContextImpl::init()
 	}
 
 	{
-		if ((m_glInfo.isGLESX && (m_glInfo.bufferStorage && m_glInfo.majorVersion * 10 + m_glInfo.minorVersion >= 32)) || !m_glInfo.isGLESX)
+		if ((m_glInfo.isGLESX && m_glInfo.bufferStorage) || !m_glInfo.isGLESX)
 			m_graphicsDrawer.reset(new BufferedDrawer(m_glInfo, m_cachedFunctions->getCachedVertexAttribArray(), m_cachedFunctions->getCachedBindBuffer()));
 		else
 			m_graphicsDrawer.reset(new UnbufferedDrawer(m_glInfo, m_cachedFunctions->getCachedVertexAttribArray()));

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -67,7 +67,7 @@ void ContextImpl::init()
 	}
 
 	{
-		if ((m_glInfo.isGLESX && m_glInfo.bufferStorage) || !m_glInfo.isGLESX)
+		if ((m_glInfo.isGLESX && (m_glInfo.bufferStorage && m_glInfo.drawElementsBaseVertex)) || !m_glInfo.isGLESX)
 			m_graphicsDrawer.reset(new BufferedDrawer(m_glInfo, m_cachedFunctions->getCachedVertexAttribArray(), m_cachedFunctions->getCachedBindBuffer()));
 		else
 			m_graphicsDrawer.reset(new UnbufferedDrawer(m_glInfo, m_cachedFunctions->getCachedVertexAttribArray()));

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -100,6 +100,8 @@ void GLInfo::init() {
 		config.generalEmulation.enableHybridFilter = 0;
 	}
 
+	drawElementsBaseVertex = !isGLESX || Utils::isExtensionSupported(*this, "GL_EXT_draw_elements_base_vertex");
+
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");
 

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -21,6 +21,7 @@ struct GLInfo {
 	bool isGLESX = false;
 	bool imageTextures = false;
 	bool bufferStorage = false;
+	bool drawElementsBaseVertex = false;
 	bool texStorage    = false;
 	bool shaderStorage = false;
 	bool msaa = false;


### PR DESCRIPTION
Tested on RPI4 - please see profile comparison of Goldeneye 64:
https://docs.google.com/spreadsheets/d/1kQ15ra9rFnzVx6Plukck8cEPczf446eRlf1rCKm21FI/edit?usp=sharing

When glBufferStorage is permitted calls to `glDrawArraysUnbuffered` and `glDrawElementsUnbuffered` (highlighted in yellow in first 'before' tab) become calls to `glDrawArrays`, `glDrawRangeElementsBaseVertex` and `glBufferStorage` (highlighted in yellow in the second 'after' tab). The total duration of said calls within each profiling interval (ends highlighted in red) are reduced in the 'after' scenario:

1.009887 (before) vs 0.7056322 (after)
0.739989 vs 0.565734

Please verify that I am comparing the right calls! This is based on conversations starting here: https://github.com/gonetz/GLideN64/issues/2329#issuecomment-693515664 - tagging @fzurita, @loganmc10 

I have only checked the intro of Goldeneye as it's a game where there's visible slowdown for the pi4. Please let me know if you want me to profile anything else. There was some concern that bufferStorage could cause slowdown, but I searched through the history and that line was introduced here: https://github.com/gonetz/GLideN64/commit/a625225323c902b614ed9601143df3bc51550fc4, and there's some related comments, but nothing that specifically indicates this will cause slowdown in devices that support it.

Thanks :)