### PR TITLE
GLideNUI: allow resizing

### DIFF
--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>747</width>
-    <height>715</height>
+    <width>597</width>
+    <height>612</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,11 +21,11 @@
     <normaloff>:/Icon.ico</normaloff>:/Icon.ico</iconset>
   </property>
   <property name="modal">
-   <bool>true</bool>
+   <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
+    <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
@@ -4059,9 +4059,8 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="fixTexrectCoordsButtonGroup"/>
-  <buttongroup name="screenshotButtonGroup"/>
   <buttongroup name="osdButtonGroup"/>
+  <buttongroup name="fixTexrectCoordsButtonGroup"/>
   <buttongroup name="factorButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This patch allows the config window to be resized freely by the user instead of it being a fixed size.