### PR TITLE
Revert "GLideNUI: introduce Config{Init,Cleanup}"

### DIFF
--- a/src/GLideNUI-wtl/ConfigDlg.cpp
+++ b/src/GLideNUI-wtl/ConfigDlg.cpp
@@ -438,16 +438,13 @@ public:
 
 GlideN64WtlModule * WtlModule = NULL;
 
-extern "C"
-{
-EXPORT void  CALL ConfigInit(void * hinst) {
+void ConfigInit(void * hinst) {
 	WtlModule = new GlideN64WtlModule((HINSTANCE)hinst);
 }
 
-EXPORT void CALL ConfigCleanup(void) {
+void ConfigCleanup(void) {
 	if (WtlModule) {
 		delete WtlModule;
 		WtlModule = NULL;
 	}
-}
 }

--- a/src/GLideNUI-wtl/ConfigDlg.h
+++ b/src/GLideNUI-wtl/ConfigDlg.h
@@ -76,3 +76,8 @@ protected:
 	uint32_t m_TabLeft, m_ProfileLeft;
 	bool m_Saved;
 };
+
+#ifdef _WIN32
+void ConfigInit(void * hinst);
+void ConfigCleanup(void);
+#endif

--- a/src/GLideNUI-wtl/GLideNUI.h
+++ b/src/GLideNUI-wtl/GLideNUI.h
@@ -13,8 +13,6 @@ extern "C" {
 #define CALL
 #endif
 
-EXPORT void CALL ConfigInit(void * hinst);
-EXPORT void CALL ConfigCleanup(void);
 EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
 EXPORT int CALL RunAbout(const wchar_t * _strFileName);
 EXPORT void CALL LoadConfig(const wchar_t * _strFileName);

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -20,21 +20,29 @@ Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 inline void initMyResource() { Q_INIT_RESOURCE(icon); }
 inline void cleanMyResource() { Q_CLEANUP_RESOURCE(icon); }
 
-static std::unique_ptr<QApplication> s_pQApp;
-static QCoreApplication* s_pAppInstance;
-
 static
 int openConfigDialog(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, float _maxAnisotropy, bool & _accepted)
 {
+	cleanMyResource();
+	initMyResource();
 	QString strIniFileName = QString::fromWCharArray(_strFileName);
 	loadSettings(strIniFileName);
 	if (config.generalEmulation.enableCustomSettings != 0 && _romName != nullptr && strlen(_romName) != 0)
 		loadCustomRomSettings(strIniFileName, _romName);
 
-	QTranslator translator;
-	if (translator.load(getTranslationFile(), strIniFileName)) {
-		s_pAppInstance->installTranslator(&translator);
+	std::unique_ptr<QApplication> pQApp;
+	QCoreApplication* pApp = QCoreApplication::instance();
+
+	if (pApp == nullptr) {
+		int argc = 0;
+		char * argv = 0;
+		pQApp.reset(new QApplication(argc, &argv));
+		pApp = pQApp.get();
 	}
+
+	QTranslator translator;
+	if (translator.load(getTranslationFile(), strIniFileName))
+		pApp->installTranslator(&translator);
 
 	ConfigDialog w(Q_NULLPTR, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint, _maxMSAALevel, _maxAnisotropy);
 
@@ -43,7 +51,7 @@ int openConfigDialog(const wchar_t * _strFileName, const char * _romName, unsign
 	w.setTitle();
 	w.show();
 
-	int res = s_pQApp ? s_pQApp->exec() : w.exec();
+	int res = pQApp ? pQApp->exec() : w.exec();
 	_accepted = w.isAccepted();
 	return res;
 }
@@ -51,13 +59,20 @@ int openConfigDialog(const wchar_t * _strFileName, const char * _romName, unsign
 static
 int openAboutDialog(const wchar_t * _strFileName)
 {
+	cleanMyResource();
+	initMyResource();
+
+	int argc = 0;
+	char * argv = 0;
+	QApplication a(argc, &argv);
+
 	QTranslator translator;
 	if (translator.load(getTranslationFile(), QString::fromWCharArray(_strFileName)))
-		s_pAppInstance->installTranslator(&translator);
+		a.installTranslator(&translator);
 
 	AboutDialog w(Q_NULLPTR, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
 	w.show();
-	return s_pQApp ? s_pQApp->exec() : w.exec();
+	return a.exec();
 }
 
 bool runConfigThread(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy) {
@@ -80,26 +95,6 @@ int runAboutThread(const wchar_t * _strFileName) {
 	openAboutDialog(_strFileName);
 #endif
 	return 0;
-}
-
-EXPORT void CALL ConfigInit(void * hinst)
-{
-	initMyResource();
-
-	s_pAppInstance = QCoreApplication::instance();
-
-	if (s_pAppInstance == nullptr) {
-		int argc = 0;
-		char * argv = 0;
-		s_pQApp.reset(new QApplication(argc, &argv));
-		s_pAppInstance = s_pQApp.get();
-	}
-}
-
-EXPORT void CALL ConfigCleanup(void)
-{
-	cleanMyResource();
-	s_pQApp.release();
 }
 
 EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy)

--- a/src/GLideNUI/GLideNUI.h
+++ b/src/GLideNUI/GLideNUI.h
@@ -7,14 +7,12 @@ extern "C" {
 
 #ifdef OS_WINDOWS
 #define EXPORT	__declspec(dllexport)
-#define CALL	__cdecl
+#define CALL		__cdecl
 #else
 #define EXPORT 	__attribute__((visibility("default")))
 #define CALL
 #endif
 
-EXPORT void CALL ConfigInit(void * hinst);
-EXPORT void CALL ConfigCleanup(void);
 EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
 EXPORT int CALL RunAbout(const wchar_t * _strFileName);
 EXPORT void CALL LoadConfig(const wchar_t * _strFileName);

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -11,10 +11,6 @@
 #define DLSYM(a, b) dlsym(a, b)
 #endif // OS_WINDOWS
 
-#ifdef M64P_GLIDENUI
-#include "GLideNUI/GLideNUI.h"
-#endif
-
 ptr_ConfigGetSharedDataFilepath ConfigGetSharedDataFilepath = nullptr;
 ptr_ConfigGetUserConfigPath ConfigGetUserConfigPath = nullptr;
 ptr_ConfigGetUserDataPath ConfigGetUserDataPath = nullptr;
@@ -107,8 +103,6 @@ m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle)
 			Config_SetDefault();
 		}
 	}
-#else
-	ConfigInit(nullptr);
 #endif // M64P_GLIDENUI
 
 	return M64ERR_SUCCESS;
@@ -128,9 +122,6 @@ m64p_error PluginAPI::PluginShutdown()
 	_callAPICommand(acRomClosed);
 	delete m_pRspThread;
 	m_pRspThread = nullptr;
-#endif
-#ifdef M64P_GLIDENUI
-	ConfigCleanup();
 #endif
 	return M64ERR_SUCCESS;
 }

--- a/src/windows/GLideN64_windows.cpp
+++ b/src/windows/GLideN64_windows.cpp
@@ -1,13 +1,18 @@
 #include "GLideN64_Windows.h"
-#include "GLideNUI/GLideNUI.h"
 
 HWND		hWnd;
 HWND		hStatusBar;
 HWND		hToolBar;
 HINSTANCE	hInstance;
 
+#ifdef WTL_UI
+void ConfigInit(void * hinst);
+void ConfigCleanup(void);
+#endif
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID /*lpvReserved*/)
 {
+#ifdef WTL_UI
     if (dwReason == DLL_PROCESS_ATTACH)
     {
         hInstance = hinstDLL;
@@ -17,5 +22,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID /*lpvReserved*/)
     {
         ConfigCleanup();
     }
+#else
+    hInstance = hinstDLL;
+#endif
 	return TRUE;
 }


### PR DESCRIPTION
This reverts commit 0ebc545c936f004b76cb4df2e57295115e4bbcd7.

Causes crashes when opening the settings window in Project64 under the following circumstances:
- Multiple GLideN64.dll files in the same GFX folder. Happens if at least one of them is a build that contains the changes of that commit.
- Selecting any other graphics plugin but GLideN64.

The only workaround is to delete GLideN64 from the GFX folder.
@Rosalie241 knows about this and asked me to open this PR.