### PR TITLE
Improve the draw elemenets base vertex check

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -105,8 +105,8 @@ void GLInfo::init() {
 	}
 
 	drawElementsBaseVertex = !isGLESX ||
-		(Utils::isExtensionSupported(*this, "GL_EXT_draw_elements_base_vertex") && (renderer != Renderer::PowerVR ||
-		numericVersion >= 32));
+		((Utils::isExtensionSupported(*this, "GL_EXT_draw_elements_base_vertex") && (renderer != Renderer::PowerVR)) ||
+		 numericVersion >= 32);
 
 	bufferStorage = (!isGLESX && (numericVersion >= 44)) || Utils::isExtensionSupported(*this, "GL_ARB_buffer_storage") ||
 			Utils::isExtensionSupported(*this, "GL_EXT_buffer_storage");


### PR DESCRIPTION
No extension is required to use ```glDrawRangeElementsBaseVertex``` for GLES 3.2. In fact, my Adreno devices say that they don't support the extension and have GLES 3.2 and the call works just fine.

See https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glDrawRangeElementsBaseVertex.xhtml

It's part of GL ES 3.2.