### PR TITLE
Fix Kirby 64 broken level selection

### DIFF
--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -256,8 +256,10 @@ void VI_UpdateScreen()
 				 (config.generalEmulation.hacks & hack_RE2) == 0 &&
 				 !pBuffer->isValid(true)) {
 			gDP.changed |= CHANGED_CPU_FB_WRITE;
-			if (config.frameBufferEmulation.copyToRDRAM == 0 && (config.generalEmulation.hacks & hack_subscreen) == 0)
+			if (config.frameBufferEmulation.copyToRDRAM == 0 && (config.generalEmulation.hacks & hack_subscreen) == 0) {
 				pBuffer->copyRdram();
+				pBuffer->m_cleared = false;
+			}
 		}
 
 		const bool bCFB = (gDP.changed&CHANGED_CPU_FB_WRITE) == CHANGED_CPU_FB_WRITE;


### PR DESCRIPTION
Without this fix, the level selection is broken when copy color to RDRAM is disabled.

This fixes https://github.com/gonetz/GLideN64/issues/2491

@gonetz Do you think this is the right fix?