### PR TITLE
cmake: Better handling of CMAKE_BUILD_TYPE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,6 +163,25 @@ if(MUPENPLUSAPI_GLIDENUI OR NOT MUPENPLUSAPI)
   endif()
 endif()
 
+# Build type
+
+if( NOT CMAKE_BUILD_TYPE)
+        set( CMAKE_BUILD_TYPE Release)
+endif( NOT CMAKE_BUILD_TYPE)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+        set(GLIDEN64_BUILD_TYPE Release)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        set(GLIDEN64_BUILD_TYPE Debug)
+endif()
+
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
+	set( DEBUG_BUILD TRUE)
+	add_definitions(
+		-DGL_DEBUG
+	)
+endif( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
+
 #check if we're running on Raspberry Pi
 if(EXISTS "${CMAKE_FIND_ROOT_PATH}/opt/vc/include/bcm_host.h" AND NOT MESA)
   message("bcm_host.h found")
@@ -365,7 +384,7 @@ if(ANDROID)
             SHARED
             IMPORTED )
 
-    if( CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
         set( BUILD_VARIANT "debug" )
     else()
         set( BUILD_VARIANT "release" )
@@ -444,19 +463,12 @@ if(X86_OPT)
   )
 endif(X86_OPT)
 
-# Build type
-
-if( NOT CMAKE_BUILD_TYPE)
-	set( CMAKE_BUILD_TYPE Release)
-endif( NOT CMAKE_BUILD_TYPE)
-
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
-	set( CMAKE_BUILD_TYPE Debug)
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 	set( DEBUG_BUILD TRUE)
 	add_definitions(
 	-DGL_DEBUG
 	)
-endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
+endif( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 
 if(GL_PROFILE)
     add_definitions(
@@ -502,12 +514,33 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 add_library( ${GLideN64_DLL_NAME} SHARED ${GLideN64_SOURCES} ${PATH_REVISION})
 
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
-  SET_TARGET_PROPERTIES(
+set_target_properties(
 	${GLideN64_DLL_NAME}
 	PROPERTIES
 	LINKER_LANGUAGE CXX # Or else we get an error message, because cmake can't figure out from the ".o"-suffix that it is a C-linker we need.
 	PREFIX ""
+)
+
+if(GLIDEN64_BUILD_TYPE STREQUAL "Release")
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT result)
+  if(result)
+    message("Interprocedural optimizations enabled")
+    set_property(TARGET ${GLideN64_DLL_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -O3")
+  endif()
+  SET_TARGET_PROPERTIES(
+        ${GLideN64_DLL_NAME}
+        PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugin/Release
+  )
+
+endif(GLIDEN64_BUILD_TYPE STREQUAL "Release")
+
+if(GLIDEN64_BUILD_TYPE STREQUAL "Debug")
+  SET_TARGET_PROPERTIES(
+	${GLideN64_DLL_NAME}
+	PROPERTIES
 	LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugin/Debug
   )
 
@@ -524,39 +557,21 @@ if( CMAKE_BUILD_TYPE STREQUAL "Debug")
 	  target_link_libraries(${GLideN64_DLL_NAME} PRIVATE ${OPENGL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osald GLideNHQd )
 	endif (NOHQ)
   endif(SDL)
-endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
-
-if( CMAKE_BUILD_TYPE STREQUAL "Release")
-  include(CheckIPOSupported)
-  check_ipo_supported(RESULT result)
-  if(result)
-    message("Interprocedural optimizations enabled")
-    set_property(TARGET ${GLideN64_DLL_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -O3")
-  endif()
-
-  SET_TARGET_PROPERTIES(
-	${GLideN64_DLL_NAME}
-	PROPERTIES
-	LINKER_LANGUAGE CXX # Or else we get an error message, because cmake can't figure out from the ".o"-suffix that it is a C-linker we need.
-	PREFIX ""
-	LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugin/Release
-  )
-
+else(GLIDEN64_BUILD_TYPE STREQUAL "Debug")
   if(SDL)
-	if (NOHQ)
-	  target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${SDL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal )
-	else (NOHQ)
-	  target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${SDL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal GLideNHQ )
-	endif (NOHQ)
+        if (NOHQ)
+          target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${SDL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal )
+        else (NOHQ)
+          target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${SDL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal GLideNHQ )
+        endif (NOHQ)
   else(SDL)
-	if (NOHQ)
-	  target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal )
-	else (NOHQ)
-	  target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal GLideNHQ )
-	endif (NOHQ)
+        if (NOHQ)
+          target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal )
+        else (NOHQ)
+          target_link_libraries(${GLideN64_DLL_NAME} ${OPENGL_LIBRARIES} ${FREETYPE_LIBRARIES} ${LOG_LIB} ${GLIDENUI_LIBRARIES} osal GLideNHQ )
+        endif (NOHQ)
   endif(SDL)
-endif( CMAKE_BUILD_TYPE STREQUAL "Release")
+endif(GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)
 	install(TARGETS ${GLideN64_DLL_NAME}

--- a/src/GLideNHQ/CMakeLists.txt
+++ b/src/GLideNHQ/CMakeLists.txt
@@ -54,17 +54,12 @@ endif(WIN32)
 
 # Build type
 
-if( NOT CMAKE_BUILD_TYPE)
-	set( CMAKE_BUILD_TYPE Release)
-endif( NOT CMAKE_BUILD_TYPE)
-
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
-	set( CMAKE_BUILD_TYPE Debug)
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 	set( DEBUG_BUILD TRUE)
 	add_definitions(
 		-DDEBUG
 	)
-endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
+endif( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	add_definitions( -D__MSC__)
@@ -81,12 +76,12 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQ
 endif()
 
 add_definitions( -DTXFILTER_LIB)
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
     SET( BUILD_VARIANT "debug" )
 else()
     SET( BUILD_VARIANT "release" )
 endif()
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
   add_library( GLideNHQd STATIC ${GLideNHQ_SOURCES})
   set_target_properties(GLideNHQd PROPERTIES LINK_SEARCH_START_STATIC 1)
   set_target_properties(GLideNHQd PROPERTIES LINK_SEARCH_END_STATIC 1)
@@ -113,9 +108,7 @@ if( CMAKE_BUILD_TYPE STREQUAL "Debug")
       osald
     )
   endif(MINGW OR BCMHOST OR APPLE OR USE_SYSTEM_LIBS)
-endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
-
-if( CMAKE_BUILD_TYPE STREQUAL "Release")
+else( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
   add_library( GLideNHQ STATIC ${GLideNHQ_SOURCES})
 
 #  set_target_properties(GLideNHQ PROPERTIES LINK_SEARCH_START_STATIC 1)
@@ -152,4 +145,4 @@ if( CMAKE_BUILD_TYPE STREQUAL "Release")
       osal
     )
   endif(PANDORA)
-endif( CMAKE_BUILD_TYPE STREQUAL "Release")
+endif( GLIDEN64_BUILD_TYPE STREQUAL "Debug")

--- a/src/osal/CMakeLists.txt
+++ b/src/osal/CMakeLists.txt
@@ -28,17 +28,12 @@ endif(WIN32)
 
 # Build type
 
-if( NOT CMAKE_BUILD_TYPE)
-	set( CMAKE_BUILD_TYPE Release)
-endif( NOT CMAKE_BUILD_TYPE)
-
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
-	set( CMAKE_BUILD_TYPE Debug)
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 	set( DEBUG_BUILD TRUE)
 	add_definitions(
 		-DDEBUG
 	)
-endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
+endif( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	add_definitions( -D__MSC__)
@@ -53,10 +48,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQ
     SET( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -static ${PIC_FLAGS} " )
 endif()
 
-if( CMAKE_BUILD_TYPE STREQUAL "Debug")
+if( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
   add_library( osald STATIC ${OSAL_SOURCES})
-endif( CMAKE_BUILD_TYPE STREQUAL "Debug")
-
-if( CMAKE_BUILD_TYPE STREQUAL "Release")
+else( GLIDEN64_BUILD_TYPE STREQUAL "Debug")
   add_library( osal STATIC ${OSAL_SOURCES})
-endif( CMAKE_BUILD_TYPE STREQUAL "Release")
+endif( GLIDEN64_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
There are four main variable for `CMAKE_BUILD_TYPE`, `Debug`, `Release`, `RelWithDebInfo` and `MinSizeRel`. Additionally there is 'None' which acts as a plain build.

This PR will make it work better with all of them, especially `None` which I was using was problematic where it missed several parts of the build.