### PR TITLE
Introduce pluginNameWithRevision

### DIFF
--- a/src/GLideN64.cpp
+++ b/src/GLideN64.cpp
@@ -1,3 +1,5 @@
+#include "Revision.h"
 char pluginName[] = "GLideN64";
+char pluginNameWithRevision[] = "GLideN64 rev." PLUGIN_REVISION;
 wchar_t pluginNameW[] = L"GLideN64";
 void (*CheckInterrupts)( void );

--- a/src/GLideN64.h
+++ b/src/GLideN64.h
@@ -2,6 +2,7 @@
 #define GLIDEN64_H
 
 extern char	pluginName[];
+extern char	pluginNameWithRevision[];
 extern wchar_t	pluginNameW[];
 extern void (*CheckInterrupts)( void );
 

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -145,7 +145,7 @@ m64p_error PluginAPI::PluginGetVersion(
 		*_APIVersion = VIDEO_PLUGIN_API_VERSION;
 
 	if (_PluginNamePtr != nullptr)
-		*_PluginNamePtr = pluginName;
+		*_PluginNamePtr = pluginNameWithRevision;
 
 	if (_Capabilities != nullptr)
 	{

--- a/src/windows/ZilmarAPIImpl_windows.cpp
+++ b/src/windows/ZilmarAPIImpl_windows.cpp
@@ -28,7 +28,7 @@ void PluginAPI::GetDllInfo(PLUGIN_INFO * PluginInfo)
 {
 	PluginInfo->Version = 0x103;
 	PluginInfo->Type = PLUGIN_TYPE_GFX;
-	sprintf(PluginInfo->Name, "%s rev.%s", pluginName, PLUGIN_REVISION);
+	sprintf(PluginInfo->Name, "%s", pluginNameWithRevision);
 	PluginInfo->NormalMemory = FALSE;
 	PluginInfo->MemoryBswaped = TRUE;
 }


### PR DESCRIPTION
This PR embeds the revision into mupen64plus' `*_PluginNamePtr` the same Zilmar spec's `PluginInfo->Name` has it.

the goal is to display what revision GLideN64 is, so that the user can easily distinguish the revisions because before this PR, if you have multiple GLideN64 dll/so files, it'll list `GLideN64` multiple times here:

![image](https://user-images.githubusercontent.com/18737914/99078887-6c3f4880-25bf-11eb-8553-3cb9a631e155.png)
