### PR TITLE
Fix #2663: Transparent textures in Densha De Go

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -19,6 +19,14 @@ frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
 
+[362D06B6]
+Good_Name=Densha de Go! 64 (J)
+generalEmulation\enableLegacyBlending=0
+
+[68D128AE]
+GoodName=Densha de Go! 64 (J) (Localization Patch v1.01)
+generalEmulation\enableLegacyBlending=0
+
 [52150A67]
 Good_Name=Bokujou Monogatari 2 (J)
 frameBufferEmulation\N64DepthCompare=1


### PR DESCRIPTION
I'm not sure that these are the right ROM names. I understand that for Japanese roms, the CRC is used as the name. But when I checked all of the other Japanese ROM names in this file, none of them matched any official CRCs that I could find in an actual ROM or db.

Additionally, a full CRC is 8 bytes, but the names in the ini file are 4 byte strings. I'm not sure where those 4 bytes come from?