### PR TITLE
Add inaccurate texture coordinates hotkey

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -202,6 +202,8 @@ const char* Config::hotkeyIniName(u32 _idx)
 		return "hkOsdRenderingResolution";
 	case Config::HotKey::hkForceGammaCorrection:
 		return "hkForceGammaCorrection";
+	case Config::HotKey::hkInaccurateTexCords:
+		return "hkInaccurateTexCords";
 	}
 	return nullptr;
 }
@@ -238,6 +240,8 @@ const char* Config::enabledHotkeyIniName(u32 _idx)
 		return "hkOsdRenderingResolutionEnabled";
 	case Config::HotKey::hkForceGammaCorrection:
 		return "hkForceGammaCorrectionEnabled";
+	case Config::HotKey::hkInaccurateTexCords:
+		return "hkInaccurateTexCordsEnabled";
 	}
 	return nullptr;
 }

--- a/src/Config.h
+++ b/src/Config.h
@@ -234,6 +234,7 @@ struct Config
 		hkOsdInternalResolution,
 		hkOsdRenderingResolution,
 		hkForceGammaCorrection,
+		hkInaccurateTexCords,
 		hkTotal
 	};
 

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -103,6 +103,8 @@ QString ConfigDialog::_hotkeyDescription(quint32 _idx) const
 		return tr("Toggle OSD rendering resolution");
 	case Config::HotKey::hkForceGammaCorrection:
 		return tr("Toggle force gamma correction");
+	case Config::HotKey::hkInaccurateTexCords:
+		return tr("Toggle inaccurate texture coordinates");
 	}
 	return tr("Unknown hotkey");
 }

--- a/src/VI.cpp
+++ b/src/VI.cpp
@@ -216,6 +216,16 @@ static void checkHotkeys()
 			dwnd().getDrawer().showMessage("Force gamma correction off\n", Milliseconds(750));
 		config.gammaCorrection.force = !config.gammaCorrection.force;
 	}
+
+	if (osal_is_key_pressed(config.hotkeys.enabledKeys[Config::hkInaccurateTexCords], 0x0001)) {
+		config.generalEmulation.enableInaccurateTextureCoordinates = !config.generalEmulation.enableInaccurateTextureCoordinates;
+		dwnd().stop();
+		dwnd().start();
+		if (config.generalEmulation.enableInaccurateTextureCoordinates == 0)
+			dwnd().getDrawer().showMessage("Disable inaccurate texture coordinates\n", Milliseconds(1000));
+		else
+			dwnd().getDrawer().showMessage("Enable inaccurate texture coordinates\n", Milliseconds(1000));
+	}
 }
 
 void VI_UpdateScreen()

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -51,6 +51,8 @@ const char* _hotkeyDescription(u32 _idx)
 		return "Hotkey: toggle OSD rendering resolution";
 	case Config::HotKey::hkForceGammaCorrection:
 		return "Hotkey: toggle force gamma correction";
+	case Config::HotKey::hkInaccurateTexCords:
+		return "Hotkey: toggle inaccurate texture coordinates";
 	}
 	return "Unknown hotkey";
 }


### PR DESCRIPTION
Requested by @GhostlyDark because Nerrel's Majora's Mask HD requires changes to look correct without the "inaccurate texture coordinates" option enabled, to help with this, a hotkey is added by this patch which makes seeing the changes & comparing them faster and easier.