### PR TITLE
cmake: Generate Revision.h in the build directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,22 +11,25 @@ option(ANDROID "Set to ON if targeting an Android device" ${ANDROID})
 option(GL_PROFILE "Set to ON to turn on GL profiling" ${GL_PROFILE})
 
 # run script to generate Revision.h
-set(PATH_REVISION "Revision.h")
+set(PATH_REVISION "${CMAKE_CURRENT_BINARY_DIR}/inc/Revision.h")
 find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
 	add_custom_command(
 		OUTPUT ${PATH_REVISION}
-		COMMAND ${CMAKE_SOURCE_DIR}/getRevision.sh
+		COMMAND
+		OUTPUT=${PATH_REVISION} ${CMAKE_SOURCE_DIR}/getRevision.sh
 		COMMENT "Generate Git version"
 	)
 else(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
 	add_custom_command(
 		OUTPUT ${PATH_REVISION}
-		COMMAND ${CMAKE_SOURCE_DIR}/getRevision.sh --nogit
+		COMMAND
+		OUTPUT=${PATH_REVISION} ${CMAKE_SOURCE_DIR}/getRevision.sh --nogit
 		COMMENT "Generate version"
 	)
 endif(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
 set_property(SOURCE ${PATH_REVISION} PROPERTY SKIP_AUTOGEN ON)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/inc")
 
 project( GLideN64 )
 

--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1,9 +1,9 @@
 #include <algorithm>
+#include <Revision.h>
 #include "assert.h"
 #include "math.h"
 #include "Platform.h"
 #include "GLideN64.h"
-#include "Revision.h"
 #include "RSP.h"
 #include "Config.h"
 #include "Combiner.h"

--- a/src/GLideN64.cpp
+++ b/src/GLideN64.cpp
@@ -1,4 +1,4 @@
-#include "Revision.h"
+#include <Revision.h>
 char pluginName[] = "GLideN64";
 char pluginNameWithRevision[] = "GLideN64 rev." PLUGIN_REVISION;
 wchar_t pluginNameW[] = L"GLideN64";

--- a/src/getRevision.sh
+++ b/src/getRevision.sh
@@ -4,7 +4,7 @@ set -eu
 
 cd -- "$(cd -- "${0%/*}/" && pwd -P)"
 
-header='./Revision.h'
+header="${OUTPUT:-./Revision.h}"
 
 if [ "${1:-}" != --nogit ]
 then
@@ -23,6 +23,7 @@ printf '%s\n' "current revision $rev" "last build revision $lastrev"
 
 if [ "$lastrev" != "$rev" ]
 then
+  [ "$header" = "${header##*/}" ] || mkdir -p -- "${header%/*}"
    printf '%s\n' "#define PLUGIN_REVISION $rev" \
       "#define PLUGIN_REVISION_W L$rev" > "$header"
 fi

--- a/src/windows/ZilmarAPIImpl_windows.cpp
+++ b/src/windows/ZilmarAPIImpl_windows.cpp
@@ -3,8 +3,8 @@
 #include "../GLideN64.h"
 #include "../GLideNUI/GLideNUI.h"
 #include "../Config.h"
-#include "../Revision.h"
 #include <DisplayWindow.h>
+#include <Revision.h>
 
 void PluginAPI::DllAbout(/*HWND _hParent*/)
 {


### PR DESCRIPTION
This generates `Revision.h` in the build directory instead of the source directory. It is nice for out of tree builds where it is conceivable that only the build directory is writable.