### PR TITLE
Fix Vs2015 compile issues

### DIFF
--- a/src/GLideNHQ/TxHiResNoCache.cpp
+++ b/src/GLideNHQ/TxHiResNoCache.cpp
@@ -86,11 +86,14 @@ bool TxHiResNoCache::get(Checksum checksum, N64FormatSize n64FmtSz, GHQTexInfo *
 		}
 		return _loadedTex.end();
 	};
-	if (auto loadedTexMap = findTex(checksum); loadedTexMap != _loadedTex.end()) {
-		DBG_INFO(80, wst("TxNoCache::get: cached chksum:%08X %08X found\n"), chksum, palchksum);
-		*info = loadedTexMap->second;
-		return true;
-	}
+    {
+        auto loadedTexMap = findTex(checksum);
+        if (loadedTexMap != _loadedTex.end()) {
+            DBG_INFO(80, wst("TxNoCache::get: cached chksum:%08X %08X found\n"), chksum, palchksum);
+            *info = loadedTexMap->second;
+            return true;
+        }
+    }
 
 	DBG_INFO(80, wst("TxNoCache::get: loading chksum:%08X %08X\n"), chksum, palchksum);
 

--- a/src/GLideNHQ/TxHiResNoCache.cpp
+++ b/src/GLideNHQ/TxHiResNoCache.cpp
@@ -10,7 +10,7 @@ TxHiResNoCache::TxHiResNoCache(int maxwidth,
 			   int options,
 			   const wchar_t *cachePath,
 			   const wchar_t *texPackPath,
-        	   const wchar_t *fullTexPath,
+			   const wchar_t *fullTexPath,
 			   const wchar_t *ident,
 			   dispInfoFuncExt callback)
 	: TxHiResLoader(maxwidth, maxheight, maxbpp, options)
@@ -86,14 +86,14 @@ bool TxHiResNoCache::get(Checksum checksum, N64FormatSize n64FmtSz, GHQTexInfo *
 		}
 		return _loadedTex.end();
 	};
-    {
-        auto loadedTexMap = findTex(checksum);
-        if (loadedTexMap != _loadedTex.end()) {
-            DBG_INFO(80, wst("TxNoCache::get: cached chksum:%08X %08X found\n"), chksum, palchksum);
-            *info = loadedTexMap->second;
-            return true;
-        }
-    }
+	{
+		auto loadedTexMap = findTex(checksum);
+		if (loadedTexMap != _loadedTex.end()) {
+			DBG_INFO(80, wst("TxNoCache::get: cached chksum:%08X %08X found\n"), chksum, palchksum);
+			*info = loadedTexMap->second;
+			return true;
+		}
+	}
 
 	DBG_INFO(80, wst("TxNoCache::get: loading chksum:%08X %08X\n"), chksum, palchksum);
 


### PR DESCRIPTION
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(89): error C2143: syntax error: missing ')' before ';'
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(89): error C2451: conditional expression of type 'std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<const _Kty,_Ty>>>>' is illegal
1>          with
1>          [
1>              _Kty=uint64,
1>              _Ty=GHQTexInfo
1>          ]
1>  ..\..\src\GLideNHQ\TxHiResNoCache.cpp(89): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(89): error C2065: 'loadedTexMap': undeclared identifier
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(89): error C2059: syntax error: ')'
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(90): error C2059: syntax error: ';'
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(91): error C2065: 'loadedTexMap': undeclared identifier
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(91): error C2227: left of '->second' must point to class/struct/union/generic type
1>  ..\..\src\GLideNHQ\TxHiResNoCache.cpp(91): note: type is 'unknown-type'
1>..\..\src\GLideNHQ\TxHiResNoCache.cpp(89): warning C4390: ';': empty controlled statement found; is this the intent?
