### PR TITLE
Render non-filtered rectangles in native resolution too, when nativeResTexrects are enabled

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -242,7 +242,7 @@ public:
 		float texCoordOffset[2][2] = { 0.0f, 0.0f };
 		if (isTexRect && !isNativeRes) {
 			float scale[2] = { 0.0f, 0.0f };
-			if (config.graphics2D.enableNativeResTexrects != 0) {
+			if (config.graphics2D.enableNativeResTexrects != 0 && gDP.otherMode.textureFilter != G_TF_POINT) {
 				scale[0] = scale[1] = 1.0f;
 			} else {
 				scale[0] = scale[1] = static_cast<float>(config.frameBufferEmulation.nativeResFactor);

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactory.cpp
@@ -257,6 +257,10 @@ public:
 					} else {
 						texCoordOffset[t][0] = (gDP.lastTexRectInfo.dsdx >= 0.0f ? 0.0f : -1.0f) * gDP.lastTexRectInfo.dsdx * _pTexture->hdRatioS;
 						texCoordOffset[t][1] = (gDP.lastTexRectInfo.dtdy >= 0.0f ? 0.0f : -1.0f) * gDP.lastTexRectInfo.dtdy * _pTexture->hdRatioT;
+						if (gDP.otherMode.textureFilter != G_TF_POINT) {
+							texCoordOffset[t][0] -= 0.5f;
+							texCoordOffset[t][1] -= 0.5f;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #2506.