### PR TITLE
Implement linux support for OSD font settings

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -9,6 +9,7 @@
 #include <QCursor>
 #include <QRegExpValidator>
 #include <QInputDialog>
+#include <QDirIterator>
 
 #include "../Config.h"
 #include "../DebugDump.h"
@@ -932,15 +933,15 @@ void ConfigDialog::on_tabWidget_currentChanged(int tab)
 		ui->tabWidget->setCursor(QCursor(Qt::WaitCursor));
 
 		QMap<QString, QStringList> internalFontList;
-		QDir fontDir(QStandardPaths::locate(QStandardPaths::FontsLocation, QString(), QStandardPaths::LocateDirectory));
+		QString fontDir = QStandardPaths::locate(QStandardPaths::FontsLocation, QString(), QStandardPaths::LocateDirectory);
 		QStringList fontFilter;
 		fontFilter << "*.ttf";
-		fontDir.setNameFilters(fontFilter);
-		QFileInfoList fontList = fontDir.entryInfoList();
-		for (int i = 0; i < fontList.size(); ++i) {
-			int id = QFontDatabase::addApplicationFont(fontList.at(i).absoluteFilePath());
+		QDirIterator fontIt(fontDir, fontFilter, QDir::Files, QDirIterator::Subdirectories);
+		while (fontIt.hasNext()) {
+			QString font = fontIt.next();
+			int id = QFontDatabase::addApplicationFont(font);
 			QString fontListFamily = QFontDatabase::applicationFontFamilies(id).at(0);
-			internalFontList[fontListFamily].append(fontList.at(i).fileName());
+			internalFontList[fontListFamily].append(font);
 		}
 
 		QMap<QString, QStringList>::const_iterator i;

--- a/src/TextDrawer.cpp
+++ b/src/TextDrawer.cpp
@@ -25,9 +25,10 @@
 
 #include "TextDrawer.h"
 
+#include <osal_files.h>
+
 #ifdef MUPENPLUSAPI
 #include "mupenplus/GLideN64_mupenplus.h"
-#include <osal_files.h>
 #endif
 
 using namespace graphics;
@@ -212,6 +213,12 @@ bool getFontFileName(char * _strName)
 #else
 	sprintf(_strName, "/usr/share/fonts/truetype/freefont/%s", config.font.name.c_str());
 #endif
+
+	// if the font name is a full path, use that instead
+	if (osal_path_existsA(config.font.name.c_str())) {
+		sprintf(_strName, "%s", config.font.name.c_str());
+	}
+
 #ifdef MUPENPLUSAPI
 	if (!osal_path_existsA(_strName)) {
 		const char * fontPath = ConfigGetSharedDataFilepath("font.ttf");


### PR DESCRIPTION
This PR implements linux support for the font settings in the OSD tab, to accomplish this I needed to change 2 things

1) use `QDirIterator` instead of `fontDir.entryInfoList()` because on linux fonts are in subdirectories
2) allow `config.font.name` to contain the full path to the font

the only downside is that it uses the full path to the fonts now instead of the base filename (in `config.font.name`), this is sadly needed for linux support though but I could make it a linux-only codepath if you want.

here's what it looks like after this PR:

![image](https://user-images.githubusercontent.com/18737914/102881928-e0d29600-444d-11eb-9ac0-6226957f36c6.png)


and here's what it looked like before this PR:

![image](https://user-images.githubusercontent.com/18737914/102882235-5e96a180-444e-11eb-91af-f5f28ab297be.png)

