### PR TITLE
GLideNUI: fix multisampling causing odd UI behavior

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -183,9 +183,7 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 		config.video.maxMultiSampling = m_maxMSAA;
 	}
 
-	const unsigned int multisampling = config.video.fxaa == 0 && config.video.multisampling > 0
-		? std::min(config.video.multisampling, m_maxMSAA)
-		: m_maxMSAA;
+	const unsigned int multisampling = std::min(config.video.multisampling, m_maxMSAA);
 
 	ui->aliasingSlider->blockSignals(true);
 	ui->aliasingSlider->setMaximum(powof(m_maxMSAA));


### PR DESCRIPTION
When a user sets MSAA to 0x, it should stay that way and not revert to the maximum possible value.

Fixes #2524