### PR TITLE
Fix build error and warning with Android

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
+++ b/src/Graphics/OpenGLContext/opengl_BufferManipulationObjectFactory.cpp
@@ -311,7 +311,7 @@ struct FramebufferTextureFormatsGLES3 : public graphics::FramebufferTextureForma
 
 #ifdef OS_ANDROID
 		// If EGL image support is available, override above
-		if (m_glinfo.eglImage) {
+		if (_glinfo.eglImage) {
 			colorInternalFormat = GL_RGBA8;
 			colorFormat = GL_RGBA;
 			colorType = GL_UNSIGNED_BYTE;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1408,6 +1408,8 @@ void TextureCache::activateTexture(u32 _t, CachedTexture *_pTexture)
 				case DrawingState::ScreenSpaceTriangle:
 					params.maxAnisotropy = Parameter(config.texture.maxAnisotropyF);
 					break;
+				default:
+					break;
 			}
 		}
 	}


### PR DESCRIPTION
The Android build broke during the last few commits. This fixes the error and one warning that has been around for a while.