### PR TITLE
Temporary fix for NVidia shaking on Windows

### DIFF
--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.cpp
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.cpp
@@ -64,10 +64,11 @@ RingBufferPool::RingBufferPool(size_t _poolSize) :
 PoolBufferPointer RingBufferPool::createPoolBuffer(const char* _buffer, size_t _bufferSize)
 {
 	size_t realBufferSize = _bufferSize;
-	const size_t remainder = _bufferSize % 4;
+	const int byteAlignment = 8;
+	const size_t remainder = _bufferSize % byteAlignment;
 
 	if (remainder != 0)
-		realBufferSize = _bufferSize + 4 - remainder;
+		realBufferSize = _bufferSize + byteAlignment - remainder;
 
 	const size_t tempInUseStart = m_inUseStartOffset;
 
@@ -116,23 +117,29 @@ PoolBufferPointer RingBufferPool::createPoolBuffer(const char* _buffer, size_t _
 			}
 
 			std::unique_lock<std::mutex> lock(m_mutex);
+			size_t poolBufferSize = m_poolBuffer.size();
 			if (m_poolBuffer.size() < realBufferSize) {
-				std::stringstream errorString;
-				errorString << " Increasing buffer size from " << m_poolBuffer.size() << " to " << realBufferSize;
-				LOG(LOG_VERBOSE, errorString.str().c_str());
-
-				m_poolBuffer.resize(realBufferSize);
+				std::stringstream logString;
+				logString << " Increasing buffer size from " << m_poolBuffer.size() << " to " << realBufferSize;
+				LOG(LOG_VERBOSE, logString.str().c_str());
+				poolBufferSize = realBufferSize;
 			}
 
-			m_condition.wait(lock, [this, realBufferSize] {
+			m_condition.wait(lock, [this, realBufferSize, poolBufferSize] {
 				const size_t tempInUseStartLocal = m_inUseStartOffset;
 				const size_t remainingLocal =
 					tempInUseStartLocal > m_inUseEndOffset || m_full ? static_cast<size_t>(
 						tempInUseStartLocal - m_inUseEndOffset) :
-					m_poolBuffer.size() - m_inUseEndOffset + tempInUseStartLocal;
+					poolBufferSize - m_inUseEndOffset + tempInUseStartLocal;
 
 				return remainingLocal >= realBufferSize;
 			});
+
+			// Resize afterwards, we don't want to lose the validity of pointers
+			// pointing at the old data
+			if (m_poolBuffer.size() < realBufferSize) {
+				m_poolBuffer.resize(realBufferSize);
+			}
 		}
 
 		return createPoolBuffer(_buffer, _bufferSize);

--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.h
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/RingBufferPool.h
@@ -55,7 +55,7 @@ private:
 	std::atomic<bool> m_full;
 	std::condition_variable_any m_condition;
 	size_t m_maxBufferPoolSize;
-	static const size_t m_startBufferPoolSize = 1024 * 100;
+	static const size_t m_startBufferPoolSize = 1024 * 1024 * 10;
 };
 
 }


### PR DESCRIPTION
Fix for #2208.

There was one race condition that reallocated a buffer while it was still being used, but that didn't fix the root cause. As a temporary workaround I'm just increasing the initialize memory pool size. Performing no reallocations of the memory pool allows it to work correctly.

The root cause seems to be something deeper with memory buffers being used across multiple threads that affects NVidia only. I may need some sort of memory barrier.