### PR TITLE
GLideNUI: allow loading default settings from GLideN64.default.ini

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -799,7 +799,7 @@ void ConfigDialog::on_buttonBox_clicked(QAbstractButton *button)
 		msgBox.setButtonText(QMessageBox::Cancel, tr("Cancel"));
 		if (msgBox.exec() == QMessageBox::RestoreDefaults) {
 			const u32 enableCustomSettings = config.generalEmulation.enableCustomSettings;
-			config.resetToDefaults();
+			resetSettings(m_strIniPath);
 			config.generalEmulation.enableCustomSettings = enableCustomSettings;
 			setTitle();
 			setRomName(m_romName);

--- a/src/GLideNUI/Settings.h
+++ b/src/GLideNUI/Settings.h
@@ -3,6 +3,7 @@
 
 void loadSettings(const QString & _strIniFolder);
 void writeSettings(const QString & _strIniFolder);
+void resetSettings(const QString & _strIniFolder);
 void loadCustomRomSettings(const QString & _strIniFolder, const char * _strRomName);
 void saveCustomRomSettings(const QString & _strIniFolder, const char * _strRomName);
 QString getTranslationFile();


### PR DESCRIPTION
This allows a ''distribution'' of Project64 with GLideN64 (i.e something my installer installs) to ship a file named `GLideN64.default.ini` which'll be used whenever a user clicks on `Restore Defaults`.