### PR TITLE
Don't allow EGL image on tegra devices

### DIFF
--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -179,7 +179,7 @@ void GLInfo::init() {
 #ifdef OS_ANDROID
 	eglImage = eglImage &&
 	        ( (isGLES2 && GraphicBufferWrapper::isSupportAvailable()) || (isGLESX && GraphicBufferWrapper::isPublicSupportAvailable()) ) &&
-		    (renderer != Renderer::PowerVR);
+		    (renderer != Renderer::PowerVR) && (renderer != Renderer::Tegra);
 #endif
 
 	if (renderer == Renderer::Intel) {


### PR DESCRIPTION
EGL image support has never really worked with tegra devices. This support appears to be getting used currently on a small number of devices that use GLES on Tegra (Nintendo switch).