### PR TITLE
GLideNUI: copy config files to user config path when needed

### DIFF
--- a/src/GLideNUI/Config_GLideNUI.cpp
+++ b/src/GLideNUI/Config_GLideNUI.cpp
@@ -16,6 +16,16 @@ void Config_DoConfig(/*HWND hParent*/)
 	wchar_t strIniFolderPath[PLUGIN_PATH_SIZE];
 	api().FindPluginPath(strIniFolderPath);
 
+#ifdef M64P_GLIDENUI
+	wchar_t strConfigFolderPath[PLUGIN_PATH_SIZE];
+	api().GetUserConfigPath(strConfigFolderPath);
+
+	if (!IsPathWriteable(strIniFolderPath)) {
+		CopyConfigFiles(strIniFolderPath, strConfigFolderPath);
+		api().GetUserConfigPath(strIniFolderPath);
+	}
+#endif // M64P_GLIDENUI
+
 	ConfigOpen = true;
 	const u32 maxMsaa = dwnd().maxMSAALevel();
 	const u32 maxAnisotropy = dwnd().maxAnisotropy();

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -97,6 +97,18 @@ int runAboutThread(const wchar_t * _strFileName) {
 	return 0;
 }
 
+#ifdef M64P_GLIDENUI
+EXPORT bool CALL IsPathWriteable(const wchar_t * dir)
+{
+	return isPathWriteable(QString::fromWCharArray(dir));
+}
+
+EXPORT void CALL CopyConfigFiles(const wchar_t * _srcDir, const wchar_t * _targetDir)
+{
+	return copyConfigFiles(QString::fromWCharArray(_srcDir), QString::fromWCharArray(_targetDir));
+}
+#endif // M64P_GLIDENUI
+
 EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy)
 {
 	return runConfigThread(_strFileName, _romName, _maxMSAALevel, _maxAnisotropy);

--- a/src/GLideNUI/GLideNUI.h
+++ b/src/GLideNUI/GLideNUI.h
@@ -13,6 +13,11 @@ extern "C" {
 #define CALL
 #endif
 
+#ifdef M64P_GLIDENUI
+EXPORT bool CALL IsPathWriteable(const wchar_t * dir);
+EXPORT void CALL CopyConfigFiles(const wchar_t * _srcDir, const wchar_t * _targetDir);
+#endif // M64P_GLIDENUI
+
 EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
 EXPORT int CALL RunAbout(const wchar_t * _strFileName);
 EXPORT void CALL LoadConfig(const wchar_t * _strFileName);

--- a/src/GLideNUI/Settings.cpp
+++ b/src/GLideNUI/Settings.cpp
@@ -600,3 +600,28 @@ void removeProfile(const QString & _strIniFolder, const QString & _strProfile)
 	QSettings settings(_strIniFolder + "/" + strIniFileName, QSettings::IniFormat);
 	settings.remove(_strProfile);
 }
+
+#ifdef M64P_GLIDENUI
+#include <QFileInfo>
+
+bool isPathWriteable(const QString dir)
+{
+	QFileInfo path(dir);
+	return path.isWritable();
+}
+
+void copyConfigFiles(const QString _srcDir, const QString _targetDir)
+{
+	QStringList files = {
+		strIniFileName,
+		strDefaultIniFileName,
+		strCustomSettingsFileName
+	};
+
+	for (const QString& file : files) {
+		if (!QFile::exists(_targetDir + "/" + file)) {
+			QFile::copy(_srcDir + "/" + file, _targetDir + "/" + file);
+		}
+	}
+}
+#endif // M64P_GLIDENUI

--- a/src/GLideNUI/Settings.h
+++ b/src/GLideNUI/Settings.h
@@ -12,6 +12,10 @@ QString getCurrentProfile(const QString & _strIniFolder);
 void changeProfile(const QString & _strIniFolder, const QString & _strProfile);
 void addProfile(const QString & _strIniFolder, const QString & _strProfile);
 void removeProfile(const QString & _strIniFolder, const QString & _strProfile);
+#ifdef M64P_GLIDENUI
+bool isPathWriteable(const QString dir);
+void copyConfigFiles(const QString _srcDir, const QString _targetDir);
+#endif // M64P_GLIDENUI
 
 #endif // SETTINGS_H
 

--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -45,6 +45,9 @@ public:
 	void FindPluginPath(wchar_t * _strPath);
 	void GetUserDataPath(wchar_t * _strPath);
 	void GetUserCachePath(wchar_t * _strPath);
+#ifdef M64P_GLIDENUI
+	void GetUserConfigPath(wchar_t * _strPath);
+#endif // M64P_GLIDENUI
 	bool isRomOpen() const { return m_bRomOpen; }
 
 #ifndef MUPENPLUSAPI

--- a/src/mupenplus/CommonAPIImpl_mupenplus.cpp
+++ b/src/mupenplus/CommonAPIImpl_mupenplus.cpp
@@ -50,10 +50,12 @@ void _cutLastPathSeparator(wchar_t * _strPath)
 }
 
 static
-void _getWSPath(const char * _path, wchar_t * _strPath)
+void _getWSPath(const char * _path, wchar_t * _strPath, bool cutLastPathSeperator = false)
 {
 	::mbstowcs(_strPath, _path, PLUGIN_PATH_SIZE);
-	_cutLastPathSeparator(_strPath);
+	if (cutLastPathSeperator) {
+		_cutLastPathSeparator(_strPath);
+	}
 }
 
 void PluginAPI::GetUserDataPath(wchar_t * _strPath)
@@ -65,6 +67,13 @@ void PluginAPI::GetUserCachePath(wchar_t * _strPath)
 {
 	_getWSPath(ConfigGetUserCachePath(), _strPath);
 }
+
+#ifdef M64P_GLIDENUI
+void PluginAPI::GetUserConfigPath(wchar_t * _strPath)
+{
+	_getWSPath(ConfigGetUserConfigPath(), _strPath);
+}
+#endif // M64P_GLIDENUI
 
 void PluginAPI::FindPluginPath(wchar_t * _strPath)
 {
@@ -91,7 +100,7 @@ void PluginAPI::FindPluginPath(wchar_t * _strPath)
 
 			if (line.find("GLideN64") != std::string::npos)
 			{
-				_getWSPath(line.c_str(), _strPath);
+				_getWSPath(line.c_str(), _strPath, true);
 				maps.close();
 				return;
 			}
@@ -104,14 +113,14 @@ void PluginAPI::FindPluginPath(wchar_t * _strPath)
 	int res = readlink("/proc/self/exe", path, 510);
 	if (res != -1) {
 		path[res] = 0;
-		_getWSPath(path, _strPath);
+		_getWSPath(path, _strPath, true);
 	}
 #elif defined(OS_MAC_OS_X)
 #define MAXPATHLEN 256
 	char path[MAXPATHLEN];
 	uint32_t pathLen = MAXPATHLEN * 2;
 	if (_NSGetExecutablePath(path, &pathLen) == 0) {
-		_getWSPath(path, _strPath);
+		_getWSPath(path, _strPath, true);
 	}
 #elif defined(OS_ANDROID)
 	GetUserCachePath(_strPath);


### PR DESCRIPTION
I've started packaging RMG for linux (it's in the AUR & flatpak) but GLideN64 can't save settings in the current codebase because `-DMUPENPLUSAPI_GLIDENUI=ON` is enabled, to fix this, this patch checks if the plugin path is writeable, if it isn't, copy the config files over to the user config directory & use that path instead for the configuration files.

Another thing this patch fixes is the uneeded call to `_cutLastPathSeparator` in `_getWSPath` for some mupen64plus functions which don't need it (like `ConfigGetUserDataPath()`, `ConfigGetUserCachePath()`, `ConfigGetUserConfigPath()`), because RMG doesn't end those paths with a trailing slash, causing GLideN64 to use the wrong path without this fix.