### PR TITLE
Fix other android issues

### DIFF
--- a/src/BufferCopy/ColorBufferToRDRAM.cpp
+++ b/src/BufferCopy/ColorBufferToRDRAM.cpp
@@ -22,8 +22,6 @@ using namespace graphics;
 
 ColorBufferToRDRAM::ColorBufferToRDRAM()
 	: m_pCurFrameBuffer(nullptr)
-	, m_frameCount(-1)
-	, m_startAddress(-1)
 {
 }
 
@@ -84,46 +82,48 @@ bool ColorBufferToRDRAM::_prepareCopy(u32& _startAddress)
 		readBuffer = m_pCurFrameBuffer->m_FBO;
 	}
 
-	u32 x0 = 0;
-	u32 width;
-	if (config.frameBufferEmulation.nativeResFactor == 0 && m_pCurFrameBuffer->m_scale != 1.0f) {
-		const u32 screenWidth = wnd.getWidth();
-		width = screenWidth;
-		if (wnd.isAdjustScreen()) {
-			width = static_cast<u32>(screenWidth*wnd.getAdjustScale());
-			x0 = (screenWidth - width) / 2;
+	if (!m_pCurFrameBuffer->isAuxiliary()) {
+		u32 x0 = 0;
+		u32 width;
+		if (config.frameBufferEmulation.nativeResFactor == 0 && m_pCurFrameBuffer->m_scale != 1.0f) {
+			const u32 screenWidth = wnd.getWidth();
+			width = screenWidth;
+			if (wnd.isAdjustScreen()) {
+				width = static_cast<u32>(screenWidth*wnd.getAdjustScale());
+				x0 = (screenWidth - width) / 2;
+			}
+		} else {
+			width = m_pCurFrameBuffer->m_pTexture->width;
 		}
+		u32 height = (u32)(bufferHeight * m_pCurFrameBuffer->m_scale);
+
+		CachedTexture * pInputTexture = m_pCurFrameBuffer->m_pTexture;
+		GraphicsDrawer::BlitOrCopyRectParams blitParams;
+		blitParams.srcX0 = x0;
+		blitParams.srcY0 = 0;
+		blitParams.srcX1 = x0 + width;
+		blitParams.srcY1 = height;
+		blitParams.srcWidth = pInputTexture->width;
+		blitParams.srcHeight = pInputTexture->height;
+		blitParams.dstX0 = 0;
+		blitParams.dstY0 = 0;
+		blitParams.dstX1 = m_pCurFrameBuffer->m_width;
+		blitParams.dstY1 = bufferHeight;
+		blitParams.dstWidth = colorBufferTexture->width;
+		blitParams.dstHeight = colorBufferTexture->height;
+		blitParams.filter = m_pCurFrameBuffer->m_scale == 1.0f ? textureParameters::FILTER_NEAREST : textureParameters::FILTER_LINEAR;
+		blitParams.tex[0] = pInputTexture;
+		blitParams.combiner = CombinerInfo::get().getTexrectDownscaleCopyProgram();
+		blitParams.readBuffer = readBuffer;
+		blitParams.drawBuffer = pBuffer->getColorFbFbo();
+		blitParams.mask = blitMask::COLOR_BUFFER;
+		wnd.getDrawer().blitOrCopyTexturedRect(blitParams);
+
+		gfxContext.bindFramebuffer(bufferTarget::READ_FRAMEBUFFER, pBuffer->getColorFbFbo());
 	} else {
-		width = m_pCurFrameBuffer->m_pTexture->width;
+		gfxContext.bindFramebuffer(bufferTarget::READ_FRAMEBUFFER, readBuffer);
 	}
-	u32 height = (u32)(bufferHeight * m_pCurFrameBuffer->m_scale);
 
-	CachedTexture * pInputTexture = m_pCurFrameBuffer->m_pTexture;
-	GraphicsDrawer::BlitOrCopyRectParams blitParams;
-	blitParams.srcX0 = x0;
-	blitParams.srcY0 = 0;
-	blitParams.srcX1 = x0 + width;
-	blitParams.srcY1 = height;
-	blitParams.srcWidth = pInputTexture->width;
-	blitParams.srcHeight = pInputTexture->height;
-	blitParams.dstX0 = 0;
-	blitParams.dstY0 = 0;
-	blitParams.dstX1 = m_pCurFrameBuffer->m_width;
-	blitParams.dstY1 = bufferHeight;
-	blitParams.dstWidth = colorBufferTexture->width;
-	blitParams.dstHeight = colorBufferTexture->height;
-	blitParams.filter = m_pCurFrameBuffer->m_scale == 1.0f ? textureParameters::FILTER_NEAREST : textureParameters::FILTER_LINEAR;
-	blitParams.tex[0] = pInputTexture;
-	blitParams.combiner = CombinerInfo::get().getTexrectDownscaleCopyProgram();
-	blitParams.readBuffer = readBuffer;
-	blitParams.drawBuffer = pBuffer->getColorFbFbo();
-	blitParams.mask = blitMask::COLOR_BUFFER;
-	wnd.getDrawer().blitOrCopyTexturedRect(blitParams);
-
-	gfxContext.bindFramebuffer(bufferTarget::READ_FRAMEBUFFER, pBuffer->getColorFbFbo());
-
-	m_frameCount = curFrame;
-	m_startAddress = _startAddress;
 	return true;
 }
 

--- a/src/BufferCopy/ColorBufferToRDRAM.h
+++ b/src/BufferCopy/ColorBufferToRDRAM.h
@@ -46,8 +46,6 @@ private:
 	static u32 _RGBAtoRGBA32(u32 _c, u32 x, u32 y);
 
 	FrameBuffer * m_pCurFrameBuffer;
-	u32 m_frameCount;
-	u32 m_startAddress;
 
 	static u32 m_blueNoiseIdx;
 };

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -514,7 +514,7 @@ public:
 		}
 		m_part +=
 			" gl_Position.xy += uVertexOffset * vec2(gl_Position.w); \n"
-			" gl_Position.zw *= vec2(1024.0f);		 \n"
+			" gl_Position.zw *= vec2(1024.0);		 \n"
 			"} \n"
 			;
 	}

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -40,9 +40,11 @@ void ColorBufferReaderWithEGLImage::_initBuffers()
 		m_image = eglCreateImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), EGL_NO_CONTEXT,
 			EGL_NATIVE_BUFFER_ANDROID, m_hardwareBuffer.getClientBuffer(), eglImgAttrs);
 
-		m_bindTexture->bind(graphics::Parameter(0), textureTarget::TEXTURE_EXTERNAL, m_pTexture->name);
-		glEGLImageTargetTexture2DOES(GLenum(textureTarget::TEXTURE_EXTERNAL), m_image);
-		m_bindTexture->bind(graphics::Parameter(0), textureTarget::TEXTURE_EXTERNAL, ObjectHandle());
+		if (m_image != nullptr) {
+			m_bindTexture->bind(graphics::Parameter(0), textureTarget::TEXTURE_EXTERNAL, m_pTexture->name);
+			glEGLImageTargetTexture2DOES(GLenum(textureTarget::TEXTURE_EXTERNAL), m_image);
+			m_bindTexture->bind(graphics::Parameter(0), textureTarget::TEXTURE_EXTERNAL, ObjectHandle());
+		}
 	}
 }
 

--- a/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ColorBufferReaderWithEGLImage.cpp
@@ -20,6 +20,10 @@ ColorBufferReaderWithEGLImage::ColorBufferReaderWithEGLImage(CachedTexture *_pTe
 ColorBufferReaderWithEGLImage::~ColorBufferReaderWithEGLImage()
 {
 	m_hardwareBuffer.release();
+
+	if (m_image != nullptr) {
+		eglDestroyImageKHR(eglGetDisplay(EGL_DEFAULT_DISPLAY), m_image);
+	}
 }
 
 void ColorBufferReaderWithEGLImage::_initBuffers()


### PR DESCRIPTION
I discovered a bunch of other issues while doing some testing and debugging issues reported by users.

* First issue, we are not destroying an EGL image once we are done with it, this results in a resource leak and eventually we crash due to that.
* Next issue, we try to initialize a hardware buffer even if the EGL image we are trying to associate with it failed to initialize.
* Final issue, for some reason the blit of auxiliary frame buffers is failing in Android, so I put back the old method only for auxiliary frame buffers which are sync copies anyways and don't use EGL image. They are also always scaled to 1x.
* Also fix recently introduced GLES 2.0 GLSL shader compilation error.