### PR TITLE
Make software vertex clipping config be part of shader storage config

### DIFF
--- a/src/Graphics/CombinerProgram.cpp
+++ b/src/Graphics/CombinerProgram.cpp
@@ -17,6 +17,7 @@ namespace graphics {
 		vecOptions.push_back(config.generalEmulation.enableDitheringQuantization);
 		vecOptions.push_back(config.generalEmulation.enableLOD);
 		vecOptions.push_back(config.generalEmulation.enableCoverage);
+		vecOptions.push_back(config.generalEmulation.enableClipping);
 		vecOptions.push_back(config.frameBufferEmulation.N64DepthCompare == Config::dcFast ? 1 : 0);
 		vecOptions.push_back(config.frameBufferEmulation.N64DepthCompare == Config::dcCompatible ? 1 : 0);
 		vecOptions.push_back(config.generalEmulation.enableLegacyBlending);

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x31U;
+		const u32 m_formatVersion = 0x32U;
 		const u32 m_keysFormatVersion = 0x05;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;


### PR DESCRIPTION
I discovered while trying to debug https://github.com/gonetz/GLideN64/issues/2449 software vertex clipping is not part of the shader storage saved configuration. This adds it.