### PR TITLE
GLideNHQ: add wildcard support

### DIFF
--- a/src/GLideNHQ/TxFilter.cpp
+++ b/src/GLideNHQ/TxFilter.cpp
@@ -506,7 +506,8 @@ TxFilter::hirestex(uint64 g64crc, uint64 r_crc64, uint16 *palette, GHQTexInfo *i
 
 			return 1; /* yep, got it */
 		}
-		if (_txHiResCache->get((r_crc64 & 0xffffffff), info)) {
+		if (_txHiResCache->get((r_crc64 >> 32), info) ||
+			_txHiResCache->get((r_crc64 & 0xffffffff), info)) {
 			DBG_INFO(80, wst("hires hit: %d x %d gfmt:%x\n"), info->width, info->height, info->format);
 
 			/* for true CI textures, we use the passed in palette to convert to


### PR DESCRIPTION
This patch implements wildcard support.

The problem before this patch is that some games have textures which change `chksum` but have the same `palchksum` (based on in-game location or other factors, note that some games have the reverse problem and only differ in `palchksum`), this causes pain for texture pack creators who need to copy textures only to change the filename.

As an example, take Resident Evil 2 which has `165` different `chksum`s for the same texture while having the exact same `palchksum`.
![image](https://user-images.githubusercontent.com/18737914/106333112-49e8cd00-6288-11eb-819a-f7a431ef0ef3.png)

This is not ideal of course so to resolve the issue this patch allows texture pack creators to replace either `chksum` or `palchksum` in the filename with `$` making everyone's life a bit easier!

![image](https://user-images.githubusercontent.com/18737914/106333299-a21fcf00-6288-11eb-9619-4959a4736175.png)

I'm not sure if you like this implementation but it seems like the simplest way to add this functionality.
