### PR TITLE
Add multi-monitor support

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -23,6 +23,7 @@ void Config::resetToDefaults()
 #endif
 	video.fullscreenHeight = video.windowedHeight = 480;
 	video.fullscreenRefresh = 60;
+	video.fullscreenMonitor = 0;
 	video.fxaa = 0;
 	video.multisampling = 0;
 	video.maxMultiSampling = 0;

--- a/src/Config.h
+++ b/src/Config.h
@@ -25,6 +25,7 @@ struct Config
 		u32 fullscreen;
 		u32 windowedWidth, windowedHeight;
 		u32 fullscreenWidth, fullscreenHeight, fullscreenRefresh;
+		u32 fullscreenMonitor;
 		u32 fxaa;
 		u32 multisampling, maxMultiSampling;
 		u32 verticalSync;

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -165,9 +165,16 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 	ui->overscanPalTopSpinBox->setValue(config.frameBufferEmulation.overscanPAL.top);
 	ui->overscanPalBottomSpinBox->setValue(config.frameBufferEmulation.overscanPAL.bottom);
 
+	QStringList fullscreenMonitorList;
+	int fullscreenMonitor;
+	fillFullscreenMonitorList(fullscreenMonitor, fullscreenMonitorList);
+	ui->fullscreenMonitorComboBox->clear();
+	ui->fullscreenMonitorComboBox->insertItems(0, fullscreenMonitorList);
+	ui->fullscreenMonitorComboBox->setCurrentIndex(fullscreenMonitor);
+
 	QStringList fullscreenModesList, fullscreenRatesList;
 	int fullscreenMode, fullscreenRate;
-	fillFullscreenResolutionsList(fullscreenModesList, fullscreenMode, fullscreenRatesList, fullscreenRate);
+	fillFullscreenResolutionsList(fullscreenMonitor, fullscreenModesList, fullscreenMode, fullscreenRatesList, fullscreenRate);
 	ui->fullScreenResolutionComboBox->clear();
 	ui->fullScreenResolutionComboBox->insertItems(0, fullscreenModesList);
 	ui->fullScreenResolutionComboBox->setCurrentIndex(fullscreenMode);
@@ -526,8 +533,9 @@ void ConfigDialog::accept(bool justSave) {
 		config.video.windowedHeight = windowedResolutionDimensions[1].trimmed().toInt();
 	}
 
-	getFullscreenResolutions(ui->fullScreenResolutionComboBox->currentIndex(), config.video.fullscreenWidth, config.video.fullscreenHeight);
-	getFullscreenRefreshRate(ui->fullScreenRefreshRateComboBox->currentIndex(), config.video.fullscreenRefresh);
+	config.video.fullscreenMonitor = ui->fullscreenMonitorComboBox->currentIndex();
+	getFullscreenResolutions(ui->fullscreenMonitorComboBox->currentIndex(), ui->fullScreenResolutionComboBox->currentIndex(), config.video.fullscreenWidth, config.video.fullscreenHeight);
+	getFullscreenRefreshRate(ui->fullscreenMonitorComboBox->currentIndex(), ui->fullScreenRefreshRateComboBox->currentIndex(), config.video.fullscreenRefresh);
 
 	config.video.fxaa = ui->fxaaRadioButton->isChecked() ? 1 : 0;
 	config.video.multisampling =
@@ -816,7 +824,20 @@ void ConfigDialog::on_fullScreenResolutionComboBox_currentIndexChanged(int index
 {
 	QStringList fullscreenRatesList;
 	int fullscreenRate;
-	fillFullscreenRefreshRateList(index, fullscreenRatesList, fullscreenRate);
+	fillFullscreenRefreshRateList(ui->fullscreenMonitorComboBox->currentIndex(), index, fullscreenRatesList, fullscreenRate);
+	ui->fullScreenRefreshRateComboBox->clear();
+	ui->fullScreenRefreshRateComboBox->insertItems(0, fullscreenRatesList);
+	ui->fullScreenRefreshRateComboBox->setCurrentIndex(fullscreenRate);
+}
+
+void ConfigDialog::on_fullscreenMonitorComboBox_currentIndexChanged(int index)
+{
+	QStringList fullscreenModesList, fullscreenRatesList;
+	int fullscreenMode, fullscreenRate;
+	fillFullscreenResolutionsList(index, fullscreenModesList, fullscreenMode, fullscreenRatesList, fullscreenRate);
+	ui->fullScreenResolutionComboBox->clear();
+	ui->fullScreenResolutionComboBox->insertItems(0, fullscreenModesList);
+	ui->fullScreenResolutionComboBox->setCurrentIndex(fullscreenMode);
 	ui->fullScreenRefreshRateComboBox->clear();
 	ui->fullScreenRefreshRateComboBox->insertItems(0, fullscreenRatesList);
 	ui->fullScreenRefreshRateComboBox->setCurrentIndex(fullscreenRate);

--- a/src/GLideNUI/ConfigDialog.h
+++ b/src/GLideNUI/ConfigDialog.h
@@ -36,6 +36,8 @@ private slots:
 
 	void on_fullScreenResolutionComboBox_currentIndexChanged(int index);
 
+	void on_fullscreenMonitorComboBox_currentIndexChanged(int index);
+
 	void on_windowedResolutionComboBox_currentIndexChanged(int index);
 
 	void on_windowedResolutionComboBox_currentTextChanged(QString text);

--- a/src/GLideNUI/FullscreenResolutions.h
+++ b/src/GLideNUI/FullscreenResolutions.h
@@ -3,12 +3,12 @@
 
 #include "ConfigDialog.h"
 
-void fillFullscreenResolutionsList(QStringList & _listResolutions, int & _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx);
+void fillFullscreenResolutionsList(int _monitorIdx, QStringList & _listResolutions, int & _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx);
+void fillFullscreenRefreshRateList(int _monitorIdx, int _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx);
+void fillFullscreenMonitorList(int & _monitorIdx, QStringList & _monitors);
 
-void fillFullscreenRefreshRateList(int _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx);
-
-void getFullscreenResolutions(int _idx, unsigned int & _width, unsigned int & _height);
-void getFullscreenRefreshRate(int _idx, unsigned int & _rate);
+void getFullscreenResolutions(int _monitorIdx, int _idx, unsigned int & _width, unsigned int & _height);
+void getFullscreenRefreshRate(int _monitorIdx, int _idx, unsigned int & _rate);
 
 #endif // FULLSCREENRESOLUTIONS_H
 

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -28,6 +28,7 @@ void _loadSettings(QSettings & settings)
 	config.video.windowedWidth = settings.value("windowedWidth", config.video.windowedWidth).toInt();
 	config.video.windowedHeight = settings.value("windowedHeight", config.video.windowedHeight).toInt();
 	config.video.fullscreenRefresh = settings.value("fullscreenRefresh", config.video.fullscreenRefresh).toInt();
+	config.video.fullscreenMonitor = settings.value("fullscreenMonitor", config.video.fullscreenMonitor).toInt();
 	config.video.multisampling = settings.value("multisampling", config.video.multisampling).toInt();
 	config.video.maxMultiSampling = settings.value("maxMultiSampling", config.video.maxMultiSampling).toInt();
 	config.video.fxaa= settings.value("fxaa", config.video.fxaa).toInt();
@@ -173,6 +174,7 @@ void _writeSettingsToFile(const QString & filename)
 	settings.setValue("windowedWidth", config.video.windowedWidth);
 	settings.setValue("windowedHeight", config.video.windowedHeight);
 	settings.setValue("fullscreenRefresh", config.video.fullscreenRefresh);
+	settings.setValue("fullscreenMonitor", config.video.fullscreenMonitor);
 	settings.setValue("multisampling", config.video.multisampling);
 	settings.setValue("maxMultiSampling", config.video.maxMultiSampling);
 	settings.setValue("fxaa", config.video.fxaa);
@@ -447,6 +449,7 @@ void saveCustomRomSettings(const QString & _strIniFolder, const char * _strRomNa
 	WriteCustomSetting(video, windowedWidth);
 	WriteCustomSetting(video, windowedHeight);
 	WriteCustomSetting(video, fullscreenRefresh);
+	WriteCustomSetting(video, fullscreenMonitor);
 	WriteCustomSetting(video, multisampling);
 	WriteCustomSetting(video, fxaa);
 	WriteCustomSetting(video, verticalSync);

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -102,6 +102,20 @@
                  </item>
                 </layout>
                </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_28">
+                 <item>
+                  <widget class="QLabel" name="fullscreenMonitorLabel">
+                   <property name="text">
+                    <string>Monitor:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="fullscreenMonitorComboBox"/>
+                 </item>
+                </layout>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/GLideNUI/fullscreenresolutions_mupen64plus.cpp
+++ b/src/GLideNUI/fullscreenresolutions_mupen64plus.cpp
@@ -57,7 +57,7 @@ static void _fillFullscreenRefreshRateList(QStringList &_listRefreshRates, int &
 	free(rates);
 }
 
-void fillFullscreenResolutionsList(QStringList &_listResolutions, int &_resolutionIdx, QStringList &_listRefreshRates, int &_rateIdx)
+void fillFullscreenResolutionsList(int _monitorIdx, QStringList &_listResolutions, int &_resolutionIdx, QStringList &_listRefreshRates, int &_rateIdx)
 {
 	fullscreen.selected.width = config.video.fullscreenWidth;
 	fullscreen.selected.height = config.video.fullscreenHeight;
@@ -97,7 +97,7 @@ void fillFullscreenResolutionsList(QStringList &_listResolutions, int &_resoluti
 	free(resolutions);
 }
 
-void fillFullscreenRefreshRateList(int _resolutionIdx, QStringList &_listRefreshRates, int &_rateIdx)
+void fillFullscreenRefreshRateList(int _monitorIdx, int _resolutionIdx, QStringList &_listRefreshRates, int &_rateIdx)
 {
 	fullscreen.selected.width = fullscreen.resolution[_resolutionIdx].width;
 	fullscreen.selected.height = fullscreen.resolution[_resolutionIdx].height;
@@ -105,13 +105,18 @@ void fillFullscreenRefreshRateList(int _resolutionIdx, QStringList &_listRefresh
 	_rateIdx = fullscreen.numRefreshRates - 1;
 }
 
-void getFullscreenResolutions(int _idx, unsigned int &_width, unsigned int &_height)
+void fillFullscreenMonitorList(int & _monitorIdx, QStringList & _monitors)
+{
+	_monitors.append(QString::number(1));
+}
+
+void getFullscreenResolutions(int _monitorIdx, int _idx, unsigned int &_width, unsigned int &_height)
 {
 	_width = fullscreen.resolution[_idx].width;
 	_height = fullscreen.resolution[_idx].height;
 }
 
-void getFullscreenRefreshRate(int _idx, unsigned int &_rate)
+void getFullscreenRefreshRate(int _monitorIdx, int _idx, unsigned int &_rate)
 {
 	_rate = fullscreen.refreshRate[_idx];
 }

--- a/src/GLideNUI/fullscreenresolutions_windows.cpp
+++ b/src/GLideNUI/fullscreenresolutions_windows.cpp
@@ -53,53 +53,54 @@ struct
 
 	DWORD	numResolutions;
 	DWORD	numRefreshRates;
-} fullscreen;
+	CHAR 	deviceName[CCHDEVICENAME];
+} fullscreen[32];
 
 static
-void _fillFullscreenRefreshRateList(QStringList & _listRefreshRates, int & _rateIdx)
+void _fillFullscreenRefreshRateList(int _monitorIdx, QStringList & _listRefreshRates, int & _rateIdx)
 {
-	memset(&fullscreen.refreshRate, 0, sizeof(fullscreen.refreshRate));
-	fullscreen.numRefreshRates = 0;
+	memset(&fullscreen[_monitorIdx].refreshRate, 0, sizeof(fullscreen[_monitorIdx].refreshRate));
+	fullscreen[_monitorIdx].numRefreshRates = 0;
 	_rateIdx = 0;
 
 	int i = 0;
-	DEVMODE deviceMode;
-	while (EnumDisplaySettings(NULL, i++, &deviceMode) != 0)
+	DEVMODEA deviceMode;
+	while (EnumDisplaySettingsA(fullscreen[_monitorIdx].deviceName, i++, &deviceMode) != 0)
 	{
 		if (deviceMode.dmBitsPerPel != 32)
 			continue;
 
 		DWORD j = 0;
-		for (; j < fullscreen.numRefreshRates; ++j)	{
-			if ((deviceMode.dmDisplayFrequency == fullscreen.refreshRate[j]))
+		for (; j < fullscreen[_monitorIdx].numRefreshRates; ++j)	{
+			if ((deviceMode.dmDisplayFrequency == fullscreen[_monitorIdx].refreshRate[j]))
 				break;
 		}
-		if ((deviceMode.dmDisplayFrequency != fullscreen.refreshRate[j]) &&
-			(deviceMode.dmPelsWidth == fullscreen.selected.width) &&
-			(deviceMode.dmPelsHeight == fullscreen.selected.height)) {
+		if ((deviceMode.dmDisplayFrequency != fullscreen[_monitorIdx].refreshRate[j]) &&
+			(deviceMode.dmPelsWidth == fullscreen[_monitorIdx].selected.width) &&
+			(deviceMode.dmPelsHeight == fullscreen[_monitorIdx].selected.height)) {
 
-			fullscreen.refreshRate[j] = deviceMode.dmDisplayFrequency;
+			fullscreen[_monitorIdx].refreshRate[j] = deviceMode.dmDisplayFrequency;
 			//: Abbreviation for Hertz; include a leading space if appropriate
 			_listRefreshRates.append(QString::number(deviceMode.dmDisplayFrequency) + QObject::tr(" Hz"));
 
-			if (fullscreen.selected.refreshRate == deviceMode.dmDisplayFrequency)
-				_rateIdx = fullscreen.numRefreshRates;
+			if (fullscreen[_monitorIdx].selected.refreshRate == deviceMode.dmDisplayFrequency)
+				_rateIdx = fullscreen[_monitorIdx].numRefreshRates;
 
-			++fullscreen.numRefreshRates;
+			++fullscreen[_monitorIdx].numRefreshRates;
 		}
 	}
 }
 
-void fillFullscreenResolutionsList(QStringList & _listResolutions, int & _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx)
+void fillFullscreenResolutionsList(int _monitorIdx, QStringList & _listResolutions, int & _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx)
 {
-	fullscreen.selected.width = config.video.fullscreenWidth;
-	fullscreen.selected.height = config.video.fullscreenHeight;
-	fullscreen.selected.refreshRate = config.video.fullscreenRefresh;
+	fullscreen[_monitorIdx].selected.width = config.video.fullscreenWidth;
+	fullscreen[_monitorIdx].selected.height = config.video.fullscreenHeight;
+	fullscreen[_monitorIdx].selected.refreshRate = config.video.fullscreenRefresh;
 
-	memset(&fullscreen.resolution, 0, sizeof(fullscreen.resolution));
-	memset(&fullscreen.refreshRate, 0, sizeof(fullscreen.refreshRate));
-	fullscreen.numResolutions = 0;
-	fullscreen.numRefreshRates = 0;
+	memset(&fullscreen[_monitorIdx].resolution, 0, sizeof(fullscreen[_monitorIdx].resolution));
+	memset(&fullscreen[_monitorIdx].refreshRate, 0, sizeof(fullscreen[_monitorIdx].refreshRate));
+	fullscreen[_monitorIdx].numResolutions = 0;
+	fullscreen[_monitorIdx].numRefreshRates = 0;
 	_resolutionIdx = 0;
 
 	static
@@ -119,24 +120,24 @@ void fillFullscreenResolutionsList(QStringList & _listResolutions, int & _resolu
 
 	int i = 0;
 	char text[128];
-	DEVMODE deviceMode;
-	while (EnumDisplaySettings(NULL, i++, &deviceMode) != 0)
+	DEVMODEA deviceMode;
+	while (EnumDisplaySettingsA(fullscreen[_monitorIdx].deviceName, i++, &deviceMode) != 0)
 	{
 		if (deviceMode.dmBitsPerPel != 32)
 			continue;
 
 		DWORD j = 0;
-		for (; j < fullscreen.numResolutions; ++j) {
-			if ((deviceMode.dmPelsWidth == fullscreen.resolution[j].width) &&
-				(deviceMode.dmPelsHeight == fullscreen.resolution[j].height)) {
+		for (; j < fullscreen[_monitorIdx].numResolutions; ++j) {
+			if ((deviceMode.dmPelsWidth == fullscreen[_monitorIdx].resolution[j].width) &&
+				(deviceMode.dmPelsHeight == fullscreen[_monitorIdx].resolution[j].height)) {
 				break;
 			}
 		}
-		if ((deviceMode.dmPelsWidth != fullscreen.resolution[j].width) ||
-			(deviceMode.dmPelsHeight != fullscreen.resolution[j].height)) {
+		if ((deviceMode.dmPelsWidth != fullscreen[_monitorIdx].resolution[j].width) ||
+			(deviceMode.dmPelsHeight != fullscreen[_monitorIdx].resolution[j].height)) {
 
-			fullscreen.resolution[fullscreen.numResolutions].width = deviceMode.dmPelsWidth;
-			fullscreen.resolution[fullscreen.numResolutions].height = deviceMode.dmPelsHeight;
+			fullscreen[_monitorIdx].resolution[fullscreen[_monitorIdx].numResolutions].width = deviceMode.dmPelsWidth;
+			fullscreen[_monitorIdx].resolution[fullscreen[_monitorIdx].numResolutions].height = deviceMode.dmPelsHeight;
 			snprintf(text, 128, "%i x %i", deviceMode.dmPelsWidth, deviceMode.dmPelsHeight);
 
 			for (int j = 0; j < numRatios; ++j)
@@ -148,32 +149,63 @@ void fillFullscreenResolutionsList(QStringList & _listResolutions, int & _resolu
 
 			_listResolutions.append(text);
 
-			if ((fullscreen.selected.width == deviceMode.dmPelsWidth) &&
-				(fullscreen.selected.height == deviceMode.dmPelsHeight))
-				_resolutionIdx = fullscreen.numResolutions;
+			if ((fullscreen[_monitorIdx].selected.width == deviceMode.dmPelsWidth) &&
+				(fullscreen[_monitorIdx].selected.height == deviceMode.dmPelsHeight))
+				_resolutionIdx = fullscreen[_monitorIdx].numResolutions;
 
-			++fullscreen.numResolutions;
+			++fullscreen[_monitorIdx].numResolutions;
 		}
 	}
 
-	_fillFullscreenRefreshRateList(_listRefreshRates, _rateIdx);
+	_fillFullscreenRefreshRateList(_monitorIdx, _listRefreshRates, _rateIdx);
 }
 
-void fillFullscreenRefreshRateList(int _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx)
+void fillFullscreenRefreshRateList(int _monitorIdx, int _resolutionIdx, QStringList & _listRefreshRates, int & _rateIdx)
 {
-	fullscreen.selected.width = fullscreen.resolution[_resolutionIdx].width;
-	fullscreen.selected.height = fullscreen.resolution[_resolutionIdx].height;
-	_fillFullscreenRefreshRateList(_listRefreshRates, _rateIdx);
-	_rateIdx = fullscreen.numRefreshRates - 1;
+	fullscreen[_monitorIdx].selected.width = fullscreen[_monitorIdx].resolution[_resolutionIdx].width;
+	fullscreen[_monitorIdx].selected.height = fullscreen[_monitorIdx].resolution[_resolutionIdx].height;
+	_fillFullscreenRefreshRateList(_monitorIdx, _listRefreshRates, _rateIdx);
+	_rateIdx = fullscreen[_monitorIdx].numRefreshRates - 1;
 }
 
-void getFullscreenResolutions(int _idx, unsigned int & _width, unsigned int & _height)
+void getFullscreenResolutions(int _monitorIdx, int _idx, unsigned int & _width, unsigned int & _height)
 {
-	_width = fullscreen.resolution[_idx].width;
-	_height = fullscreen.resolution[_idx].height;
+	_width = fullscreen[_monitorIdx].resolution[_idx].width;
+	_height = fullscreen[_monitorIdx].resolution[_idx].height;
 }
 
-void getFullscreenRefreshRate(int _idx, unsigned int & _rate)
+static BOOL CALLBACK Monitorenumproc(HMONITOR monitorHandle, HDC deviceHandle, LPRECT monitorRect, LPARAM data)
 {
-	_rate = fullscreen.refreshRate[_idx];
+	UNREFERENCED_PARAMETER(deviceHandle);
+	UNREFERENCED_PARAMETER(monitorRect);
+
+	int* currentMonitor = (int*)data;
+
+	memset(&fullscreen[*currentMonitor].deviceName, 0, sizeof(fullscreen[*currentMonitor].deviceName));
+
+	MONITORINFOEXA monitorInfo;
+	monitorInfo.cbSize = sizeof(MONITORINFOEXA);
+	if (GetMonitorInfoA(monitorHandle, &monitorInfo)) {
+		strcpy(fullscreen[*currentMonitor].deviceName, monitorInfo.szDevice);
+	}
+
+	*currentMonitor = *currentMonitor + 1;
+	return true;
+}
+
+void fillFullscreenMonitorList(int & _monitorIdx, QStringList & _monitors)
+{
+	_monitorIdx = config.video.fullscreenMonitor;
+
+	int monitorCount = 0;
+	EnumDisplayMonitors(NULL, NULL, Monitorenumproc, (LPARAM)&monitorCount);
+
+	for (int i = 0; (i < monitorCount && i < 32); i++) {
+		_monitors.append(QString::number(i + 1));
+	}
+}
+
+void getFullscreenRefreshRate(int _monitorIdx, int _idx, unsigned int & _rate)
+{
+	_rate = fullscreen[_monitorIdx].refreshRate[_idx];
 }


### PR DESCRIPTION
This adds the ability to choose a fullscreen monitor, this is handy when someone wants to make GLideN64 fullscreen on a different monitor than their primary one.

Fixes https://github.com/gonetz/GLideN64/issues/447
Fixes https://github.com/gonetz/GLideN64/issues/2442