### PR TITLE
Update GLideN64.custom.ini

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -44,6 +44,7 @@ frameBufferEmulation\copyAuxToRDRAM=1
 [DONKEY%20KONG%2064]
 Good_Name=Donkey Kong 64 (E)(J)(U)
 frameBufferEmulation\copyDepthToRDRAM=1
+frameBufferEmulation\N64DepthCompare=0
 
 [DR.MARIO%2064]
 Good_Name=Dr. Mario 64 (U)


### PR DESCRIPTION
Sorry about that yesterday, going mad, let me try this again. Disabling Depth compare option on DK64 to fix camera bug.