### PR TITLE
GLideNUI: move to static Qt5.15 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 version: 1.0.{build}
 pull_requests:
@@ -8,9 +8,9 @@ environment:
   BUILD_PATH: $(APPVEYOR_BUILD_FOLDER)\build
   QTDIR_x86: C:\Static_Qt_x86
   QTDIR_x64: C:\Static_Qt_x64
-  QT_BUILD_BASE_URL: https://github.com/gonetz/GLideN64/releases/download/qt_build/
-  QT_BUILD_x86: qt-5_7_1-x86-msvc2017-static
-  QT_BUILD_x64: qt-5_7_1-x64-msvc2017-static
+  QT_BUILD_BASE_URL: https://github.com/Rosalie241/GLideN64/releases/download/qt_build/
+  QT_BUILD_x86: qt-5_15-x86-msvc2017-static
+  QT_BUILD_x64: qt-5_15-x64-msvc2017-static
   # Builds
   PJ64PluginsDirQT: $(BUILD_PATH)\QT_for_Project64\
   PJ64PluginsDirQT_x64: $(BUILD_PATH)\QT_for_Project64_x64\

--- a/projects/msvc/GLideNUI.vcxproj
+++ b/projects/msvc/GLideNUI.vcxproj
@@ -67,7 +67,7 @@
       <OutputFile>$(OutDir)\GLideNUI.lib</OutputFile>
     </ClCompile>
     <Lib>
-      <AdditionalLibraryDirectories>$(QTDIR)\lib;$(QTDIR)\plugins\platforms;$(QTDIR)\plugins\imageformats</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(QTDIR)\lib;$(QTDIR)\plugins\styles;$(QTDIR)\plugins\platforms;$(QTDIR)\plugins\imageformats</AdditionalLibraryDirectories>
       <AdditionalDependencies>imm32.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
@@ -80,7 +80,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>qtpcred.lib;qtmaind.lib;qwindowsd.lib;qicod.lib;qtharfbuzzngd.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;Qt5PlatformSupportd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>qtpcre2d.lib;qtmaind.lib;qwindowsd.lib;qicod.lib;Qt5Cored.lib;Qt5Guid.lib;Qt5Widgetsd.lib;UxTheme.lib;qwindowsvistastyled.lib;Qt5WindowsUiAutomationSupportd.lib;Qt5FontDatabaseSupportd.lib;Qt5EventDispatcherSupportd.lib;Qt5FontDatabaseSupportd.lib;Qt5ThemeSupportd.lib;qtharfbuzzd.lib;Ws2_32.lib;Netapi32.lib;Userenv.lib;Ws2_32.lib;Wtsapi32.lib;Imm32.lib;WinMM.lib;Version.lib;Netapi32.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
     <Link>
       <AdditionalDependencies>Qt5UiToolsd.lib;Qt5WinExtrasd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -95,7 +95,7 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>qtpcre.lib;qtmain.lib;qwindows.lib;qico.lib;qtharfbuzzng.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;Qt5PlatformSupport.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>qtpcre2.lib;qtmain.lib;qwindows.lib;qico.lib;Qt5Core.lib;Qt5Gui.lib;Qt5Widgets.lib;UxTheme.lib;qwindowsvistastyle.lib;Qt5WindowsUiAutomationSupport.lib;Qt5FontDatabaseSupport.lib;Qt5EventDispatcherSupport.lib;Qt5FontDatabaseSupport.lib;Qt5ThemeSupport.lib;qtharfbuzz.lib;Ws2_32.lib;Netapi32.lib;Userenv.lib;Ws2_32.lib;Wtsapi32.lib;Imm32.lib;WinMM.lib;Version.lib;Netapi32.lib;Dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
     <Link>
       <AdditionalDependencies>Qt5UiTools.lib;Qt5WinExtras.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -12,6 +12,7 @@
 #include <QtPlugin>
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 #endif
 
 //#define RUN_DIALOG_IN_THREAD


### PR DESCRIPTION
please re-upload the qt builds from [my repo's `qt_build` release](https://github.com/Rosalie241/GLideN64/releases/tag/qt_build) to [your repo's `qt_build` release](https://github.com/gonetz/GLideN64/releases/tag/qt_build) and change the url in `QT_BUILD_BASE_URL`, I'll update the wiki with the new qt build instructions after merging.