### PR TITLE
Stop using predefined texture sizes introduced for Android

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -12,17 +12,6 @@
 #include "Log.h"
 #include "MemoryStatus.h"
 
-/*
-#include "ColorBufferToRDRAM_GL.h"
-#include "ColorBufferToRDRAM_BufferStorageExt.h"
-#elif defined(OS_ANDROID) && defined (GLES2)
-#include "ColorBufferToRDRAM_GL.h"
-#include "ColorBufferToRDRAM_GLES.h"
-#else
-#include "ColorBufferToRDRAMStub.h"
-#endif
-*/
-
 #include <Graphics/Context.h>
 #include <Graphics/Parameters.h>
 #include <Graphics/ColorBufferReader.h>
@@ -165,12 +154,12 @@ bool ColorBufferToRDRAM::_prepareCopy(u32& _startAddress)
 		return false;
 
 	if(m_pTexture == nullptr ||
-		m_pTexture->width != _getRealWidth(pBuffer->m_width) ||
-		m_pTexture->height != VI_GetMaxBufferHeight(_getRealWidth(pBuffer->m_width)))
+		m_pTexture->width != pBuffer->m_width ||
+		m_pTexture->height != VI_GetMaxBufferHeight(pBuffer->m_width))
 	{
 		_destroyFBTexure();
 
-		m_lastBufferWidth = _getRealWidth(pBuffer->m_width);
+		m_lastBufferWidth = pBuffer->m_width;
 		_initFBTexture();
 	}
 
@@ -339,18 +328,6 @@ void ColorBufferToRDRAM::_copy(u32 _startAddress, u32 _endAddress, bool _sync)
 	m_bufferReader->cleanUp();
 
 	gDP.changed |= CHANGED_SCISSOR;
-}
-
-u32 ColorBufferToRDRAM::_getRealWidth(u32 _viWidth)
-{
-	u32 index = 0;
-	const u32 maxIndex = static_cast<u32>(m_allowedRealWidths.size()) - 1;
-	while (index < maxIndex && _viWidth > m_allowedRealWidths[index])
-	{
-		++index;
-	}
-
-	return m_allowedRealWidths[index];
 }
 
 void ColorBufferToRDRAM::copyToRDRAM(u32 _address, bool _sync)

--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -87,47 +87,43 @@ bool ColorBufferToRDRAM::_prepareCopy(u32& _startAddress)
 		readBuffer = m_pCurFrameBuffer->m_FBO;
 	}
 
-	if (m_pCurFrameBuffer->m_scale != 1.0f) {
-		u32 x0 = 0;
-		u32 width;
-		if (config.frameBufferEmulation.nativeResFactor == 0) {
-			const u32 screenWidth = wnd.getWidth();
-			width = screenWidth;
-			if (wnd.isAdjustScreen()) {
-				width = static_cast<u32>(screenWidth*wnd.getAdjustScale());
-				x0 = (screenWidth - width) / 2;
-			}
-		} else {
-			width = m_pCurFrameBuffer->m_pTexture->width;
+	u32 x0 = 0;
+	u32 width;
+	if (config.frameBufferEmulation.nativeResFactor == 0) {
+		const u32 screenWidth = wnd.getWidth();
+		width = screenWidth;
+		if (wnd.isAdjustScreen()) {
+			width = static_cast<u32>(screenWidth*wnd.getAdjustScale());
+			x0 = (screenWidth - width) / 2;
 		}
-		u32 height = (u32)(bufferHeight * m_pCurFrameBuffer->m_scale);
-
-		CachedTexture * pInputTexture = m_pCurFrameBuffer->m_pTexture;
-		GraphicsDrawer::BlitOrCopyRectParams blitParams;
-		blitParams.srcX0 = x0;
-		blitParams.srcY0 = 0;
-		blitParams.srcX1 = x0 + width;
-		blitParams.srcY1 = height;
-		blitParams.srcWidth = pInputTexture->width;
-		blitParams.srcHeight = pInputTexture->height;
-		blitParams.dstX0 = 0;
-		blitParams.dstY0 = 0;
-		blitParams.dstX1 = m_pCurFrameBuffer->m_width;
-		blitParams.dstY1 = bufferHeight;
-		blitParams.dstWidth = colorBufferTexture->width;
-		blitParams.dstHeight = colorBufferTexture->height;
-		blitParams.filter = textureParameters::FILTER_LINEAR;
-		blitParams.tex[0] = pInputTexture;
-		blitParams.combiner = CombinerInfo::get().getTexrectDownscaleCopyProgram();
-		blitParams.readBuffer = readBuffer;
-		blitParams.drawBuffer = pBuffer->getColorFbFbo();
-		blitParams.mask = blitMask::COLOR_BUFFER;
-		wnd.getDrawer().blitOrCopyTexturedRect(blitParams);
-
-		gfxContext.bindFramebuffer(bufferTarget::READ_FRAMEBUFFER, pBuffer->getColorFbFbo());
 	} else {
-		gfxContext.bindFramebuffer(bufferTarget::READ_FRAMEBUFFER, readBuffer);
+		width = m_pCurFrameBuffer->m_pTexture->width;
 	}
+	u32 height = (u32)(bufferHeight * m_pCurFrameBuffer->m_scale);
+
+	CachedTexture * pInputTexture = m_pCurFrameBuffer->m_pTexture;
+	GraphicsDrawer::BlitOrCopyRectParams blitParams;
+	blitParams.srcX0 = x0;
+	blitParams.srcY0 = 0;
+	blitParams.srcX1 = x0 + width;
+	blitParams.srcY1 = height;
+	blitParams.srcWidth = pInputTexture->width;
+	blitParams.srcHeight = pInputTexture->height;
+	blitParams.dstX0 = 0;
+	blitParams.dstY0 = 0;
+	blitParams.dstX1 = m_pCurFrameBuffer->m_width;
+	blitParams.dstY1 = bufferHeight;
+	blitParams.dstWidth = colorBufferTexture->width;
+	blitParams.dstHeight = colorBufferTexture->height;
+	blitParams.filter = m_pCurFrameBuffer->m_scale == 1.0f ? textureParameters::FILTER_NEAREST : textureParameters::FILTER_LINEAR;
+	blitParams.tex[0] = pInputTexture;
+	blitParams.combiner = CombinerInfo::get().getTexrectDownscaleCopyProgram();
+	blitParams.readBuffer = readBuffer;
+	blitParams.drawBuffer = pBuffer->getColorFbFbo();
+	blitParams.mask = blitMask::COLOR_BUFFER;
+	wnd.getDrawer().blitOrCopyTexturedRect(blitParams);
+
+	gfxContext.bindFramebuffer(bufferTarget::READ_FRAMEBUFFER, pBuffer->getColorFbFbo());
 
 	m_frameCount = curFrame;
 	m_startAddress = _startAddress;

--- a/src/BufferCopy/ColorBufferToRDRAM.h
+++ b/src/BufferCopy/ColorBufferToRDRAM.h
@@ -29,18 +29,12 @@ private:
 	ColorBufferToRDRAM(const ColorBufferToRDRAM &) = delete;
 	virtual ~ColorBufferToRDRAM();
 
-	CachedTexture * m_pTexture;
-
 	union RGBA {
 		struct {
 			u8 r, g, b, a;
 		};
 		u32 raw;
 	};
-
-	void _initFBTexture(void);
-
-	void _destroyFBTexure(void);
 
 	bool _prepareCopy(u32& _startAddress);
 
@@ -51,17 +45,11 @@ private:
 	static u16 _RGBAtoRGBA16(u32 _c, u32 x, u32 y);
 	static u32 _RGBAtoRGBA32(u32 _c, u32 x, u32 y);
 
-	graphics::ObjectHandle m_FBO;
 	FrameBuffer * m_pCurFrameBuffer;
 	u32 m_frameCount;
 	u32 m_startAddress;
 
-	u32 m_lastBufferWidth;
-
 	static u32 m_blueNoiseIdx;
-
-	std::array<u32, 3> m_allowedRealWidths;
-	std::unique_ptr<graphics::ColorBufferReader> m_bufferReader;
 };
 
 void copyWhiteToRDRAM(FrameBuffer * _pBuffer);

--- a/src/BufferCopy/ColorBufferToRDRAM.h
+++ b/src/BufferCopy/ColorBufferToRDRAM.h
@@ -46,8 +46,6 @@ private:
 
 	void _copy(u32 _startAddress, u32 _endAddress, bool _sync);
 
-	u32 _getRealWidth(u32 _viWidth);
-
 	// Convert pixel from video memory to N64 buffer format.
 	static u8 _RGBAtoR8(u8 _c, u32 x, u32 y);
 	static u16 _RGBAtoRGBA16(u32 _c, u32 x, u32 y);

--- a/src/FrameBuffer.h
+++ b/src/FrameBuffer.h
@@ -3,6 +3,7 @@
 
 #include <list>
 #include <vector>
+#include <memory>
 
 #include "gDP.h"
 #include "Textures.h"
@@ -12,6 +13,10 @@ struct gDPTile;
 struct DepthBuffer;
 
 const u32 fingerprint[4] = { 2, 6, 4, 3 };
+
+namespace graphics {
+	class ColorBufferReader;
+}
 
 struct FrameBuffer
 {
@@ -28,6 +33,10 @@ struct FrameBuffer
 	void setDirty();
 	bool isValid(bool _forceCheck) const;
 	bool isAuxiliary() const;
+	CachedTexture * getColorFbTexture();
+	graphics::ObjectHandle getColorFbFbo();
+	const u8 * readPixels(s32 _x0, s32 _y0, u32 _width, u32 _height, u32 _size, bool _sync);
+	void cleanUp();
 
 	u32 m_startAddress = 0;
 	u32 m_endAddress = 0;
@@ -62,6 +71,10 @@ struct FrameBuffer
 	graphics::ObjectHandle m_depthFBO;
 	CachedTexture *m_pDepthTexture = nullptr;
 
+	std::unique_ptr<graphics::ColorBufferReader> m_bufferReader;
+	graphics::ObjectHandle m_ColorBufferFBO;
+	CachedTexture *m_pColorBufferTexture = nullptr;
+
 	DepthBuffer *m_pDepthBuffer = nullptr;
 
 	// multisampling
@@ -94,6 +107,8 @@ private:
 	void _initCopyTexture();
 	CachedTexture * _copyFrameBufferTexture();
 	CachedTexture * _getSubTexture(u32 _t);
+	void _initColorFBTexture(int _width);
+	void _destroyColorFBTexure();
 
 	mutable u32 m_validityChecked = false;
 };

--- a/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.cpp
+++ b/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.cpp
@@ -22,6 +22,8 @@ GraphicBufferWrapper::GraphicBufferWrapper() {
 		m_private = true;
 		m_privateGraphicBuffer = new GraphicBuffer();
 	}
+
+	m_stride = 0;
 }
 
 GraphicBufferWrapper::~GraphicBufferWrapper() {
@@ -51,7 +53,6 @@ bool GraphicBufferWrapper::allocate(const AHardwareBuffer_Desc *desc) {
 	}
 }
 
-
 int GraphicBufferWrapper::lock(uint64_t usage, void **out_virtual_address) {
 
 	int returnValue = 0;
@@ -63,7 +64,6 @@ int GraphicBufferWrapper::lock(uint64_t usage, void **out_virtual_address) {
 
 	return returnValue;
 }
-
 
 void GraphicBufferWrapper::release() {
 	if (!m_private) {
@@ -81,7 +81,6 @@ void GraphicBufferWrapper::unlock() {
 
 }
 
-
 EGLClientBuffer GraphicBufferWrapper::getClientBuffer() {
 	EGLClientBuffer clientBuffer = nullptr;
 	if (m_private) {
@@ -93,6 +92,15 @@ EGLClientBuffer GraphicBufferWrapper::getClientBuffer() {
 	return clientBuffer;
 }
 
+unsigned GraphicBufferWrapper::getStride() const {
+	if (m_private) {
+		return m_privateGraphicBuffer->getStride();
+	} else {
+		AHardwareBuffer_Desc bufferInfo;
+		AndroidHardwareBufferCompat::GetInstance().Describe(m_publicGraphicBuffer, &bufferInfo);
+		return bufferInfo.stride;
+	}
+}
 
 int GraphicBufferWrapper::getApiLevel()
 {

--- a/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.h
+++ b/src/Graphics/OpenGLContext/GraphicBuffer/GraphicBufferWrapper.h
@@ -28,6 +28,7 @@ public:
 	void release();
 	void unlock();
 	EGLClientBuffer getClientBuffer();
+	unsigned int getStride() const;
 
 private:
 
@@ -36,6 +37,7 @@ private:
 	bool m_private;
 	GraphicBuffer* m_privateGraphicBuffer;
 	AHardwareBuffer* m_publicGraphicBuffer;
+	unsigned int m_stride;
 
 };
 

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -55,7 +55,7 @@ const u8 * ColorBufferReaderWithEGLImage::_readPixels(const ReadColorBufferParam
 		m_hardwareBuffer.lock(AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN, &gpuData);
 		m_bufferLocked = true;
 		_heightOffset = static_cast<u32>(_params.y0);
-		_stride = m_pTexture->width;
+		_stride = m_hardwareBuffer.getStride();
 	} else {
 		gpuData = m_pixelData.data();
 		glReadPixels(_params.x0, _params.y0,  m_pTexture->width, _params.height, format, type, gpuData);


### PR DESCRIPTION
For Android we use EGL image for async copies and for sync copies and devices that don't support EGL image, the fixed texture sizes don't seem to improve performance.

Also, this fixes the red dot not working on Adreno devices.