### PR TITLE
Fix incorrect width used for sync color buffer reads with EGLImage

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -58,7 +58,7 @@ const u8 * ColorBufferReaderWithEGLImage::_readPixels(const ReadColorBufferParam
 		_stride = m_pTexture->width;
 	} else {
 		gpuData = m_pixelData.data();
-		glReadPixels(_params.x0, _params.y0, _params.width, _params.height, format, type, gpuData);
+		glReadPixels(_params.x0, _params.y0,  m_pTexture->width, _params.height, format, type, gpuData);
 		_heightOffset = 0;
 		_stride = m_pTexture->width;
 	}


### PR DESCRIPTION
I found this while doing some unrelated testing.

It fixes: https://github.com/gonetz/GLideN64/issues/2046