### PR TITLE
TxHiResCache: fix texture pack not loading

### DIFF
--- a/src/GLideNHQ/TxHiResCache.cpp
+++ b/src/GLideNHQ/TxHiResCache.cpp
@@ -72,7 +72,7 @@ TxHiResCache::TxHiResCache(int maxwidth,
 
 	/* read in hires textures */
 	if (!_cacheDumped) {
-		if (TxHiResCache::load(0) && (getOptions() & HIRES_DUMP_ENABLED) != 0)
+		if (_load(0) && (getOptions() & HIRES_DUMP_ENABLED) != 0)
 			_cacheDumped = TxCache::save();
 	}
 }


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/gonetz/GLideN64/commit/4a9e1260cef1c9a7d56a176c1384170471095371.

I apologize for not seeing this issue earlier.