### PR TITLE
Fix crash when trying to delete invalid frame buffer

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -544,8 +544,11 @@ void TextureCache::removeFrameBufferTexture(CachedTexture * _pTexture)
 		return;
 	FBTextures::const_iterator iter = m_fbTextures.find(u32(_pTexture->name));
 	assert(iter != m_fbTextures.cend());
-	gfxContext.deleteTexture(ObjectHandle(iter->second.name));
-	m_fbTextures.erase(iter);
+
+	if (iter != m_fbTextures.cend()) {
+		gfxContext.deleteTexture(ObjectHandle(iter->second.name));
+		m_fbTextures.erase(iter);
+	}
 }
 
 CachedTexture * TextureCache::addFrameBufferTexture(graphics::Parameter _target)


### PR DESCRIPTION
There seem to be some instances where we are trying to delete a frame buffer texture that was never created. I don't know which game this is happening in since I'm just getting crash reports from google, but here is an example backtrace:
```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 0 >>> org.mupen64plusae.v3.fzurita <<<

backtrace:
  #00  pc 00000000001698c0  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-video-GLideN64.so (TextureCache::removeFrameBufferTexture(CachedTexture*)+39)
  #00  pc 00000000001535bb  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-video-GLideN64.so (FrameBuffer::_destroyColorFBTexure()+30)
  #00  pc 0000000000153569  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-video-GLideN64.so (FrameBuffer::~FrameBuffer()+104)
  #00  pc 0000000000154919  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-video-GLideN64.so (std::__ndk1::list<FrameBuffer, std::__ndk1::allocator<FrameBuffer> >::erase(std::__ndk1::__list_const_iterator<FrameBuffer, void*>)+26)
  #00  pc 0000000000155db3  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-video-GLideN64.so (FrameBufferList::renderBuffer()+978)
  #00  pc 000000000016d567  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-video-GLideN64.so (VI_UpdateScreen()+1614)
  #00  pc 00000000000d26c8  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-core.so
  #00  pc 000000000006eb60  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-core.so
  #00  pc 00000000000182e0  /data/app/org.mupen64plusae.v3.fzurita-1/lib/arm/libmupen64plus-core.so
```