### PR TITLE
GLideNUI: correct macro in saveCustomRomSettings

### DIFF
--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -396,8 +396,8 @@ void saveCustomRomSettings(const QString & _strIniFolder, const char * _strRomNa
 		origConfig.G.S != settings.value(#S, config.G.S).toFloat()) \
 		settings.setValue(#S, config.G.S)
 #define WriteCustomSettingS(S) \
-	const QString new##S = QString::fromWCharArray(config.textureFilter.txPath); \
-	const QString orig##S = QString::fromWCharArray(origConfig.textureFilter.txPath); \
+	const QString new##S = QString::fromWCharArray(config.textureFilter.S); \
+	const QString orig##S = QString::fromWCharArray(origConfig.textureFilter.S); \
 	if (orig##S  != new##S || \
 		orig##S != settings.value(#S, new##S).toString()) \
 		settings.setValue(#S, new##S)


### PR DESCRIPTION
This fixes per-game ROM settings texture directories:

to reproduce the issue:
1) delete `GLideN64.ini`
2) open a game
3) enable texture pack for said game & configure directories
4) re-open config dialog

![image](https://user-images.githubusercontent.com/18737914/102831395-ff07aa00-43eb-11eb-9cd0-489761aee8a1.png)
