### PR TITLE
src/GLideNHQ/CMakeLists.txt: Bump cmake version

### DIFF
--- a/src/GLideNHQ/CMakeLists.txt
+++ b/src/GLideNHQ/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.9)
 
 project( GLideNHQ )
 


### PR DESCRIPTION
This matches the other cmake files.

Silences a cmake warning with `cmake-3.21.4`.
```
CMake Deprecation Warning at GLideNHQ/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```