### PR TITLE
Tex coord bounds fix

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactoryAccurate.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactoryAccurate.cpp
@@ -26,8 +26,7 @@ public:
 	void update(bool _force) override {
 		const bool isNativeRes = config.frameBufferEmulation.nativeResFactor == 1 && config.video.multisampling == 0;
 		const bool isTexRect = dwnd().getDrawer().getDrawingState() == DrawingState::TexRect;
-		const bool isBackground = gSP.textureTile[0] != nullptr && gSP.textureTile[0]->textureMode == TEXTUREMODE_BGIMAGE;
-		const bool useTexCoordBounds = (isTexRect || isBackground) && !isNativeRes && config.graphics2D.enableTexCoordBounds;
+		const bool useTexCoordBounds = gDP.m_texCoordBounds.valid && !isNativeRes;
 		/* At rasterization stage, the N64 places samples on the top left of the fragment while OpenGL		*/
 		/* places them in the fragment center. As a result, a normal approach results in shifted texture	*/
 		/* coordinates. In native resolution, this difference can be negated by shifting vertices by 0.5.	*/
@@ -83,6 +82,7 @@ public:
 		uTexCoordOffset.set(texCoordOffset[0], texCoordOffset[1], _force);
 		uUseTexCoordBounds.set(useTexCoordBounds ? 1 : 0, _force);
 		uTexCoordBounds.set(tcbounds, _force);
+		gDP.m_texCoordBounds.valid = false;
 	}
 
 private:

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactoryAccurate.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactoryAccurate.cpp
@@ -72,16 +72,10 @@ public:
 		}
 		float tcbounds[4] = {};
 		if (useTexCoordBounds) {
-			f32 S = _FIXED2FLOAT(gDP.lastTexRectInfo.s, 5);
-			f32 T = _FIXED2FLOAT(gDP.lastTexRectInfo.t, 5);
-			f32 uls = S + (ceilf(gDP.lastTexRectInfo.ulx) - gDP.lastTexRectInfo.ulx) * gDP.lastTexRectInfo.dsdx;
-			f32 lrs = S + (ceilf(gDP.lastTexRectInfo.lrx) - gDP.lastTexRectInfo.ulx - 1.0f) * gDP.lastTexRectInfo.dsdx;
-			f32 ult = T + (ceilf(gDP.lastTexRectInfo.uly) - gDP.lastTexRectInfo.uly) * gDP.lastTexRectInfo.dtdy;
-			f32 lrt = T + (ceilf(gDP.lastTexRectInfo.lry) - gDP.lastTexRectInfo.uly - 1.0f) * gDP.lastTexRectInfo.dtdy;
-			tcbounds[0] = fmin(uls, lrs);
-			tcbounds[1] = fmin(ult, lrt);
-			tcbounds[2] = fmax(uls, lrs);
-			tcbounds[3] = fmax(ult, lrt);
+			tcbounds[0] = gDP.m_texCoordBounds.uls;
+			tcbounds[1] = gDP.m_texCoordBounds.ult;
+			tcbounds[2] = gDP.m_texCoordBounds.lrs;
+			tcbounds[3] = gDP.m_texCoordBounds.lrt;
 		}
 
 		uVertexOffset.set(vertexOffset, vertexOffset, _force);

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactoryAccurate.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramUniformFactoryAccurate.cpp
@@ -26,7 +26,8 @@ public:
 	void update(bool _force) override {
 		const bool isNativeRes = config.frameBufferEmulation.nativeResFactor == 1 && config.video.multisampling == 0;
 		const bool isTexRect = dwnd().getDrawer().getDrawingState() == DrawingState::TexRect;
-		const bool useTexCoordBounds = isTexRect && !isNativeRes && config.graphics2D.enableTexCoordBounds;
+		const bool isBackground = gSP.textureTile[0] != nullptr && gSP.textureTile[0]->textureMode == TEXTUREMODE_BGIMAGE;
+		const bool useTexCoordBounds = (isTexRect || isBackground) && !isNativeRes && config.graphics2D.enableTexCoordBounds;
 		/* At rasterization stage, the N64 places samples on the top left of the fragment while OpenGL		*/
 		/* places them in the fragment center. As a result, a normal approach results in shifted texture	*/
 		/* coordinates. In native resolution, this difference can be negated by shifting vertices by 0.5.	*/

--- a/src/TexrectDrawer.cpp
+++ b/src/TexrectDrawer.cpp
@@ -347,6 +347,7 @@ bool TexrectDrawer::draw()
 	GraphicsDrawer &  drawer = wnd.getDrawer();
 	drawer.setBlendMode();
 	gDP.changed |= CHANGED_RENDERMODE;  // Force update of depth compare parameters
+	gDP.m_texCoordBounds.valid = false;
 	drawer._updateDepthCompare();
 
 	int enableAlphaTest = 0;

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -916,11 +916,13 @@ void gDPTextureRectangle(f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, s16 s, s1
 	f32 ult = T + (ceilf(uly) - uly) * DTDY;
 	f32 lrt = T + (ceilf(lry) - uly - 1.0f) * DTDY;
 
-	gDP.m_texCoordBounds.valid = true;
-	gDP.m_texCoordBounds.uls = fmin(uls, lrs);
-	gDP.m_texCoordBounds.ult = fmin(ult, lrt);
-	gDP.m_texCoordBounds.lrs = fmax(uls, lrs);
-	gDP.m_texCoordBounds.lrt = fmax(ult, lrt);
+	if (config.graphics2D.enableTexCoordBounds != 0) {
+		gDP.m_texCoordBounds.valid = true;
+		gDP.m_texCoordBounds.uls = fmin(uls, lrs);
+		gDP.m_texCoordBounds.ult = fmin(ult, lrt);
+		gDP.m_texCoordBounds.lrs = fmax(uls, lrs);
+		gDP.m_texCoordBounds.lrt = fmax(ult, lrt);
+	}
 
 	GraphicsDrawer & drawer = dwnd().getDrawer();
 	GraphicsDrawer::TexturedRectParams params(ulx, uly, lrx, lry, dsdx, dtdy, s, t,

--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -907,6 +907,21 @@ void gDPTextureRectangle(f32 ulx, f32 uly, f32 lrx, f32 lry, s32 tile, s16 s, s1
 	gDP.lastTexRectInfo.dsdx = !flip ? dsdx : dtdy;
 	gDP.lastTexRectInfo.dtdy = !flip ? dtdy : dsdx;
 
+	f32 S = _FIXED2FLOAT(!flip ? s : t, 5);
+	f32 T = _FIXED2FLOAT(!flip ? t : s, 5);
+	f32 DSDX = !flip ? dsdx : dtdy;
+	f32 DTDY = !flip ? dtdy : dsdx;
+	f32 uls = S + (ceilf(ulx) - ulx) * DSDX;
+	f32 lrs = S + (ceilf(lrx) - ulx - 1.0f) * DSDX;
+	f32 ult = T + (ceilf(uly) - uly) * DTDY;
+	f32 lrt = T + (ceilf(lry) - uly - 1.0f) * DTDY;
+
+	gDP.m_texCoordBounds.valid = true;
+	gDP.m_texCoordBounds.uls = fmin(uls, lrs);
+	gDP.m_texCoordBounds.ult = fmin(ult, lrt);
+	gDP.m_texCoordBounds.lrs = fmax(uls, lrs);
+	gDP.m_texCoordBounds.lrt = fmax(ult, lrt);
+
 	GraphicsDrawer & drawer = dwnd().getDrawer();
 	GraphicsDrawer::TexturedRectParams params(ulx, uly, lrx, lry, dsdx, dtdy, s, t,
 		flip, false, true, frameBufferList().getCurrent());

--- a/src/gDP.h
+++ b/src/gDP.h
@@ -130,7 +130,7 @@ struct gDPTexrectInfo
 };
 
 struct texCoordBounds {
-	bool valid;
+	bool valid = false;
 	f32 uls, lrs, ult, lrt;
 };
 

--- a/src/gDP.h
+++ b/src/gDP.h
@@ -129,6 +129,11 @@ struct gDPTexrectInfo
 	f32 dsdx, dtdy;
 };
 
+struct texCoordBounds {
+	bool valid;
+	f32 uls, lrs, ult, lrt;
+};
+
 struct gDPInfo
 {
 	struct OtherMode
@@ -264,6 +269,7 @@ struct gDPInfo
 
 	gDPLoadTileInfo loadInfo[512];
 	gDPTexrectInfo lastTexRectInfo;
+	texCoordBounds m_texCoordBounds;
 };
 
 extern gDPInfo gDP;

--- a/src/uCodes/S2DEX.cpp
+++ b/src/uCodes/S2DEX.cpp
@@ -481,7 +481,7 @@ struct ObjCoordinates
 		f32 imageW = (f32)gSP.bgImage.width;
 		f32 imageH = (f32)gSP.bgImage.height;
 
-		if (u32(imageW) == 512 && (config.generalEmulation.hacks & hack_RE2) != 0) {
+		if (u32(imageW) == 512 && (config.generalEmulation.hacks & hack_RE2) != 0u) {
 			const f32 width = f32(*REG.VI_WIDTH);
 			const f32 scale = imageW / width;
 			imageW = width;
@@ -502,7 +502,7 @@ struct ObjCoordinates
 		lrs = uls + (lrx - ulx) * scaleW;
 		lrt = ult + (lry - uly) * scaleH;
 
-		if (config.frameBufferEmulation.nativeResFactor != 1 || config.video.multisampling != 0) {
+		if (config.frameBufferEmulation.nativeResFactor != 1u || config.video.multisampling != 0u) {
 			uls -= 0.5f * scaleW;
 			ult -= 0.5f * scaleH;
 			lrs -= 0.5f * scaleW;
@@ -513,7 +513,7 @@ struct ObjCoordinates
 		if (gDP.otherMode.cycleType != G_CYC_COPY) {
 			// Correct texture coordinates if G_OBJRM_BILERP
 			// bilinear interpolation is set
-			if ((gSP.objRendermode & G_OBJRM_BILERP) != 0) {
+			if ((gSP.objRendermode & G_OBJRM_BILERP) != 0u) {
 				// No correction gives the best picture, but is this correct?
 				//uls -= 0.5f;
 				//ult -= 0.5f;
@@ -522,7 +522,7 @@ struct ObjCoordinates
 			}
 			// SHRINKSIZE_1 adds a 0.5f perimeter around the image
 			// upper left texture coords += 0.5f; lower left texture coords -= 0.5f
-			if ((gSP.objRendermode&G_OBJRM_SHRINKSIZE_1) != 0) {
+			if ((gSP.objRendermode&G_OBJRM_SHRINKSIZE_1) != 0u) {
 				uls += 0.5f;
 				ult += 0.5f;
 				lrs -= 0.5f;
@@ -530,7 +530,7 @@ struct ObjCoordinates
 			}
 			// SHRINKSIZE_2 adds a 1.0f perimeter
 			// upper left texture coords += 1.0f; lower left texture coords -= 1.0f
-			else if ((gSP.objRendermode&G_OBJRM_SHRINKSIZE_2) != 0) {
+			else if ((gSP.objRendermode&G_OBJRM_SHRINKSIZE_2) != 0u) {
 				uls += 1.0f;
 				ult += 1.0f;
 				lrs -= 1.0f;
@@ -538,9 +538,15 @@ struct ObjCoordinates
 			}
 		}
 
+		gDP.m_texCoordBounds.valid = true;
+		gDP.m_texCoordBounds.uls = uls;
+		gDP.m_texCoordBounds.lrs = lrs - 1.0f;
+		gDP.m_texCoordBounds.ult = ult;
+		gDP.m_texCoordBounds.lrt = lrt - 1.0f;
+
 		// BgRect1CycOnePiece() and BgRectCopyOnePiece() do only support
 		// imageFlip in horizontal direction
-		if ((_pObjScaleBg->imageFlip & G_BG_FLAG_FLIPS) != 0) {
+		if ((_pObjScaleBg->imageFlip & G_BG_FLAG_FLIPS) != 0u) {
 			std::swap(ulx, lrx);
 		}
 

--- a/src/uCodes/S2DEX.cpp
+++ b/src/uCodes/S2DEX.cpp
@@ -538,11 +538,13 @@ struct ObjCoordinates
 			}
 		}
 
-		gDP.m_texCoordBounds.valid = true;
-		gDP.m_texCoordBounds.uls = uls;
-		gDP.m_texCoordBounds.lrs = lrs - 1.0f;
-		gDP.m_texCoordBounds.ult = ult;
-		gDP.m_texCoordBounds.lrt = lrt - 1.0f;
+		if (config.graphics2D.enableTexCoordBounds != 0u) {
+			gDP.m_texCoordBounds.valid = true;
+			gDP.m_texCoordBounds.uls = uls;
+			gDP.m_texCoordBounds.lrs = lrs - 1.0f;
+			gDP.m_texCoordBounds.ult = ult;
+			gDP.m_texCoordBounds.lrt = lrt - 1.0f;
+		}
 
 		// BgRect1CycOnePiece() and BgRectCopyOnePiece() do only support
 		// imageFlip in horizontal direction


### PR DESCRIPTION
The following commits are rebased to current master:
* Modify implementation of texture coordinate bounds for non-native resolutions.
* Use texture coordinate bounds for s2dex one-piece backgrounds
* Fix gDP.m_texCoordBounds validity.

refs issue #2484