### PR TITLE
Fix shader storage when hardware lighting is enabled

### DIFF
--- a/src/Combiner.h
+++ b/src/Combiner.h
@@ -91,7 +91,6 @@
 #define G_GCI_ZERO				20
 #define G_GCI_HALF				21
 #define G_GCI_HW_LIGHT			22
-#define G_GCI_HW_LIGHT			22
 #define G_GCI_LAST				23
 
 struct CombinerOp

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,8 +20,8 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x30U;
-		const u32 m_keysFormatVersion = 0x04;
+		const u32 m_formatVersion = 0x31U;
+		const u32 m_keysFormatVersion = 0x05;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;
 	};


### PR DESCRIPTION
This is a fix for https://github.com/gonetz/GLideN64/issues/2418.

As currently implemented, shader storage does not seem to compile keys correctly if the microcode changes in the middle of a game when the previous keys were generated.