### PR TITLE
GLideN64 soft vertex clipping performance improvement for Adreno GPUs

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -725,6 +725,23 @@ private:
 	fUniform uClipRatio;
 };
 
+class UPolygonOffset : public UniformGroup
+{
+public:
+	UPolygonOffset(GLuint _program) {
+		LocateUniform(uPolygonOffset);
+	}
+
+	void update(bool _force) override
+	{
+		f32 offset = gfxContext.isEnabled(graphics::enable::POLYGON_OFFSET_FILL) ? 0.003f : 0.0f;
+		uPolygonOffset.set(offset, _force);
+	}
+
+private:
+	fUniform uPolygonOffset;
+};
+
 class UScreenCoordsScale : public UniformGroup
 {
 public:
@@ -1113,6 +1130,10 @@ void CombinerProgramUniformFactory::buildUniforms(GLuint _program,
 	if (config.generalEmulation.enableFragmentDepthWrite != 0 ||
 		config.frameBufferEmulation.N64DepthCompare != Config::dcDisable)
 		_uniforms.emplace_back(new URenderTarget(_program));
+
+	if (m_glInfo.isGLESX && m_glInfo.noPerspective) {
+		_uniforms.emplace_back(new UPolygonOffset(_program));
+	}
 
 	_uniforms.emplace_back(new UClipRatio(_program));
 


### PR DESCRIPTION
As stated in https://github.com/gonetz/GLideN64/issues/2427, the software vertex clipping has some really bad performance penalties in Adreno GPUs. For example it drops Banjo-Tooie from around 50fps in the opening area to around 27fps. This change restores some of the performance but not all. It's now reaching around 40fps in the same area.

This change essentially restores some of the old code that was used when ```GL_NV_shader_noperspective_interpolation``` minus anything that discards pixels since that is now being done in software.

I tested the usual cases like the zelda slingshot and https://github.com/gonetz/GLideN64/issues/2382 still remains fixed.

I'm not sure why this doesn't have the same performance as the old method that used to discard pixels. Disabling fragment depth write completely brings back the old performance. So it's possible that the extra discards that were happening in the shader were preventing extra depth writes from happening.