### PR TITLE
Disable draw_elements_base_vertex with PowerVR

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -104,7 +104,9 @@ void GLInfo::init() {
 		config.generalEmulation.enableHybridFilter = 0;
 	}
 
-	drawElementsBaseVertex = !isGLESX || Utils::isExtensionSupported(*this, "GL_EXT_draw_elements_base_vertex");
+	drawElementsBaseVertex = !isGLESX ||
+		(Utils::isExtensionSupported(*this, "GL_EXT_draw_elements_base_vertex") && (renderer != Renderer::PowerVR ||
+		numericVersion >= 32));
 
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");


### PR DESCRIPTION
Disable "draw_elements_base_vertex" extension if renderer is PowerVR and GLES is < 3.2.

This will allow the extension to work if the PowerVR GPU supports GLES 3.2.