### PR TITLE
Fix N64 Depth Compare on Intel PC

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -559,7 +559,7 @@ public:
 			std::stringstream ss;
 			ss << "#version " << Utils::to_string(_glinfo.majorVersion) << Utils::to_string(_glinfo.minorVersion) << "0 core " << std::endl;
 			if (config.frameBufferEmulation.N64DepthCompare != Config::dcDisable) {
-				if (_glinfo.ext_fetch)
+				if (_glinfo.n64DepthWithFbFetch)
 					ss << "#extension GL_EXT_shader_framebuffer_fetch : enable" << std::endl;
 				else if (_glinfo.imageTextures) {
 					if (_glinfo.majorVersion * 10 + _glinfo.minorVersion < 42) {


### PR DESCRIPTION
Fixes an issue reported to me here: https://github.com/loganmc10/m64p/issues/148

I can reproduce this on my Windows 10 PC with an Intel GPU

Broken since: https://github.com/gonetz/GLideN64/pull/2460 . This was just the result of one of the if statements not being updated properly during that PR