### PR TITLE
GLideNUI: introduce config.hotkeys.enabledKeys

### DIFF
--- a/projects/msvc/GLideNUI.vcxproj
+++ b/projects/msvc/GLideNUI.vcxproj
@@ -108,6 +108,7 @@
     <ClCompile Include="..\..\src\GLideNUI\AboutDialog.cpp" />
     <ClCompile Include="..\..\src\GLideNUI\ConfigDialog.cpp" />
     <ClCompile Include="..\..\src\GLideNUI\QtKeyToHID.cpp" />
+    <ClCompile Include="..\..\SRC\GLideNUI\HIDKeyToName.cpp" />
     <ClCompile Include="Debug\moc_AboutDialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)'=='Release'">true</ExcludedFromBuild>
     </ClCompile>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,7 @@ set(GLideNUI_SOURCES
   GLideNUI/ScreenShot.cpp
   GLideNUI/Settings.cpp
   GLideNUI/QtKeyToHID.cpp
+  GLideNUI/HIDKeyToName.cpp
   GLideNUI/configDialog.ui
   GLideNUI/icon.qrc
 )

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -139,8 +139,10 @@ void Config::resetToDefaults()
 	onScreenDisplay.statistics = 0;
 	onScreenDisplay.pos = posBottomLeft;
 
-	for (u32 idx = 0; idx < HotKey::hkTotal; ++idx)
+	for (u32 idx = 0; idx < HotKey::hkTotal; ++idx) {
+		hotkeys.enabledKeys[idx] = 0;
 		hotkeys.keys[idx] = 0;
+	}
 
 	debug.dumpMode = 0;
 }
@@ -200,3 +202,40 @@ const char* Config::hotkeyIniName(u32 _idx)
 	}
 	return nullptr;
 }
+
+const char* Config::enabledHotkeyIniName(u32 _idx)
+{
+	switch (_idx)
+	{
+	case Config::HotKey::hkTexDump:
+		return "hkTexDumpEnabled";
+	case Config::HotKey::hkHdTexReload:
+		return "hkHdTexReloadEnabled";
+	case Config::HotKey::hkHdTexToggle:
+		return "hkHdTexToggleEnabled";
+	case Config::HotKey::hkTexCoordBounds:
+		return "hkTexCoordBoundsEnabled";
+	case Config::HotKey::hkNativeResTexrects:
+		return "hkNativeResTexrectsEnabled";
+	case Config::HotKey::hkVsync:
+		return "hkVsyncEnabled";
+	case Config::HotKey::hkFBEmulation:
+		return "hkFBEmulationEnabled";
+	case Config::HotKey::hkN64DepthCompare:
+		return "hkN64DepthCompareEnabled";
+	case Config::HotKey::hkOsdVis:
+		return "hkOsdVisEnabled";
+	case Config::HotKey::hkOsdFps:
+		return "hkOsdFpsEnabled";
+	case Config::HotKey::hkOsdPercent:
+		return "hkOsdPercentEnabled";
+	case Config::HotKey::hkOsdInternalResolution:
+		return "hkOsdInternalResolutionEnabled";
+	case Config::HotKey::hkOsdRenderingResolution:
+		return "hkOsdRenderingResolutionEnabled";
+	case Config::HotKey::hkForceGammaCorrection:
+		return "hkForceGammaCorrectionEnabled";
+	}
+	return nullptr;
+}
+

--- a/src/Config.h
+++ b/src/Config.h
@@ -235,6 +235,7 @@ struct Config
 	};
 
 	struct {
+		u8 enabledKeys[hkTotal];
 		u8 keys[hkTotal];
 	} hotkeys;
 
@@ -245,6 +246,7 @@ struct Config
 	void resetToDefaults();
 	void validate();
 	static const char* hotkeyIniName(u32 _idx);
+	static const char* enabledHotkeyIniName(u32 _idx);
 };
 
 #define hack_Ogre64					(1<<0)  //Ogre Battle 64 background copy

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -18,8 +18,8 @@
 #include "ConfigDialog.h"
 #include "FullscreenResolutions.h"
 #include "qevent.h"
-#include "osal_keys.h"
 #include "QtKeyToHID.h"
+#include "HIDKeyToName.h"
 
 static
 struct
@@ -428,7 +428,7 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 
 			if (config.hotkeys.keys[idx] != 0) {
 				pWgt->setHidCode(config.hotkeys.keys[idx]);
-				pBtn->setText(osal_keycode_name(config.hotkeys.keys[idx]));
+				pBtn->setText(HIDKeyToName(config.hotkeys.keys[idx]));
 				pItem->setCheckState(Qt::Checked);
 			}
 		}
@@ -1156,7 +1156,10 @@ void ConfigDialog::on_btn_clicked() {
 			HotkeyMessageBox msgBox(this);
 			msgBox.setInformativeText(QString("Press a key for ") + pLabel->text());
 			msgBox.exec();
-			if (msgBox.m_Key != Qt::Key::Key_unknown) {
+			const unsigned int hidCode = QtKeyToHID(msgBox.m_Key);
+			if (hidCode == 0) {
+				pBtn->setText("Invalid Key");
+			} else {
 				const unsigned int hidCode = QtKeyToHID(msgBox.m_Key);
 				for (quint32 idx = 0; idx < Config::HotKey::hkTotal; ++idx) {
 					QListWidgetItem * pItem = ui->hotkeyListWidget->item(idx);
@@ -1169,7 +1172,7 @@ void ConfigDialog::on_btn_clicked() {
 						break;
 					}
 				}
-				pBtn->setText(osal_keycode_name(hidCode));
+				pBtn->setText(HIDKeyToName(hidCode));
 				((HotkeyItemWidget*)pBtn->parent())->setHidCode(hidCode);
 			}
 		}

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -10,6 +10,7 @@
 #include <QRegularExpression>
 #include <QInputDialog>
 #include <QDirIterator>
+#include <qnamespace.h>
 
 #include "../Config.h"
 #include "../DebugDump.h"
@@ -429,7 +430,9 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 			if (config.hotkeys.keys[idx] != 0) {
 				pWgt->setHidCode(config.hotkeys.keys[idx]);
 				pBtn->setText(HIDKeyToName(config.hotkeys.keys[idx]));
-				pItem->setCheckState(Qt::Checked);
+				if (config.hotkeys.enabledKeys[idx] != 0) {
+					pItem->setCheckState(Qt::Checked);
+				}
 			}
 		}
 	}
@@ -692,7 +695,7 @@ void ConfigDialog::accept(bool justSave) {
 	if (!txDumpPath.exists() &&
 		!txDumpPath.mkdir(txDumpPath.absolutePath()) &&
 		config.textureFilter.txHiresEnable != 0 &&
-		config.hotkeys.keys[Config::HotKey::hkTexDump] != 0) {
+		config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
 		QMessageBox msgBox;
 		msgBox.setStandardButtons(QMessageBox::Close);
 		msgBox.setWindowTitle("GLideN64");
@@ -743,11 +746,12 @@ void ConfigDialog::accept(bool justSave) {
 	config.onScreenDisplay.statistics = ui->statisticsCheckBox->isChecked() ? 1 : 0;
 
 	for (quint32 idx = 0; idx < Config::HotKey::hkTotal; ++idx) {
-		config.hotkeys.keys[idx] = 0;
+		config.hotkeys.keys[idx] = config.hotkeys.enabledKeys[idx] = 0;
 		QListWidgetItem * pItem = ui->hotkeyListWidget->item(idx);
+		HotkeyItemWidget* pWgt = (HotkeyItemWidget*)ui->hotkeyListWidget->itemWidget(pItem);
+		config.hotkeys.keys[idx] = pWgt->hidCode();
 		if (pItem->checkState() == Qt::Checked) {
-			HotkeyItemWidget* pWgt = (HotkeyItemWidget*)ui->hotkeyListWidget->itemWidget(pItem);
-			config.hotkeys.keys[idx] = pWgt->hidCode();
+			config.hotkeys.enabledKeys[idx] = pWgt->hidCode();
 		}
 	}
 

--- a/src/GLideNUI/HIDKeyToName.cpp
+++ b/src/GLideNUI/HIDKeyToName.cpp
@@ -1,0 +1,387 @@
+#include "HIDKeyToName.h"
+#include "keycode/keycode.h"
+
+QString HIDKeyToName(unsigned int key)
+{
+	QString returnValue;
+
+	switch (key)
+	{
+		default:
+			returnValue = "Unknown";
+			break;
+		case KEY_A:
+			returnValue = "A";
+			break;
+		case KEY_B:
+			returnValue = "B";
+			break;
+		case KEY_C:
+			returnValue = "C";
+			break;
+		case KEY_D:
+			returnValue = "D";
+			break;
+		case KEY_E:
+			returnValue = "E";
+			break;
+		case KEY_F:
+			returnValue = "F";
+			break;
+		case KEY_G:
+			returnValue = "G";
+			break;
+		case KEY_H:
+			returnValue = "H";
+			break;
+		case KEY_I:
+			returnValue = "I";
+			break;
+		case KEY_J:
+			returnValue = "J";
+			break;
+		case KEY_K:
+			returnValue = "K";
+			break;
+		case KEY_L:
+			returnValue = "L";
+			break;
+		case KEY_M:
+			returnValue = "M";
+			break;
+		case KEY_N:
+			returnValue = "N";
+			break;
+		case KEY_O:
+			returnValue = "O";
+			break;
+		case KEY_P:
+			returnValue = "P";
+			break;
+		case KEY_Q:
+			returnValue = "Q";
+			break;
+		case KEY_R:
+			returnValue = "R";
+			break;
+		case KEY_S:
+			returnValue = "S";
+			break;
+		case KEY_T:
+			returnValue = "T";
+			break;
+		case KEY_U:
+			returnValue = "U";
+			break;
+		case KEY_V:
+			returnValue = "V";
+			break;
+		case KEY_W:
+			returnValue = "W";
+			break;
+		case KEY_X:
+			returnValue = "X";
+			break;
+		case KEY_Y:
+			returnValue = "Y";
+			break;
+		case KEY_Z:
+			returnValue = "Z";
+			break;
+		case KEY_1:
+			returnValue = "1";
+			break;
+		case KEY_2:
+			returnValue = "2";
+			break;
+		case KEY_3:
+			returnValue = "3";
+			break;
+		case KEY_4:
+			returnValue = "4";
+			break;
+		case KEY_5:
+			returnValue = "5";
+			break;
+		case KEY_6:
+			returnValue = "6";
+			break;
+		case KEY_7:
+			returnValue = "7";
+			break;
+		case KEY_8:
+			returnValue = "8";
+			break;
+		case KEY_9:
+			returnValue = "9";
+			break;
+		case KEY_0:
+			returnValue = "0";
+			break;
+		case KEY_Escape:
+			returnValue = "Escape";
+			break;
+		case KEY_Delete:
+			returnValue = "Delete";
+			break;
+		case KEY_Tab:
+			returnValue = "Tab";
+			break;
+		case KEY_Space:
+			returnValue = "Space";
+			break;
+		case KEY_Minus:
+			returnValue = "Minus";
+			break;
+		case KEY_Equals:
+			returnValue = "Equals";
+			break;
+		case KEY_LeftBracket:
+			returnValue = "{";
+			break;
+		case KEY_RightBracket:
+			returnValue = "}";
+			break;
+		case KEY_Backslash:
+			returnValue = "\\";
+			break;
+		case KEY_Semicolon:
+			returnValue = ";";
+			break;
+		case KEY_Quote:
+			returnValue = "\"";
+			break;
+		case KEY_Grave:
+			returnValue = "Grave";
+			break;
+		case KEY_Comma:
+			returnValue = ",";
+			break;
+		case KEY_Period:
+			returnValue = ".";
+			break;
+		case KEY_Slash:
+			returnValue = "/";
+			break;
+		case KEY_CapsLock:
+			returnValue = "Capslock";
+			break;
+		case KEY_F1:
+			returnValue = "F1";
+			break;
+		case KEY_F2:
+			returnValue = "F2";
+			break;
+		case KEY_F3:
+			returnValue = "F3";
+			break;
+		case KEY_F4:
+			returnValue = "F4";
+			break;
+		case KEY_F5:
+			returnValue = "F5";
+			break;
+		case KEY_F6:
+			returnValue = "F6";
+			break;
+		case KEY_F7:
+			returnValue = "F7";
+			break;
+		case KEY_F8:
+			returnValue = "F8";
+			break;
+		case KEY_F9:
+			returnValue = "F9";
+			break;
+		case KEY_F10:
+			returnValue = "F10";
+			break;
+		case KEY_F11:
+			returnValue = "F11";
+			break;
+		case KEY_F12:
+			returnValue = "F12";
+			break;
+		case KEY_PrintScreen:
+			returnValue = "Print Screen";
+			break;
+		case KEY_ScrollLock:
+			returnValue = "Scroll Lock";
+			break;
+		case KEY_Pause:
+			returnValue = "Pause";
+			break;
+		case KEY_Insert:
+			returnValue = "Insert";
+			break;
+		case KEY_Home:
+			returnValue = "Home";
+			break;
+		case KEY_PageUp:
+			returnValue = "Page Up";
+			break;
+		case KEY_DeleteForward:
+			returnValue = "Delete Forward";
+			break;
+		case KEY_End:
+			returnValue = "End";
+			break;
+		case KEY_PageDown:
+			returnValue = "Page Down";
+			break;
+		case KEY_Right:
+			returnValue = "Right";
+			break;
+		case KEY_Left:
+			returnValue = "Left";
+			break;
+		case KEY_Down:
+			returnValue = "Down";
+			break;
+		case KEY_Up:
+			returnValue = "Up";
+			break;
+		case KP_NumLock:
+			returnValue = "[Keypad] Numlock";
+			break;
+		case KP_Divide:
+			returnValue = "[Keypad] /";
+			break;
+		case KP_Multiply:
+			returnValue = "[Keypad] *";
+			break;
+		case KP_Subtract:
+			returnValue = "[Keypad] -";
+			break;
+		case KP_Add:
+			returnValue = "[Keypad] +";
+			break;
+		case KP_Enter:
+			returnValue = "[Keypad] Enter";
+			break;
+		case KP_1:
+			returnValue = "[Keypad] 1";
+			break;
+		case KP_2:
+			returnValue = "[Keypad] 2";
+			break;
+		case KP_3:
+			returnValue = "[Keypad] 3";
+			break;
+		case KP_4:
+			returnValue = "[Keypad] 4";
+			break;
+		case KP_5:
+			returnValue = "[Keypad] 5";
+			break;
+		case KP_6:
+			returnValue = "[Keypad] 6";
+			break;
+		case KP_7:
+			returnValue = "[Keypad] 7";
+			break;
+		case KP_8:
+			returnValue = "[Keypad] 8";
+			break;
+		case KP_9:
+			returnValue = "[Keypad] 9";
+			break;
+		case KP_0:
+			returnValue = "[Keypad] 0";
+			break;
+		case KP_Point:
+			returnValue = "[Keypad] .";
+			break;
+		case KEY_NonUSBackslash:
+			returnValue = "\\";
+			break;
+		case KP_Equals:
+			returnValue = "=";
+			break;
+		case KEY_F13:
+			returnValue = "F13";
+			break;
+		case KEY_F14:
+			returnValue = "F14";
+			break;
+		case KEY_F15:
+			returnValue = "F15";
+			break;
+		case KEY_F16:
+			returnValue = "F16";
+			break;
+		case KEY_F17:
+			returnValue = "F17";
+			break;
+		case KEY_F18:
+			returnValue = "F18";
+			break;
+		case KEY_F19:
+			returnValue = "F19";
+			break;
+		case KEY_F20:
+			returnValue = "F20";
+			break;
+		case KEY_F21:
+			returnValue = "F21";
+			break;
+		case KEY_F22:
+			returnValue = "F22";
+			break;
+		case KEY_F23:
+			returnValue = "F23";
+			break;
+		case KEY_F24:
+			returnValue = "F24";
+			break;
+		case KEY_Help:
+			returnValue = "Help";
+			break;
+		case KEY_Menu:
+			returnValue = "Menu";
+			break;
+		case KEY_Mute:
+			returnValue = "Mute";
+			break;
+		case KEY_SysReq:
+			returnValue = "Sys";
+			break;
+		case KEY_Return:
+			returnValue = "[Keypad] Return";
+			break;
+		case KP_Clear:
+			returnValue = "[Keypad] Clear";
+			break;
+		case KP_Decimal:
+			returnValue = "[Keypad] .";
+			break;
+		case KEY_LeftControl:
+			returnValue = "[Keypad] Left";
+			break;
+		case KEY_LeftShift:
+			returnValue = "Left Shift";
+			break;
+		case KEY_LeftAlt:
+			returnValue = "Left Alt";
+			break;
+		case KEY_LeftGUI:
+			returnValue = "Left Super";
+			break;
+		case KEY_RightControl:
+			returnValue = "Right Control";
+			break;
+		case KEY_RightShift:
+			returnValue = "Right Shift";
+			break;
+		case KEY_RightAlt:
+			returnValue = "Right Alt";
+			break;
+		case KEY_RightGUI:
+			returnValue = "Right Super";
+			break;
+	}
+
+	return returnValue;
+}
+
+

--- a/src/GLideNUI/HIDKeyToName.h
+++ b/src/GLideNUI/HIDKeyToName.h
@@ -1,0 +1,8 @@
+#ifndef HIDKEYTONAME
+#define HIDKEYTONAME
+
+#include <QString>
+
+QString HIDKeyToName(unsigned int key);
+
+#endif // HIDKEYTONAME

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -144,6 +144,7 @@ void _loadSettings(QSettings & settings)
 	settings.beginGroup("hotkeys");
 	for (u32 idx = 0; idx < Config::HotKey::hkTotal; ++idx) {
 		config.hotkeys.keys[idx] = settings.value(Config::hotkeyIniName(idx), config.hotkeys.keys[idx]).toInt();
+		config.hotkeys.enabledKeys[idx] = settings.value(Config::enabledHotkeyIniName(idx), config.hotkeys.keys[idx]).toInt();
 	}
 	settings.endGroup();
 
@@ -319,6 +320,7 @@ void writeSettings(const QString & _strIniFolder)
 	settings.beginGroup("hotkeys");
 	for (u32 idx = 0; idx < Config::HotKey::hkTotal; ++idx) {
 		settings.setValue(Config::hotkeyIniName(idx), config.hotkeys.keys[idx]);
+		settings.setValue(Config::enabledHotkeyIniName(idx), config.hotkeys.enabledKeys[idx]);
 	}
 	settings.endGroup();
 

--- a/src/TextureFilterHandler.cpp
+++ b/src/TextureFilterHandler.cpp
@@ -55,7 +55,7 @@ u32 TextureFilterHandler::_getConfigOptions() const
 		options |= (DUMP_TEXCACHE | DUMP_HIRESTEXCACHE);
 	if (config.textureFilter.txHiresFullAlphaChannel)
 		options |= LET_TEXARTISTS_FLY;
-	if (config.hotkeys.keys[Config::HotKey::hkTexDump] != 0)
+	if (config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0)
 		options |= DUMP_TEX;
 	if (config.textureFilter.txDeposterize)
 		options |= DEPOSTERIZE;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -804,7 +804,7 @@ void TextureCache::_loadBackground(CachedTexture *pTexture)
 
 	if (m_toggleDumpTex &&
 		config.textureFilter.txHiresEnable != 0 &&
-		config.hotkeys.keys[Config::HotKey::hkTexDump] != 0) {
+		config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
 		txfilter_dmptx((u8*)pDest, pTexture->width, pTexture->height,
 			pTexture->width, (u16)u32(glInternalFormat),
 			(unsigned short)(pTexture->format << 8 | pTexture->size),
@@ -1216,7 +1216,7 @@ void TextureCache::_load(u32 _tile, CachedTexture *_pTexture)
 
 		if (m_toggleDumpTex &&
 			config.textureFilter.txHiresEnable != 0 &&
-			config.hotkeys.keys[Config::HotKey::hkTexDump] != 0) {
+			config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
 			txfilter_dmptx((u8*)texData.get(), tmptex.width, tmptex.height,
 					tmptex.width, (u16)u32(glInternalFormat),
 					(unsigned short)(_pTexture->format << 8 | _pTexture->size),

--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -107,7 +107,7 @@ static void checkHotkeys()
 		SwitchDump(config.debug.dumpMode);
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkHdTexToggle], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkHdTexToggle], 0x0001)) {
 		if (config.textureFilter.txHiresEnable == 0)
 			dwnd().getDrawer().showMessage("Enable HD textures\n", Milliseconds(750));
 		else
@@ -118,7 +118,7 @@ static void checkHotkeys()
 
 	if (config.textureFilter.txHiresEnable != 0) {
 		/* Force reload hi-res textures. Useful for texture artists */
-		if (osal_is_key_pressed(config.hotkeys.keys[Config::hkHdTexReload], 0x0001)) {
+		if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkHdTexReload], 0x0001)) {
 			dwnd().getDrawer().showMessage("Reload HD textures\n", Milliseconds(750));
 			if (txfilter_reloadhirestex()) {
 				textureCache().clear();
@@ -126,11 +126,11 @@ static void checkHotkeys()
 		}
 
 		/* Turn on texture dump */
-		if (osal_is_key_pressed(config.hotkeys.keys[Config::hkTexDump], 0x0001))
+		if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkTexDump], 0x0001))
 			textureCache().toggleDumpTex();
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkTexCoordBounds], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkTexCoordBounds], 0x0001)) {
 		if (config.graphics2D.enableTexCoordBounds == 0)
 			dwnd().getDrawer().showMessage("Bound texrect texture coordinates on\n", Milliseconds(1000));
 		else
@@ -138,7 +138,7 @@ static void checkHotkeys()
 		config.graphics2D.enableTexCoordBounds = !config.graphics2D.enableTexCoordBounds;
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkNativeResTexrects], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkNativeResTexrects], 0x0001)) {
 		static u32 s_nativeResTexrects = Config::NativeResTexrectsMode::ntOptimized;
 		if (config.graphics2D.enableNativeResTexrects != Config::NativeResTexrectsMode::ntDisable) {
 			s_nativeResTexrects = config.graphics2D.enableNativeResTexrects;
@@ -152,7 +152,7 @@ static void checkHotkeys()
 			dwnd().getDrawer().showMessage("Enable 2D texrects in native resolution\n", Milliseconds(1000));
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkVsync], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkVsync], 0x0001)) {
 		config.video.verticalSync = !config.video.verticalSync;
 		dwnd().stop();
 		dwnd().start();
@@ -163,7 +163,7 @@ static void checkHotkeys()
 	}
 
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkFBEmulation], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkFBEmulation], 0x0001)) {
 		config.frameBufferEmulation.enable = !config.frameBufferEmulation.enable;
 		dwnd().stop();
 		dwnd().start();
@@ -174,7 +174,7 @@ static void checkHotkeys()
 	}
 
 	if (config.frameBufferEmulation.enable != 0 &&
-		osal_is_key_pressed(config.hotkeys.keys[Config::hkN64DepthCompare], 0x0001)) {
+		osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkN64DepthCompare], 0x0001)) {
 		static u32 N64DepthCompare = Config::N64DepthCompareMode::dcCompatible;
 		if (config.frameBufferEmulation.N64DepthCompare != Config::N64DepthCompareMode::dcDisable) {
 			N64DepthCompare = config.frameBufferEmulation.N64DepthCompare;
@@ -189,27 +189,27 @@ static void checkHotkeys()
 			dwnd().getDrawer().showMessage("Enable N64 depth compare\n", Milliseconds(1000));
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkOsdVis], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkOsdVis], 0x0001)) {
 		config.onScreenDisplay.vis = !config.onScreenDisplay.vis;
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkOsdFps], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkOsdFps], 0x0001)) {
 		config.onScreenDisplay.fps = !config.onScreenDisplay.fps;
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkOsdPercent], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkOsdPercent], 0x0001)) {
 		config.onScreenDisplay.percent = !config.onScreenDisplay.percent;
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkOsdInternalResolution], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkOsdInternalResolution], 0x0001)) {
 		config.onScreenDisplay.internalResolution = !config.onScreenDisplay.internalResolution;
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkOsdRenderingResolution], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkOsdRenderingResolution], 0x0001)) {
 		config.onScreenDisplay.renderingResolution = !config.onScreenDisplay.renderingResolution;
 	}
 
-	if (osal_is_key_pressed(config.hotkeys.keys[Config::hkForceGammaCorrection], 0x0001)) {
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkForceGammaCorrection], 0x0001)) {
 		if (config.gammaCorrection.force == 0)
 			dwnd().getDrawer().showMessage("Force gamma correction on\n", Milliseconds(750));
 		else

--- a/src/osal/osal_keys.h
+++ b/src/osal/osal_keys.h
@@ -16,8 +16,6 @@ EXPORT void CALL osal_keys_update_state();
 
 EXPORT unsigned int CALL osal_is_key_pressed(unsigned int _key, unsigned int _mask);
 
-EXPORT const char * CALL osal_keycode_name(unsigned int _hidCode);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/osal/osal_keys_linux.c
+++ b/src/osal/osal_keys_linux.c
@@ -117,7 +117,6 @@ EXPORT void CALL osal_keys_quit()
 
 EXPORT void CALL osal_keys_update_state()
 {
-#ifdef OS_LINUX
 	keyboard_t* keyboard;
 	for (int i = 0; i < l_KeyBoardCount; i++) {
 		keyboard = &l_Keyboards[i];
@@ -127,7 +126,6 @@ EXPORT void CALL osal_keys_update_state()
 		// query keyboard state
 		ioctl(fileno(keyboard->file), EVIOCGKEY(sizeof(keyboard->key_map)), keyboard->key_map);
 	}
-#endif // OS_LINUX
 }
 
 EXPORT unsigned int CALL osal_is_key_pressed(unsigned int _key, unsigned int _mask)

--- a/src/osal/osal_keys_linux.c
+++ b/src/osal/osal_keys_linux.c
@@ -47,36 +47,6 @@ static const unsigned char LINUX_HID_TO_NATIVE[256] = {
 	255, 255, 255, 255, 255, 255, 255, 255, 255, 255
 };
 
-static const char* LINUX_HID_NAME[256] = {
-	0, 0, 0, 0, "A", "B", "C", "D", "E", 
-	"F", "G", "H", "I", "J", "K", "L", "M", 
-	"N", "O", "P", "Q", "R", "S", "T", "U", 
-	"V", "W", "X", "Y", "Z", "1", "2", "3",
-	"4", "5", "6", "7", "8", "9", "0", 0,
-	"Escape", "Delete", "Tab", "Space", "-", "=",
-	"[", "]", "Backslash", 0, ";",
-	"'", "Grave", ",", ".", "/", "Capslock", 
-	"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9",
-	"F10", "F11", "F12", "Print", "Scrolllock", "Pause",
-	"Insert", "Home", "Page Up", "Delete", "End", "Page Down",
-	"Right", "Left", "Down", "Up", "Numlock", "/", "*", "-", "+", 
-	"Enter", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", ".",
-	"\\", "=", "F13", "F14", "F15", "F16", "F17", "F18", "F19", "F20",
-	"F21", "F22", "F23", "F24", 0, "Help", "Menu", 0, 0, 0, 0, 0, 0, 
-	0, 0, "Mute", "Sysrq", "Enter", "Clear", ",", "Left Control", "Left Shift",
-	"Left Alt", "Left Meta", "Right Control", "Right Shift", "Right Alt", "Right Meta",
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
-
 typedef struct {
 	FILE* file;
 	char key_map[KEY_MAX/8 + 1];
@@ -191,11 +161,6 @@ EXPORT unsigned int CALL osal_is_key_pressed(unsigned int _key, unsigned int _ma
 	}
 
 	return 0;
-}
-
-EXPORT const char * CALL osal_keycode_name(unsigned int _hidCode)
-{
-	return LINUX_HID_NAME[_hidCode];
 }
 
 #ifdef __cplusplus

--- a/src/osal/osal_keys_unix.c
+++ b/src/osal/osal_keys_unix.c
@@ -21,15 +21,6 @@ EXPORT unsigned int CALL osal_is_key_pressed(unsigned int _key, unsigned int _ma
 	return 0;
 }
 
-EXPORT unsigned int CALL osal_virtual_key_to_hid(unsigned int _key, unsigned int _hidKey)
-{
-	return 0;
-}
-
-EXPORT const char * CALL osal_keycode_name(unsigned int _hidCode)
-{
-	return 0;
-}
 
 #ifdef __cplusplus
 }

--- a/src/osal/osal_keys_win.c
+++ b/src/osal/osal_keys_win.c
@@ -24,24 +24,6 @@ static const unsigned char WIN_HID_TO_NATIVE[256] = {
 255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
 };
 
-static const char KEYCODE_WINDOWS_NAME_DATA[] =
-"\0'\0,\0-\0.\0/\0;\0=\0A\0B\0Backspace\0C\0Caps Lock\0D\0Delete\0E\0End\0"
-"Enter\0Escape\0F\0F1\0F10\0F11\0F12\0F2\0F3\0F4\0F5\0F6\0F7\0F8\0F9\0G\0H"
-"\0Home\0I\0Insert\0J\0K\0L\0Left\0Left Alt\0Left Control\0Left Shift\0Lef"
-"t Windows\0M\0N\0O\0P\0Page Down\0Page Up\0Pause\0Print Screen\0Q\0R\0Rig"
-"ht\0Right Alt\0Right Control\0Right Shift\0Right Windows\0S\0Scroll Lock"
-"\0T\0Tab\0U\0V\0W\0X\0Y\0Z\0[\0\\\0]\0`";
-static const unsigned short KEYCODE_WINDOWS_NAME_OFFSET[] = {
-	0,0,0,0,15,17,29,41,50,69,110,112,119,128,130,132,185,187,189,191,230,232,
-	290,304,310,312,314,316,318,320,72,84,90,93,96,99,102,105,108,76,0,62,19,
-	306,0,5,13,322,326,324,0,11,1,328,3,7,9,31,71,86,89,92,95,98,101,104,107,74,
-	78,82,217,292,211,121,114,203,43,52,193,234,134,198,208,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,56,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,148,161,139,172,250,264,240,276
-};
-
 EXPORT void CALL osal_keys_init()
 {
 }
@@ -59,17 +41,6 @@ EXPORT unsigned int CALL osal_is_key_pressed(unsigned int _key, unsigned int _ma
 	if (_key == 0 || _key > 255)
 		return 0;
 	return GetAsyncKeyState(WIN_HID_TO_NATIVE[_key]) & _mask;
-}
-
-EXPORT const char * CALL osal_keycode_name(unsigned int _hidCode)
-{
-	unsigned offset;
-	if (232 <= _hidCode)
-		return NULL;
-	offset = KEYCODE_WINDOWS_NAME_OFFSET[_hidCode];
-	if (offset == 0)
-		return NULL;
-	return KEYCODE_WINDOWS_NAME_DATA + offset;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
depends on the changes in #2539, will rebase as needed.

this allows someone to set a key but save it without having it enabled:
![image](https://user-images.githubusercontent.com/18737914/127325435-d12ed50c-89d3-4d91-8a23-c9d57064a6c5.png)

Before this patch this was impossible to do and each disabled key wouldn't save and reset to having no value, that behavior is unexpected in my opinion.