### PR TITLE
Compile shader from keys if shader storage binary is invalid

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.cpp
@@ -202,12 +202,10 @@ bool ShaderStorage::saveShadersStorage(const graphics::Combiners & _combiners) c
 
 static
 CombinerProgramImpl * _readCombinerProgramFromStream(std::istream & _is,
+	CombinerKey& _cmbKey,
 	CombinerProgramUniformFactory & _uniformFactory,
 	opengl::CachedUseProgram * _useProgram)
 {
-	CombinerKey cmbKey;
-	cmbKey.read(_is);
-
 	int inputs;
 	_is.read((char*)&inputs, sizeof(inputs));
 	CombinerInputs cmbInputs(inputs);
@@ -220,15 +218,17 @@ CombinerProgramImpl * _readCombinerProgramFromStream(std::istream & _is,
 	_is.read(binary.data(), binaryLength);
 
 	GLuint program = glCreateProgram();
-	const bool isRect = cmbKey.isRectKey();
+	const bool isRect = _cmbKey.isRectKey();
 	glsl::Utils::locateAttributes(program, isRect, cmbInputs.usesTexture());
 	glProgramBinary(program, binaryFormat, binary.data(), binaryLength);
-	assert(glsl::Utils::checkProgramLinkStatus(program));
+	if (!glsl::Utils::checkProgramLinkStatusRequired(program)) {
+		return nullptr;
+	}
 
 	UniformGroups uniforms;
-	_uniformFactory.buildUniforms(program, cmbInputs, cmbKey, uniforms);
+	_uniformFactory.buildUniforms(program, cmbInputs, _cmbKey, uniforms);
 
-	return new CombinerProgramImpl(cmbKey, program, _useProgram, cmbInputs, std::move(uniforms));
+	return new CombinerProgramImpl(_cmbKey, program, _useProgram, cmbInputs, std::move(uniforms));
 }
 
 bool ShaderStorage::_loadFromCombinerKeys(graphics::Combiners & _combiners)
@@ -344,9 +344,21 @@ bool ShaderStorage::loadShadersStorage(graphics::Combiners & _combiners)
 		f32 progress = 0.0f;
 		f32 percents = percent;
 		for (u32 i = 0; i < len; ++i) {
-			CombinerProgramImpl * pCombiner = _readCombinerProgramFromStream(fin, uniformFactory, m_useProgram);
-			pCombiner->update(true);
-			_combiners[pCombiner->getKey()] = pCombiner;
+			CombinerKey cmbKey;
+			cmbKey.read(fin);
+
+			CombinerProgramImpl * pCombiner = _readCombinerProgramFromStream(fin, cmbKey, uniformFactory, m_useProgram);
+
+			if (pCombiner != nullptr) {
+				pCombiner->update(true);
+				_combiners[pCombiner->getKey()] = pCombiner;
+			} else {
+				LOG(LOG_ERROR, "Shader is not a valid binary compiling from key instead");
+				graphics::CombinerProgram *pCombinerFromKey = Combiner_Compile(cmbKey);
+				pCombinerFromKey->update(true);
+				_combiners[cmbKey] = pCombinerFromKey;
+			}
+
 			progress += step;
 			if (progress > percents) {
 				displayLoadProgress(L"LOAD COMBINER SHADERS %.1f%%", f32(i + 1) * 100.f / f32(len) );

--- a/src/Graphics/OpenGLContext/GLSL/glsl_Utils.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_Utils.cpp
@@ -55,6 +55,13 @@ bool Utils::checkShaderCompileStatus(GLuint obj)
 bool Utils::checkProgramLinkStatus(GLuint obj)
 {
 #ifdef GL_DEBUG
+	checkProgramLinkStatusRequired(obj);
+#endif
+	return true;
+}
+
+bool Utils::checkProgramLinkStatusRequired(GLuint obj)
+{
 	GLint status;
 	glGetProgramiv(obj, GL_LINK_STATUS, &status);
 	if (status == GL_FALSE) {
@@ -64,7 +71,6 @@ bool Utils::checkProgramLinkStatus(GLuint obj)
 		LOG(LOG_ERROR, "shader_link error: %s", shader_log);
 		return false;
 	}
-#endif
 	return true;
 }
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_Utils.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_Utils.h
@@ -9,6 +9,7 @@ namespace glsl {
 		static void locateAttributes(GLuint _program, bool _rect, bool _textures);
 		static bool checkShaderCompileStatus(GLuint obj);
 		static bool checkProgramLinkStatus(GLuint obj);
+		static bool checkProgramLinkStatusRequired(GLuint obj);
 		static void logErrorShader(GLenum _shaderType, const std::string & _strShader);
 		static GLuint createRectShaderProgram(const char * _strVertex, const char * _strFragment);
 


### PR DESCRIPTION
In one of my low end devices, probably due to some driver bug, the binary shaders being produced can't be loaded. I can see when this happens when the shader fails to link.

I had to take the shader error checks out of the GL_DEBUG macro since I can't check for link errors otherwise. I don't see any worse stuttering when a shader is compiling due to checking for the errors.