### PR TITLE
TxHiResCache: save cache in reload()

### DIFF
--- a/src/GLideNHQ/TxHiResCache.cpp
+++ b/src/GLideNHQ/TxHiResCache.cpp
@@ -151,7 +151,7 @@ bool TxHiResCache::_load(boolean replace) /* 0 : reload, 1 : replace partial */
 
 bool TxHiResCache::reload()
 {
-	return _load(0) && !TxCache::empty();
+	return _load(0) && !TxCache::empty() && TxCache::save();
 }
 
 TxHiResCache::LoadResult TxHiResCache::_loadHiResTextures(const wchar_t * dir_path, boolean replace)


### PR DESCRIPTION
When reloading textures, the file storage would generate an invalid HTS file, this patch fixes that.