### PR TITLE
WindowsWGL: use adaptive vsync when supported

### DIFF
--- a/src/Graphics/OpenGLContext/windows/WindowsWGL.cpp
+++ b/src/Graphics/OpenGLContext/windows/WindowsWGL.cpp
@@ -102,7 +102,15 @@ bool WindowsWGL::start()
 
 		if (strstr(wglextensions, "WGL_EXT_swap_control") != nullptr) {
 			PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
-			wglSwapIntervalEXT(config.video.verticalSync);
+
+			// use adaptive vsync when supported and
+			// when vsync is enabled
+			if (strstr(wglextensions, "WGL_EXT_swap_control_tear") != nullptr &&
+				config.video.verticalSync > 0) {
+				wglSwapIntervalEXT(-1);
+			} else {
+				wglSwapIntervalEXT(config.video.verticalSync);
+			}
 		}
 	}
 


### PR DESCRIPTION
From https://www.khronos.org/opengl/wiki/Swap_Interval:

> if the renderer takes slightly longer than the v-blank intervals to render, say 18ms, then a different problem can result. It will effectively take two full v-blank intervals to display an image to the user, turning a 60fps program into a 30fps program.

I think this behavior is undesirable for end-users, so this patch makes `WindowsWGL` use adaptive vsync instead (when supported), which works in a different way:

> Adaptive vsync enables v-blank synchronisation when the frame rate is higher than the sync rate, but disables synchronisation when the frame rate drops below the sync rate. Disabling the synchronisation on low frame rates prevents the common problem where the frame rate syncs to a integer fraction of the screen's refresh rate in a complex scene. 

I personally feel like such behavior is more desirable, because before this patch, some users were complaining that sometimes their game would halve in speed for some time when vsync was enabled due to some slowdown (i.e vsync would force the game at 30 Hz instead of 60 Hz).