### PR TITLE
Fix some shader compilation errors

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_SpecialShadersFactory.cpp
@@ -130,9 +130,6 @@ namespace glsl {
 				"  fragColor = vec4(uFogColor.rgb, get_alpha());			\n"
 				"}															\n"
 				;
-
-			if (config.frameBufferEmulation.N64DepthCompare == Config::dcDisable && _glinfo.fetch_depth)
-				 m_part = "#extension GL_ARM_shader_framebuffer_fetch_depth_stencil : enable	\n" + m_part;
 		}
 	};
 

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -276,8 +276,13 @@ s32 ContextImpl::getMaxTextureSize() const
 f32 ContextImpl::getMaxAnisotropy() const
 {
 	GLfloat maxInisotropy = 0.0f;
-	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxInisotropy);
-	return maxInisotropy;
+
+	if (m_glInfo.anisotropic_filtering) {
+		glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxInisotropy);
+		return maxInisotropy;
+	} else {
+		return 0.0f;
+	}
 }
 
 void ContextImpl::bindImageTexture(const graphics::Context::BindImageTextureParameters & _params)

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -175,6 +175,7 @@ void GLInfo::init() {
 	ext_fetch_arm =  Utils::isExtensionSupported(*this, "GL_ARM_shader_framebuffer_fetch") && !ext_fetch;
 
 	dual_source_blending = !isGLESX || (Utils::isExtensionSupported(*this, "GL_EXT_blend_func_extended") && !isAnyAdreno);
+	anisotropic_filtering = Utils::isExtensionSupported(*this, "GL_EXT_texture_filter_anisotropic");
 
 #ifdef OS_ANDROID
 	eglImage = eglImage &&
@@ -217,6 +218,8 @@ void GLInfo::init() {
 		ptrDebugMessageControl = (PFNGLDEBUGMESSAGECONTROLPROC) eglGetProcAddress("glDebugMessageControlKHR");
 	}
 #endif
+
+
 
 #ifdef GL_DEBUG
 	glDebugMessageCallback(on_gl_error, nullptr);

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.h
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.h
@@ -39,6 +39,7 @@ struct GLInfo {
 	bool eglImage = false;
 	bool eglImageFramebuffer = false;
 	bool dual_source_blending = false;
+	bool anisotropic_filtering = false;
 	bool coverage = false;
 	Renderer renderer = Renderer::Other;
 


### PR DESCRIPTION
* The device I was testing on doesn't support Anisotropic filtering
* GLSL 100 doesn't support texture, only texture2d
* GLSL 100 doesn't seem to support ```min``` and ```clamp``` with integers.

After making those fixes, it mostly works, it's extremely slow in my GLES 2.0 device though, about a 50% performance loss in addition to the other recent performance losses. The plugin is no longer playable even at lowest settings.

Also, there is some strange issues with lod:
![goldeneye-002](https://user-images.githubusercontent.com/11581687/132134798-78ab27ac-886a-470b-9d5a-806cf708d880.png)
