### PR TITLE
Cleanup unneeded code

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -51,7 +51,6 @@ void Config::resetToDefaults()
 	generalEmulation.hacks = 0;
 #if defined(OS_ANDROID) || defined(OS_IOS)
 	generalEmulation.enableFragmentDepthWrite = 0;
-	generalEmulation.enableBlitScreenWorkaround = 0;
 	generalEmulation.forcePolygonOffset = 0;
 	generalEmulation.polygonOffsetFactor = 0.0f;
 	generalEmulation.polygonOffsetUnits = 0.0f;

--- a/src/Config.h
+++ b/src/Config.h
@@ -65,7 +65,6 @@ struct Config
 		u32 enableLegacyBlending;
 		u32 enableHybridFilter;
 		u32 enableFragmentDepthWrite;
-		u32 enableBlitScreenWorkaround;
 		u32 hacks;
 #if defined(OS_ANDROID) || defined(OS_IOS)
 		u32 forcePolygonOffset;

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -314,11 +314,6 @@ ShaderProgram * Context::createGammaCorrectionShader()
 	return m_impl->createGammaCorrectionShader();
 }
 
-ShaderProgram * Context::createOrientationCorrectionShader()
-{
-	return m_impl->createOrientationCorrectionShader();
-}
-
 ShaderProgram * Context::createFXAAShader()
 {
 	return m_impl->createFXAAShader();

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -247,8 +247,6 @@ namespace graphics {
 
 		ShaderProgram * createGammaCorrectionShader();
 
-		ShaderProgram * createOrientationCorrectionShader();
-
 		ShaderProgram * createFXAAShader();
 
 		TextDrawerShaderProgram * createTextDrawerShader();

--- a/src/Graphics/ContextImpl.h
+++ b/src/Graphics/ContextImpl.h
@@ -63,7 +63,6 @@ namespace graphics {
 		virtual ShaderProgram * createTexrectDownscaleCopyShader() = 0;
 		virtual ShaderProgram * createTexrectColorAndDepthDownscaleCopyShader() = 0;
 		virtual ShaderProgram * createGammaCorrectionShader() = 0;
-		virtual ShaderProgram * createOrientationCorrectionShader() = 0;
 		virtual ShaderProgram * createFXAAShader() = 0;
 		virtual TextDrawerShaderProgram * createTextDrawerShader() = 0;
 		virtual void resetShaderProgram() = 0;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -1730,24 +1730,6 @@ public:
 	}
 };
 
-class ShaderFragmentMainEndSpecial : public ShaderPart
-{
-public:
-	ShaderFragmentMainEndSpecial(const opengl::GLInfo & _glinfo)
-	{
-		if (_glinfo.isGLES2) {
-			m_part =
-				"  gl_FragColor = fragColor; \n"
-				"} \n\n"
-				;
-		} else {
-			m_part =
-				"} \n\n"
-				;
-		}
-	}
-};
-
 class ShaderFragmentMainEnd : public ShaderPart
 {
 public:

--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -542,22 +542,6 @@ namespace glsl {
 		}
 	};
 
-	class OrientationCorrection : public ShaderPart
-	{
-	public:
-		OrientationCorrection(const opengl::GLInfo & _glinfo)
-		{
-			m_part =
-				"IN mediump vec2 vTexCoord0;													\n"
-				"uniform sampler2D uTex0;													\n"
-				"OUT lowp vec4 fragColor;													\n"
-				"void main()																\n"
-				"{																			\n"
-				"    fragColor = texture2D(uTex0, vec2(1.0 - vTexCoord0.x, 1.0 - vTexCoord0.y));       \n"
-			;
-		}
-	};
-
 	/*---------------TextDrawerShaderPart-------------*/
 
 	class TextDraw : public ShaderPart
@@ -903,25 +887,6 @@ namespace glsl {
 		}
 	};
 
-	typedef SpecialShader<VertexShaderTexturedRect, OrientationCorrection> OrientationCorrectionShaderBase;
-
-	class OrientationCorrectionShader : public OrientationCorrectionShaderBase
-	{
-	public:
-		OrientationCorrectionShader(const opengl::GLInfo & _glinfo,
-			opengl::CachedUseProgram * _useProgram,
-			const ShaderPart * _vertexHeader,
-			const ShaderPart * _fragmentHeader,
-			const ShaderPart * _fragmentEnd)
-			: OrientationCorrectionShaderBase(_glinfo, _useProgram, _vertexHeader, _fragmentHeader, _fragmentEnd)
-		{
-			m_useProgram->useProgram(m_program);
-			const int texLoc = glGetUniformLocation(GLuint(m_program), "uTex0");
-			glUniform1i(texLoc, 0);
-			m_useProgram->useProgram(graphics::ObjectHandle::null);
-		}
-	};
-
 	/*---------------TexrectDrawerShader-------------*/
 
 	typedef SpecialShader<VertexShaderTexturedRect, TextDraw, graphics::TextDrawerShaderProgram> TextDrawerShaderBase;
@@ -1016,11 +981,6 @@ namespace glsl {
 	graphics::ShaderProgram * SpecialShadersFactory::createGammaCorrectionShader() const
 	{
 		return new GammaCorrectionShader(m_glinfo, m_useProgram, m_vertexHeader, m_fragmentHeader, m_fragmentEnd);
-	}
-
-	graphics::ShaderProgram * SpecialShadersFactory::createOrientationCorrectionShader() const
-	{
-		return new OrientationCorrectionShader(m_glinfo, m_useProgram, m_vertexHeader, m_fragmentHeader, m_fragmentEnd);
 	}
 
 	graphics::ShaderProgram * SpecialShadersFactory::createFXAAShader() const

--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.h
@@ -38,8 +38,6 @@ namespace glsl {
 
 		graphics::ShaderProgram * createGammaCorrectionShader() const;
 
-		graphics::ShaderProgram * createOrientationCorrectionShader() const;
-
 		graphics::ShaderProgram * createFXAAShader() const;
 
 		graphics::TextDrawerShaderProgram * createTextDrawerShader() const;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -450,11 +450,6 @@ graphics::ShaderProgram * ContextImpl::createGammaCorrectionShader()
 	return m_specialShadersFactory->createGammaCorrectionShader();
 }
 
-graphics::ShaderProgram * ContextImpl::createOrientationCorrectionShader()
-{
-	return m_specialShadersFactory->createOrientationCorrectionShader();
-}
-
 graphics::ShaderProgram * ContextImpl::createFXAAShader()
 {
 	return m_specialShadersFactory->createFXAAShader();

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.h
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.h
@@ -134,8 +134,6 @@ namespace opengl {
 
 		graphics::ShaderProgram * createGammaCorrectionShader() override;
 
-		graphics::ShaderProgram * createOrientationCorrectionShader() override;
-
 		graphics::ShaderProgram * createFXAAShader() override;
 
 		graphics::TextDrawerShaderProgram * createTextDrawerShader() override;

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -72,10 +72,6 @@ void PostProcessor::init()
 		m_FXAAProgram.reset(gfxContext.createFXAAShader());
 		m_postprocessingList.emplace_front(std::mem_fn(&PostProcessor::_doFXAA));
 	}
-	if (config.generalEmulation.enableBlitScreenWorkaround != 0) {
-		m_orientationCorrectionProgram.reset(gfxContext.createOrientationCorrectionShader());
-		m_postprocessingList.emplace_front(std::mem_fn(&PostProcessor::_doOrientationCorrection));
-	}
 }
 
 void PostProcessor::destroy()
@@ -83,7 +79,6 @@ void PostProcessor::destroy()
 	m_postprocessingList.clear();
 	m_gammaCorrectionProgram.reset();
 	m_FXAAProgram.reset();
-	m_orientationCorrectionProgram.reset();
 	m_pResultBuffer.reset();
 }
 
@@ -161,17 +156,6 @@ FrameBuffer * PostProcessor::_doGammaCorrection(FrameBuffer * _pBuffer)
 		return _pBuffer;
 
 	return _doPostProcessing(_pBuffer, m_gammaCorrectionProgram.get());
-}
-
-FrameBuffer * PostProcessor::_doOrientationCorrection(FrameBuffer * _pBuffer)
-{
-	if (_pBuffer == nullptr)
-		return nullptr;
-
-	if (config.generalEmulation.enableBlitScreenWorkaround == 0)
-		return _pBuffer;
-
-	return _doPostProcessing(_pBuffer, m_orientationCorrectionProgram.get());
 }
 
 FrameBuffer * PostProcessor::_doFXAA(FrameBuffer * _pBuffer)

--- a/src/PostProcessor.h
+++ b/src/PostProcessor.h
@@ -30,7 +30,6 @@ private:
 	PostProcessor(const PostProcessor & _other) = delete;
 
 	FrameBuffer * _doGammaCorrection(FrameBuffer * _pBuffer);
-	FrameBuffer * _doOrientationCorrection(FrameBuffer * _pBuffer);
 	FrameBuffer * _doFXAA(FrameBuffer * _pBuffer);
 
 	void _createResultBuffer(const FrameBuffer * _pMainBuffer);
@@ -39,7 +38,6 @@ private:
 	FrameBuffer * _doPostProcessing(FrameBuffer * _pBuffer, graphics::ShaderProgram * _pShader);
 
 	std::unique_ptr<graphics::ShaderProgram> m_gammaCorrectionProgram;
-	std::unique_ptr<graphics::ShaderProgram> m_orientationCorrectionProgram;
 	std::unique_ptr<graphics::ShaderProgram> m_FXAAProgram;
 	std::unique_ptr<FrameBuffer> m_pResultBuffer;
 	CachedTexture * m_pTextureOriginal;

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -160,8 +160,6 @@ bool Config_SetDefault()
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableCustomSettings", config.generalEmulation.enableCustomSettings, "Use GLideN64 per-game settings.");
 	assert(res == M64ERR_SUCCESS);
 #if defined(OS_ANDROID) || defined(OS_IOS)
-	res = ConfigSetDefaultBool(g_configVideoGliden64, "EnableBlitScreenWorkaround", config.generalEmulation.enableBlitScreenWorkaround, "Enable to render everything upside down");
-	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "ForcePolygonOffset", config.generalEmulation.forcePolygonOffset, "If true, use polygon offset values specified below");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultFloat(g_configVideoGliden64, "PolygonOffsetFactor", config.generalEmulation.polygonOffsetFactor, "Specifies a scale factor that is used to create a variable depth offset for each polygon");
@@ -491,7 +489,6 @@ void Config_LoadConfig()
 	config.generalEmulation.enableFragmentDepthWrite = ConfigGetParamBool(g_configVideoGliden64, "EnableFragmentDepthWrite");
 	config.generalEmulation.enableCustomSettings = ConfigGetParamBool(g_configVideoGliden64, "EnableCustomSettings");
 #if defined(OS_ANDROID) || defined(OS_IOS)
-	config.generalEmulation.enableBlitScreenWorkaround = ConfigGetParamBool(g_configVideoGliden64, "EnableBlitScreenWorkaround");
 	config.generalEmulation.forcePolygonOffset = ConfigGetParamBool(g_configVideoGliden64, "ForcePolygonOffset");
 	config.generalEmulation.polygonOffsetFactor = ConfigGetParamFloat(g_configVideoGliden64, "PolygonOffsetFactor");
 	config.generalEmulation.polygonOffsetUnits = ConfigGetParamFloat(g_configVideoGliden64, "PolygonOffsetUnits");


### PR DESCRIPTION
The blit screen workaround is not needed for modern Android devices, and old Android devices that support GLideN64 and need the workaround are too slow to run GLideN64 at playable speeds.

Also, there was some code that was left over when adding the frame buffer fetch extension that wasn't needed and should be cleaned up.