### PR TITLE
FrameBuffer: fix crash in resolveMultisampledTexture

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -303,6 +303,9 @@ void FrameBuffer::resolveMultisampledTexture(bool _bForce)
 	if (m_resolved && !_bForce)
 		return;
 
+	if (!m_pResolveTexture)
+		return;
+
 	Context::BlitFramebuffersParams blitParams;
 	blitParams.readBuffer = m_FBO;
 	blitParams.drawBuffer = m_resolveFBO;


### PR DESCRIPTION
I can consistently reproduce this crash:
```
Thread 29 "Thread::Emulati" received signal SIGSEGV, Segmentation fault.
FrameBuffer::resolveMultisampledTexture (this=0x7fff909ee920, _bForce=false)
    at /home/rosalie/dev/RMG/Build/Debug/Source/3rdParty/mupen64plus-video-GLideN64/src/FrameBuffer.cpp:315
315             blitParams.dstX1 = m_pResolveTexture->width;
(gdb) p m_pResolveTexture
$1 = (CachedTexture *) 0x0
```
this happens when the user doesn't have a cache yet, the user is in-game and tries to turn MSAA on, this PR fixes the crash.