### PR TITLE
ci: use ncipollo/release-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,7 @@ jobs:
           git tag -f github-actions
           git push -f origin github-actions
       - name: Create Release
-        uses: Rosalie241/release-action@v1.8.10
+        uses: ncipollo/release-action@v1
         with:
           prerelease: true
           allowUpdates: true


### PR DESCRIPTION
This switches back to the upstream ncipollo/release-action repo for the release action due to my PR being merged.

see https://github.com/ncipollo/release-action/pull/109 & https://github.com/ncipollo/release-action/issues/108#issuecomment-917720916