### PR TITLE
Fix N64 Depth compare with Adreno

### DIFF
--- a/src/DepthBuffer.cpp
+++ b/src/DepthBuffer.cpp
@@ -320,18 +320,7 @@ void DepthBuffer::activateDepthBufferTexture(FrameBuffer * _pBuffer)
 
 void DepthBuffer::bindDepthImageTexture(ObjectHandle _fbo)
 {
-	if (Context::ImageTextures) {
-		Context::BindImageTextureParameters bindParams;
-		bindParams.imageUnit = textureImageUnits::DepthZ;
-		bindParams.texture = m_pDepthImageZTexture->name;
-		bindParams.accessMode = textureImageAccessMode::READ_WRITE;
-		bindParams.textureFormat = gfxContext.getFramebufferTextureFormats().depthImageInternalFormat;
-		gfxContext.bindImageTexture(bindParams);
-
-		bindParams.imageUnit = textureImageUnits::DepthDeltaZ;
-		bindParams.texture = m_pDepthImageDeltaZTexture->name;
-		gfxContext.bindImageTexture(bindParams);
-	} else if (Context::FramebufferFetchDepth) {
+	if (Context::FramebufferFetchDepth) {
 		Context::FrameBufferRenderTarget targetParams;
 		targetParams.bufferHandle = _fbo;
 		targetParams.bufferTarget = bufferTarget::DRAW_FRAMEBUFFER;
@@ -345,6 +334,17 @@ void DepthBuffer::bindDepthImageTexture(ObjectHandle _fbo)
 		gfxContext.addFrameBufferRenderTarget(targetParams);
 
 		gfxContext.setDrawBuffers(3);
+	} else if (Context::ImageTextures) {
+		Context::BindImageTextureParameters bindParams;
+		bindParams.imageUnit = textureImageUnits::DepthZ;
+		bindParams.texture = m_pDepthImageZTexture->name;
+		bindParams.accessMode = textureImageAccessMode::READ_WRITE;
+		bindParams.textureFormat = gfxContext.getFramebufferTextureFormats().depthImageInternalFormat;
+		gfxContext.bindImageTexture(bindParams);
+
+		bindParams.imageUnit = textureImageUnits::DepthDeltaZ;
+		bindParams.texture = m_pDepthImageDeltaZTexture->name;
+		gfxContext.bindImageTexture(bindParams);
 	}
 }
 

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -40,7 +40,7 @@ void Context::init()
 	ImageTextures = m_impl->isSupported(SpecialFeatures::ImageTextures);
 	IntegerTextures = m_impl->isSupported(SpecialFeatures::IntegerTextures);
 	ClipControl = m_impl->isSupported(SpecialFeatures::ClipControl);
-	FramebufferFetchDepth = m_impl->isSupported(SpecialFeatures::FramebufferFetchDepth);
+	FramebufferFetchDepth = m_impl->isSupported(SpecialFeatures::N64DepthWithFbFetchDepth);
 	FramebufferFetchColor = m_impl->isSupported(SpecialFeatures::FramebufferFetchColor);
 	TextureBarrier = m_impl->isSupported(SpecialFeatures::TextureBarrier);
 	EglImage = m_impl->isSupported(SpecialFeatures::EglImage);

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -24,7 +24,7 @@ namespace graphics {
 		ImageTextures,
 		IntegerTextures,
 		ClipControl,
-		FramebufferFetchDepth,
+		N64DepthWithFbFetchDepth,
 		FramebufferFetchColor,
 		TextureBarrier,
 		EglImage,

--- a/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_ShaderStorage.h
@@ -20,7 +20,7 @@ namespace glsl {
 		bool _saveCombinerKeys(const graphics::Combiners & _combiners) const;
 		bool _loadFromCombinerKeys(graphics::Combiners & _combiners);
 
-		const u32 m_formatVersion = 0x32U;
+		const u32 m_formatVersion = 0x33U;
 		const u32 m_keysFormatVersion = 0x05;
 		const opengl::GLInfo & m_glinfo;
 		opengl::CachedUseProgram * m_useProgram;

--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -68,10 +68,10 @@ namespace glsl {
 				;
 
 			if (config.frameBufferEmulation.N64DepthCompare != Config::dcDisable) {
-				if (_glinfo.imageTextures)
+				if (_glinfo.imageTextures && !_glinfo.n64DepthWithFbFetch)
 					m_part += "layout(binding = 2, r32f) highp uniform restrict readonly image2D uDepthImageZ;		\n";
 
-				if (_glinfo.ext_fetch) {
+				if (_glinfo.n64DepthWithFbFetch) {
 					m_part +=
 						"layout(location = 0) OUT lowp vec4 fragColor;	\n"
 						"layout(location = 1) inout highp vec4 depthZ;	\n"
@@ -100,14 +100,14 @@ namespace glsl {
 			} else {
 				// Either _glinfo.imageTextures or _glinfo.ext_fetch must be enabled when N64DepthCompare != 0
 				// see GLInfo::init()
-				if (_glinfo.imageTextures) {
+				if (_glinfo.n64DepthWithFbFetch) {
+					m_part +=
+						"  highp float bufZ = depthZ.r;	\n"
+						;
+				} else if (_glinfo.imageTextures) {
 					m_part +=
 						"  mediump ivec2 coord = ivec2(gl_FragCoord.xy);	\n"
 						"  highp float bufZ = imageLoad(uDepthImageZ,coord).r;	\n"
-						;
-				} else if (_glinfo.ext_fetch) {
-					m_part +=
-						"  highp float bufZ = depthZ.r;	\n"
 						;
 				}
 			}

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -513,8 +513,8 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return !m_glInfo.isGLES2;
 	case graphics::SpecialFeatures::ClipControl:
 		return !m_glInfo.isGLESX;
-	case graphics::SpecialFeatures::FramebufferFetchDepth:
-		return m_glInfo.ext_fetch;
+	case graphics::SpecialFeatures::N64DepthWithFbFetchDepth:
+		return m_glInfo.n64DepthWithFbFetch;
 	case graphics::SpecialFeatures::FramebufferFetchColor:
 		return m_glInfo.ext_fetch || m_glInfo.ext_fetch_arm;
 	case graphics::SpecialFeatures::TextureBarrier:

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -169,7 +169,8 @@ void GLInfo::init() {
 	texture_barrier = !isGLESX && (numericVersion >= 45 || Utils::isExtensionSupported(*this, "GL_ARB_texture_barrier"));
 	texture_barrierNV = Utils::isExtensionSupported(*this, "GL_NV_texture_barrier");
 
-	ext_fetch = Utils::isExtensionSupported(*this, "GL_EXT_shader_framebuffer_fetch") && !isGLES2 && (!isGLESX || ext_draw_buffers_indexed) && !imageTexturesInterlock;
+	ext_fetch = Utils::isExtensionSupported(*this, "GL_EXT_shader_framebuffer_fetch") && (!isGLESX || ext_draw_buffers_indexed);
+	n64DepthWithFbFetch = ext_fetch && !imageTexturesInterlock;
 	eglImage = (Utils::isEGLExtensionSupported("EGL_KHR_image_base") || Utils::isEGLExtensionSupported("EGL_KHR_image"));
 	ext_fetch_arm =  Utils::isExtensionSupported(*this, "GL_ARM_shader_framebuffer_fetch") && !ext_fetch;
 
@@ -189,7 +190,7 @@ void GLInfo::init() {
 
 	if (config.frameBufferEmulation.N64DepthCompare != Config::dcDisable) {
 		if (config.frameBufferEmulation.N64DepthCompare == Config::dcFast) {
-			if (!imageTexturesInterlock && !ext_fetch) {
+			if (!imageTexturesInterlock && !n64DepthWithFbFetch) {
 				config.frameBufferEmulation.N64DepthCompare = Config::dcDisable;
 				LOG(LOG_WARNING, "Your GPU does not support the extensions needed for fast N64 Depth Compare.");
 			}

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -35,6 +35,7 @@ struct GLInfo {
 	bool fragment_ordering = false;
 	bool ext_fetch = false;
 	bool ext_fetch_arm = false;
+	bool n64DepthWithFbFetch = false;
 	bool eglImage = false;
 	bool eglImageFramebuffer = false;
 	bool dual_source_blending = false;


### PR DESCRIPTION
Mainly check for FB fetch extension to be present before image textures. This should be tried in PC to make sure I didn't break anything there.

This is a fix for https://github.com/gonetz/GLideN64/issues/2459