### PR TITLE
Remove CLIP control hack for GLES

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -394,11 +394,6 @@ CachedTexture * FrameBuffer::_getSubTexture(u32 _t)
 		copyHeight = m_pTexture->height - y0;
 
 	ObjectHandle readFBO = m_FBO;
-	if (Context::WeakBlitFramebuffer &&
-			m_pTexture->frameBufferTexture == CachedTexture::fbMultiSample) {
-		resolveMultisampledTexture(true);
-		readFBO = m_resolveFBO;
-	}
 
 	Context::BlitFramebuffersParams blitParams;
 	blitParams.readBuffer = readFBO;
@@ -1020,11 +1015,8 @@ void FrameBufferList::attachDepthBuffer()
 
 		bool goodDepthBufferTexture = false;
 		if (Context::DepthFramebufferTextures) {
-			if (Context::WeakBlitFramebuffer)
-				goodDepthBufferTexture = pDepthBuffer->m_pDepthBufferTexture->width == pCurrent->m_pTexture->width;
-			else
-				goodDepthBufferTexture = pDepthBuffer->m_pDepthBufferTexture->width >= pCurrent->m_pTexture->width ||
-											std::abs(static_cast<s32>(pCurrent->m_width) - static_cast<s32>(pDepthBuffer->m_width)) < 2;
+			goodDepthBufferTexture = pDepthBuffer->m_pDepthBufferTexture->width >= pCurrent->m_pTexture->width ||
+					std::abs(static_cast<s32>(pCurrent->m_width) - static_cast<s32>(pDepthBuffer->m_width)) < 2;
 		} else {
 			goodDepthBufferTexture = pDepthBuffer->m_depthRenderbufferWidth == pCurrent->m_pTexture->width;
 		}

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -12,7 +12,6 @@ bool Context::DepthFramebufferTextures = false;
 bool Context::ShaderProgramBinary = false;
 bool Context::ImageTextures = false;
 bool Context::IntegerTextures = false;
-bool Context::ClipControl = false;
 bool Context::FramebufferFetchDepth = false;
 bool Context::FramebufferFetchColor = false;
 bool Context::TextureBarrier = false;
@@ -39,7 +38,6 @@ void Context::init()
 	ShaderProgramBinary = m_impl->isSupported(SpecialFeatures::ShaderProgramBinary);
 	ImageTextures = m_impl->isSupported(SpecialFeatures::ImageTextures);
 	IntegerTextures = m_impl->isSupported(SpecialFeatures::IntegerTextures);
-	ClipControl = m_impl->isSupported(SpecialFeatures::ClipControl);
 	FramebufferFetchDepth = m_impl->isSupported(SpecialFeatures::N64DepthWithFbFetchDepth);
 	FramebufferFetchColor = m_impl->isSupported(SpecialFeatures::FramebufferFetchColor);
 	TextureBarrier = m_impl->isSupported(SpecialFeatures::TextureBarrier);

--- a/src/Graphics/Context.cpp
+++ b/src/Graphics/Context.cpp
@@ -7,7 +7,6 @@ Context gfxContext;
 
 bool Context::Multisampling = false;
 bool Context::BlitFramebuffer = false;
-bool Context::WeakBlitFramebuffer = false;
 bool Context::DepthFramebufferTextures = false;
 bool Context::ShaderProgramBinary = false;
 bool Context::ImageTextures = false;
@@ -33,7 +32,6 @@ void Context::init()
 	m_fbTexFormats.reset(m_impl->getFramebufferTextureFormats());
 	Multisampling = m_impl->isSupported(SpecialFeatures::Multisampling);
 	BlitFramebuffer = m_impl->isSupported(SpecialFeatures::BlitFramebuffer);
-	WeakBlitFramebuffer = m_impl->isSupported(SpecialFeatures::WeakBlitFramebuffer);
 	DepthFramebufferTextures = m_impl->isSupported(SpecialFeatures::DepthFramebufferTextures);
 	ShaderProgramBinary = m_impl->isSupported(SpecialFeatures::ShaderProgramBinary);
 	ImageTextures = m_impl->isSupported(SpecialFeatures::ImageTextures);

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -23,7 +23,6 @@ namespace graphics {
 		ShaderProgramBinary,
 		ImageTextures,
 		IntegerTextures,
-		ClipControl,
 		N64DepthWithFbFetchDepth,
 		FramebufferFetchColor,
 		TextureBarrier,
@@ -300,7 +299,6 @@ namespace graphics {
 		static bool ShaderProgramBinary;
 		static bool ImageTextures;
 		static bool IntegerTextures;
-		static bool ClipControl;
 		static bool FramebufferFetchDepth;
 		static bool FramebufferFetchColor;
 		static bool TextureBarrier;

--- a/src/Graphics/Context.h
+++ b/src/Graphics/Context.h
@@ -18,7 +18,6 @@ namespace graphics {
 	enum class SpecialFeatures {
 		Multisampling,
 		BlitFramebuffer,
-		WeakBlitFramebuffer,
 		DepthFramebufferTextures,
 		ShaderProgramBinary,
 		ImageTextures,
@@ -294,7 +293,6 @@ namespace graphics {
 
 		static bool Multisampling;
 		static bool BlitFramebuffer;
-		static bool WeakBlitFramebuffer;
 		static bool DepthFramebufferTextures;
 		static bool ShaderProgramBinary;
 		static bool ImageTextures;

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -522,8 +522,6 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 		return m_glInfo.depthTexture;
 	case graphics::SpecialFeatures::IntegerTextures:
 		return !m_glInfo.isGLES2;
-	case graphics::SpecialFeatures::ClipControl:
-		return !m_glInfo.isGLESX;
 	case graphics::SpecialFeatures::N64DepthWithFbFetchDepth:
 		return m_glInfo.n64DepthWithFbFetch;
 	case graphics::SpecialFeatures::FramebufferFetchColor:

--- a/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
+++ b/src/Graphics/OpenGLContext/opengl_ContextImpl.cpp
@@ -510,8 +510,6 @@ bool ContextImpl::isSupported(graphics::SpecialFeatures _feature) const
 	switch (_feature) {
 	case graphics::SpecialFeatures::BlitFramebuffer:
 		return !m_glInfo.isGLES2;
-	case graphics::SpecialFeatures::WeakBlitFramebuffer:
-		return m_glInfo.isGLESX;
 	case graphics::SpecialFeatures::Multisampling:
 		return m_glInfo.msaa;
 	case graphics::SpecialFeatures::ImageTextures:

--- a/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
+++ b/src/Graphics/OpenGLContext/opengl_GLInfo.cpp
@@ -104,6 +104,11 @@ void GLInfo::init() {
 		config.generalEmulation.enableHybridFilter = 0;
 	}
 
+	// Force software vertex clipping to enabled for GLES
+	if (isGLESX) {
+		config.generalEmulation.enableClipping = 1;
+	}
+
 	drawElementsBaseVertex = !isGLESX ||
 		(Utils::isExtensionSupported(*this, "GL_EXT_draw_elements_base_vertex") || numericVersion >= 32);
 #ifdef EGL

--- a/src/GraphicsDrawer.cpp
+++ b/src/GraphicsDrawer.cpp
@@ -95,15 +95,6 @@ void GraphicsDrawer::addTriangle(u32 _v0, u32 _v1, u32 _v2)
 			vtx.z = gDP.primDepth.z * vtx.w;
 		}
 	}
-
-	if (!Context::ClipControl) {
-		if (GBI.isNoN() && gDP.otherMode.depthCompare == 0 && gDP.otherMode.depthUpdate == 0) {
-			for (u32 i = firstIndex; i < triangles.num; ++i) {
-				SPVertex & vtx = triangles.vertices[triangles.elements[i]];
-				vtx.z = 0.0f;
-			}
-		}
-	}
 }
 
 void GraphicsDrawer::_updateCullFace() const


### PR DESCRIPTION
It's not longer needed due to software vertex clipping.
