### PR TITLE
Introduce txHiResUploadLimit 

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -104,6 +104,8 @@ void Config::resetToDefaults()
 	textureFilter.txEnhancedTextureFileStorage = 0;
 	textureFilter.txHiresTextureFileStorage = 0;
 	textureFilter.txNoTextureFileStorage = 0;
+	
+	textureFilter.txHiResUploadLimit = 2000;
 
 	api().GetUserDataPath(textureFilter.txPath);
 	gln_wcscat(textureFilter.txPath, wst("/hires_texture"));

--- a/src/Config.h
+++ b/src/Config.h
@@ -178,6 +178,8 @@ struct Config
 		u32 txHiresTextureFileStorage;		// Use file storage instead of memory cache for hires textures.
 		u32 txNoTextureFileStorage;			// Use no file storage or cache for hires textures.
 
+		u32 txHiResUploadLimit; // Limit of uploading hi-res textures to VRAM (in MB)
+
 		wchar_t txPath[PLUGIN_PATH_SIZE]; // Path to texture packs
 		wchar_t txCachePath[PLUGIN_PATH_SIZE]; // Path to store texture cache, that is .htc files
 		wchar_t txDumpPath[PLUGIN_PATH_SIZE]; // Path to store texture dumps

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -347,6 +347,8 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 	ui->texCachePathLineEdit->setText(QString::fromWCharArray(config.textureFilter.txCachePath));
 	ui->texDumpPathLineEdit->setText(QString::fromWCharArray(config.textureFilter.txDumpPath));
 
+	ui->textureFilterLimitSpinBox->setValue(config.textureFilter.txHiResUploadLimit);
+
 	// OSD settings
 	QString fontName(config.font.name.c_str());
 	ui->fontLineEdit->setText(fontName);
@@ -697,6 +699,8 @@ void ConfigDialog::accept(bool justSave) {
 		return;
 	}
 	config.textureFilter.txDumpPath[txDumpPath.path().toWCharArray(config.textureFilter.txDumpPath)] = L'\0';
+
+	config.textureFilter.txHiResUploadLimit = ui->textureFilterLimitSpinBox->value();
 
 	// OSD settings
 	config.font.size = ui->fontSizeSpinBox->value();

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -106,6 +106,7 @@ void _loadSettings(QSettings & settings)
 	config.textureFilter.txEnhancedTextureFileStorage = settings.value("txEnhancedTextureFileStorage", config.textureFilter.txEnhancedTextureFileStorage).toInt();
 	config.textureFilter.txHiresTextureFileStorage = settings.value("txHiresTextureFileStorage", config.textureFilter.txHiresTextureFileStorage).toInt();
 	config.textureFilter.txNoTextureFileStorage = settings.value("txNoTextureFileStorage", config.textureFilter.txNoTextureFileStorage).toInt();
+	config.textureFilter.txHiResUploadLimit = settings.value("txHiResUploadLimit", config.textureFilter.txHiResUploadLimit).toInt();
 	QString txPath = QString::fromWCharArray(config.textureFilter.txPath);
 	config.textureFilter.txPath[settings.value("txPath", txPath).toString().toWCharArray(config.textureFilter.txPath)] = L'\0';
 	QString txCachePath = QString::fromWCharArray(config.textureFilter.txCachePath);
@@ -252,6 +253,7 @@ void _writeSettingsToFile(const QString & filename)
 	settings.setValue("txEnhancedTextureFileStorage", config.textureFilter.txEnhancedTextureFileStorage);
 	settings.setValue("txHiresTextureFileStorage", config.textureFilter.txHiresTextureFileStorage);
 	settings.setValue("txNoTextureFileStorage", config.textureFilter.txNoTextureFileStorage);
+	settings.setValue("txHiResUploadLimit", config.textureFilter.txHiResUploadLimit);
 	settings.setValue("txPath", QString::fromWCharArray(config.textureFilter.txPath));
 	settings.setValue("txCachePath", QString::fromWCharArray(config.textureFilter.txCachePath));
 	settings.setValue("txDumpPath", QString::fromWCharArray(config.textureFilter.txDumpPath));
@@ -515,6 +517,7 @@ void saveCustomRomSettings(const QString & _strIniFolder, const char * _strRomNa
 	WriteCustomSetting(textureFilter, txEnhancedTextureFileStorage);
 	WriteCustomSetting(textureFilter, txHiresTextureFileStorage);
 	WriteCustomSetting(textureFilter, txNoTextureFileStorage);
+	WriteCustomSetting(textureFilter, txHiResUploadLimit);
 	WriteCustomSetting(textureFilter, txHiresEnable);
 	WriteCustomSetting(textureFilter, txHiresFullAlphaChannel);
 	WriteCustomSetting(textureFilter, txHresAltCRC);

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -2754,6 +2754,66 @@
         </widget>
        </item>
        <item>
+        <widget class="QFrame" name="textureFilterLimitFrame">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_28">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="textureFilterLimitLabel">
+            <property name="text">
+             <string>Limit of uploading hi-res textures to VRAM (0 = no limit): </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="textureFilterLimitSpinBox">
+            <property name="suffix">
+             <string> MB</string>
+            </property>
+            <property name="maximum">
+             <number>99999</number>
+            </property>
+            <property name="singleStep">
+             <number>50</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>266</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <layout class="QVBoxLayout" name="verticalLayout_52">
          <property name="spacing">
           <number>4</number>

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -514,15 +514,30 @@ void TextureCache::destroy()
 	for (FBTextures::const_iterator cur = m_fbTextures.cbegin(); cur != m_fbTextures.cend(); ++cur)
 		gfxContext.deleteTexture(cur->second.name);
 	m_fbTextures.clear();
+
+	m_currentTexCacheSize = 0;
 }
 
 void TextureCache::_checkCacheSize()
 {
-	if (m_textures.size() >= m_maxCacheSize) {
+	const u64 maxCacheSize = config.textureFilter.txHiResUploadLimit * 1024 * 1024;
+
+	// we don't need to do anything,
+	// when the limit has been disabled
+	if (maxCacheSize == 0) {
+		return;
+	}
+
+	// keep removing textures until we're below the max size
+	while (m_currentTexCacheSize >= maxCacheSize)
+	{
 		CachedTexture& clsTex = m_textures.back();
 		gfxContext.deleteTexture(clsTex.name);
 		m_lruTextureLocations.erase(clsTex.crc);
 		m_textures.pop_back();
+
+		// update current cache size
+		m_currentTexCacheSize -= clsTex.textureBytes;
 	}
 }
 
@@ -726,6 +741,7 @@ bool TextureCache::_loadHiresBackground(CachedTexture *_pTexture, u64 & _ricecrc
 
 		assert(!gfxContext.isError());
 		_updateCachedTexture(ghqTexInfo, _pTexture, tile_width, tile_height);
+		m_currentTexCacheSize += _pTexture->textureBytes;
 		return true;
 	}
 	return false;
@@ -838,6 +854,7 @@ void TextureCache::_loadBackground(CachedTexture *pTexture)
 			params.data = ghqTexInfo.data;
 			gfxContext.init2DTexture(params);
 			_updateCachedTexture(ghqTexInfo, pTexture, pTexture->width, pTexture->height);
+			m_currentTexCacheSize += pTexture->textureBytes;
 			bLoaded = true;
 		}
 	}
@@ -951,6 +968,7 @@ bool TextureCache::_loadHiresTexture(u32 _tile, CachedTexture *_pTexture, u64 & 
 		gfxContext.init2DTexture(params);
 		assert(!gfxContext.isError());
 		_updateCachedTexture(ghqTexInfo, _pTexture, width, height);
+		m_currentTexCacheSize += _pTexture->textureBytes;
 		return true;
 	}
 
@@ -1250,6 +1268,7 @@ void TextureCache::_loadFast(u32 _tile, CachedTexture *_pTexture)
 				params.data = ghqTexInfo.data;
 				gfxContext.init2DTexture(params);
 				_updateCachedTexture(ghqTexInfo, _pTexture, tmptex.width, tmptex.height);
+				m_currentTexCacheSize += _pTexture->textureBytes;
 				bLoaded = true;
 			}
 		}
@@ -1477,6 +1496,7 @@ void TextureCache::_loadAccurate(u32 _tile, CachedTexture *_pTexture)
 				params.data = ghqTexInfo.data;
 				gfxContext.init2DTexture(params);
 				_updateCachedTexture(ghqTexInfo, _pTexture, tmptex.width, tmptex.height);
+				m_currentTexCacheSize += _pTexture->textureBytes;
 				bLoaded = true;
 			}
 		}
@@ -1718,6 +1738,7 @@ void TextureCache::clear()
 	}
 	m_textures.clear();
 	m_lruTextureLocations.clear();
+	m_currentTexCacheSize = 0;
 }
 
 void TextureCache::toggleDumpTex()
@@ -1808,6 +1829,8 @@ void TextureCache::update(u32 _t)
 		gfxContext.deleteTexture(currentTex.name);
 		m_lruTextureLocations.erase(locations_iter);
 		m_textures.erase(iter);
+
+		m_currentTexCacheSize -= currentTex.textureBytes;
 	}
 
 	m_misses++;

--- a/src/Textures.h
+++ b/src/Textures.h
@@ -107,11 +107,8 @@ private:
 	s32 m_curUnpackAlignment;
 	bool m_toggleDumpTex;
 	std::vector<u32> m_tempTextureHolder;
-#ifdef VC
-	const size_t m_maxCacheSize = 1500;
-#else
-	const size_t m_maxCacheSize = 8000;
-#endif
+
+	u64 m_currentTexCacheSize = 0;
 };
 
 void getTextureShiftScale(u32 tile, const TextureCache & cache, f32 & shiftScaleS, f32 & shiftScaleT);

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -259,6 +259,8 @@ bool Config_SetDefault()
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "txNoTextureFileStorage", config.textureFilter.txNoTextureFileStorage, "Use no file storage or cache for HD textures.");
 	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultInt(g_configVideoGliden64, "txHiResUploadLimit", config.textureFilter.txHiResUploadLimit, "Limit of uploading hi-res textures to VRAM (in MB, 0 = no limit)");
+	assert(res == M64ERR_SUCCESS);	
 	// Convert to multibyte
 	char txPath[PLUGIN_PATH_SIZE * 2];
 	wcstombs(txPath, config.textureFilter.txPath, PLUGIN_PATH_SIZE * 2);
@@ -471,6 +473,8 @@ void Config_LoadCustomConfig()
 	if (result == M64ERR_SUCCESS) config.textureFilter.txHiresTextureFileStorage = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "textureFilter\\txNoTextureFileStorage", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.textureFilter.txNoTextureFileStorage = atoi(value);
+	result = ConfigExternalGetParameter(fileHandle, sectionName, "textureFilter\\txHiResUploadLimit", value, sizeof(value));
+	if (result == M64ERR_SUCCESS) config.textureFilter.txHiResUploadLimit = atoi(value);
 	ConfigExternalClose(fileHandle);
 }
 
@@ -561,6 +565,7 @@ void Config_LoadConfig()
 	config.textureFilter.txEnhancedTextureFileStorage = ConfigGetParamBool(g_configVideoGliden64, "txEnhancedTextureFileStorage");
 	config.textureFilter.txHiresTextureFileStorage = ConfigGetParamBool(g_configVideoGliden64, "txHiresTextureFileStorage");
 	config.textureFilter.txNoTextureFileStorage = ConfigGetParamBool(g_configVideoGliden64, "txNoTextureFileStorage");
+	config.textureFilter.txHiResUploadLimit = ConfigGetParamInt(g_configVideoGliden64, "txHiResUploadLimit");
 	::mbstowcs(config.textureFilter.txPath, ConfigGetParamString(g_configVideoGliden64, "txPath"), PLUGIN_PATH_SIZE);
 	::mbstowcs(config.textureFilter.txCachePath, ConfigGetParamString(g_configVideoGliden64, "txCachePath"), PLUGIN_PATH_SIZE);
 	::mbstowcs(config.textureFilter.txDumpPath, ConfigGetParamString(g_configVideoGliden64, "txDumpPath"), PLUGIN_PATH_SIZE);


### PR DESCRIPTION
This makes the maximum amount of textures loaded in `Textures.cpp` configurable by the user instead of hardcoding it.

on systems with little VRAM/RAM lowering this value may help to prevent crashes, it will however cause some stutter when we reach the limit (due to the constant removal of textures, however that seems to stabilize after a little while), but that's better than crashing.