### PR TITLE
Fix issue where the barycoords vertex attribute was not being disabled

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_UnbufferedDrawer.cpp
+++ b/src/Graphics/OpenGLContext/opengl_UnbufferedDrawer.cpp
@@ -183,8 +183,11 @@ void UnbufferedDrawer::drawLine(f32 _width, SPVertex * _vertices)
 
 	m_cachedAttribArray->enableVertexAttribArray(triangleAttrib::texcoord, false);
 	m_cachedAttribArray->enableVertexAttribArray(triangleAttrib::modify, false);
-	if (m_useCoverage)
+
+	if (m_useCoverage) {
 		m_cachedAttribArray->enableVertexAttribArray(triangleAttrib::barycoords, false);
+		m_cachedAttribArray->enableVertexAttribArray(rectAttrib::barycoords, false);
+	}
 
 	m_cachedAttribArray->enableVertexAttribArray(rectAttrib::position, false);
 	m_cachedAttribArray->enableVertexAttribArray(rectAttrib::texcoord0, false);


### PR DESCRIPTION
Fix for this:

https://github.com/gonetz/GLideN64/issues/2445

It turned out to not be related to threaded renderer. It just seemed to break randomly end the end.