### PR TITLE
Fix wrong buffer height in PostProcessor

### DIFF
--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -95,7 +95,7 @@ PostProcessor & PostProcessor::get()
 
 void PostProcessor::_preDraw(FrameBuffer * _pBuffer)
 {
-	if (!m_pResultBuffer || m_pResultBuffer->m_width != _pBuffer->m_width ||
+	if (!m_pResultBuffer || m_pResultBuffer->m_width != _pBuffer->m_width || m_pResultBuffer->m_height != _pBuffer->m_height ||
 		m_pResultBuffer->m_scale != _pBuffer->m_scale)
 		_createResultBuffer(_pBuffer);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2852068/120325531-09599880-c2e8-11eb-92ec-ca5915d1d4a8.png)

Happens in duke zero hour when ForceGammaCorrection = True
