### PR TITLE
cmake: Better handling of git

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,11 +12,20 @@ option(GL_PROFILE "Set to ON to turn on GL profiling" ${GL_PROFILE})
 
 # run script to generate Revision.h
 set(PATH_REVISION "Revision.h")
-add_custom_command(
-        OUTPUT ${PATH_REVISION}
-        COMMAND ${CMAKE_SOURCE_DIR}/getRevision.sh
-        COMMENT "Generate Git version"
-)
+find_package(Git)
+if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
+	add_custom_command(
+		OUTPUT ${PATH_REVISION}
+		COMMAND ${CMAKE_SOURCE_DIR}/getRevision.sh
+		COMMENT "Generate Git version"
+	)
+else(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
+	add_custom_command(
+		OUTPUT ${PATH_REVISION}
+		COMMAND ${CMAKE_SOURCE_DIR}/getRevision.sh --nogit
+		COMMENT "Generate version"
+	)
+endif(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
 set_property(SOURCE ${PATH_REVISION} PROPERTY SKIP_AUTOGEN ON)
 
 project( GLideN64 )
@@ -534,7 +543,6 @@ if(GLIDEN64_BUILD_TYPE STREQUAL "Release")
         PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugin/Release
   )
-
 endif(GLIDEN64_BUILD_TYPE STREQUAL "Release")
 
 if(GLIDEN64_BUILD_TYPE STREQUAL "Debug")

--- a/src/getRevision.sh
+++ b/src/getRevision.sh
@@ -1,12 +1,28 @@
-SCRIPT_DIRECTORY=`dirname "$0"`
-rev=\"`git rev-parse --short HEAD`\"
-lastrev=$(head -n 1 "$SCRIPT_DIRECTORY/Revision.h" 2> /dev/null | cut -d ' ' -f3)
+#!/bin/sh
 
-echo current revision $rev
-echo last build revision $lastrev
+set -eu
+
+cd -- "$(cd -- "${0%/*}/" && pwd -P)"
+
+header='./Revision.h'
+
+if [ "${1:-}" != --nogit ]
+then
+   rev="\"$(git rev-parse --short HEAD)\"" || rev='""'
+else
+   rev='""'
+fi
+
+lastrev=''
+if [ -e "$header" ]
+then
+   lastrev="$(head -n 1 "$header" 2> /dev/null | cut -d ' ' -f3)"
+fi
+
+printf '%s\n' "current revision $rev" "last build revision $lastrev"
 
 if [ "$lastrev" != "$rev" ]
 then
-   echo "#define PLUGIN_REVISION $rev" > "$SCRIPT_DIRECTORY/Revision.h"
-   echo "#define PLUGIN_REVISION_W L$rev" >> "$SCRIPT_DIRECTORY/Revision.h"
+   printf '%s\n' "#define PLUGIN_REVISION $rev" \
+      "#define PLUGIN_REVISION_W L$rev" > "$header"
 fi


### PR DESCRIPTION
This fixes some problems:

* When building out of tree the git command will work in the wrong directory.
* The user may not actually have git installed.
* The source tree may not actually have the `.git` directory, for example when downloading a source archive from github.