### PR TITLE
Allow texture dumping without having to use a hotkey

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -100,6 +100,7 @@ void Config::resetToDefaults()
 	textureFilter.txForce16bpp = 0;
 	textureFilter.txCacheCompression = 1;
 	textureFilter.txSaveCache = 1;
+	textureFilter.txDump = 0;
 
 	textureFilter.txEnhancedTextureFileStorage = 0;
 	textureFilter.txHiresTextureFileStorage = 0;

--- a/src/Config.h
+++ b/src/Config.h
@@ -173,6 +173,7 @@ struct Config
 		u32 txForce16bpp;				// Force use 16bit color textures
 		u32 txCacheCompression;			// Zip textures cache
 		u32 txSaveCache;				// Save texture cache to hard disk
+		u32 txDump;                     // Dump textures
 
 		u32 txEnhancedTextureFileStorage;	// Use file storage instead of memory cache for enhanced textures.
 		u32 txHiresTextureFileStorage;		// Use file storage instead of memory cache for hires textures.

--- a/src/TextureFilterHandler.cpp
+++ b/src/TextureFilterHandler.cpp
@@ -55,7 +55,7 @@ u32 TextureFilterHandler::_getConfigOptions() const
 		options |= (DUMP_TEXCACHE | DUMP_HIRESTEXCACHE);
 	if (config.textureFilter.txHiresFullAlphaChannel)
 		options |= LET_TEXARTISTS_FLY;
-	if (config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0)
+	if (config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0 || config.textureFilter.txDump)
 		options |= DUMP_TEX;
 	if (config.textureFilter.txDeposterize)
 		options |= DEPOSTERIZE;

--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1090,9 +1090,10 @@ void TextureCache::_loadBackground(CachedTexture *pTexture)
 		return;
 	}
 
-	if (m_toggleDumpTex &&
+	if ((m_toggleDumpTex &&
 		config.textureFilter.txHiresEnable != 0 &&
-		config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
+		config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) ||
+		config.textureFilter.txDump) {
 		txfilter_dmptx((u8*)pDest, pTexture->width, pTexture->height,
 			pTexture->width, (u16)u32(glInternalFormat),
 			N64FormatSize(pTexture->format, pTexture->size),
@@ -1485,9 +1486,10 @@ void TextureCache::_loadFast(u32 _tile, CachedTexture *_pTexture)
 			return;
 		}
 
-		if (m_toggleDumpTex &&
+		if ((m_toggleDumpTex &&
 			config.textureFilter.txHiresEnable != 0 &&
-			config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
+			config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) ||
+			config.textureFilter.txDump) {
 			txfilter_dmptx((u8*)m_tempTextureHolder.data(), tmptex.width, tmptex.height,
 						   tmptex.width, (u16)u32(glInternalFormat),
 						   N64FormatSize(_pTexture->format, _pTexture->size),
@@ -1660,9 +1662,10 @@ void TextureCache::_loadAccurate(u32 _tile, CachedTexture *_pTexture)
 			getLoadParams(tmptex.format, tmptex.size);
 			_getTextureDestData(tmptex, &m_tempTextureHolder[texDataOffset], glInternalFormat, GetTexel, &line);
 
-			if (m_toggleDumpTex &&
+			if ((m_toggleDumpTex &&
 				config.textureFilter.txHiresEnable != 0 &&
-				config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
+				config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) ||
+				config.textureFilter.txDump) {
 				txfilter_dmptx((u8*)(m_tempTextureHolder.data() + texDataOffset), tmptex.width, tmptex.height,
 					tmptex.width, (u16)u32(glInternalFormat),
 					N64FormatSize(_pTexture->format, _pTexture->size),
@@ -1718,9 +1721,10 @@ void TextureCache::_loadAccurate(u32 _tile, CachedTexture *_pTexture)
 			return;
 		}
 
-		if (m_toggleDumpTex &&
+		if ((m_toggleDumpTex &&
 			config.textureFilter.txHiresEnable != 0 &&
-			config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) {
+			config.hotkeys.enabledKeys[Config::HotKey::hkTexDump] != 0) ||
+			config.textureFilter.txDump) {
 			txfilter_dmptx((u8*)m_tempTextureHolder.data(), tmptex.width, tmptex.height,
 					tmptex.width, (u16)u32(glInternalFormat),
 					N64FormatSize(_pTexture->format, _pTexture->size),

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -255,6 +255,8 @@ bool Config_SetDefault()
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "txSaveCache", config.textureFilter.txSaveCache, "Save texture cache to hard disk.");
 	assert(res == M64ERR_SUCCESS);
+	res = ConfigSetDefaultBool(g_configVideoGliden64, "txDump", config.textureFilter.txDump, "Dump textures");
+	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "txEnhancedTextureFileStorage", config.textureFilter.txEnhancedTextureFileStorage, "Use file storage instead of memory cache for enhanced textures.");
 	assert(res == M64ERR_SUCCESS);
 	res = ConfigSetDefaultBool(g_configVideoGliden64, "txHiresTextureFileStorage", config.textureFilter.txHiresTextureFileStorage, "Use file storage instead of memory cache for HD textures.");
@@ -469,6 +471,8 @@ void Config_LoadCustomConfig()
 	if (result == M64ERR_SUCCESS) config.textureFilter.txCacheCompression = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "textureFilter\\txSaveCache", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.textureFilter.txSaveCache = atoi(value);
+	result = ConfigExternalGetParameter(fileHandle, sectionName, "textureFilter\\txDump", value, sizeof(value));
+	if (result == M64ERR_SUCCESS) config.textureFilter.txDump = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "textureFilter\\txEnhancedTextureFileStorage", value, sizeof(value));
 	if (result == M64ERR_SUCCESS) config.textureFilter.txEnhancedTextureFileStorage = atoi(value);
 	result = ConfigExternalGetParameter(fileHandle, sectionName, "textureFilter\\txHiresTextureFileStorage", value, sizeof(value));
@@ -564,6 +568,7 @@ void Config_LoadConfig()
 	config.textureFilter.txForce16bpp = ConfigGetParamBool(g_configVideoGliden64, "txForce16bpp");
 	config.textureFilter.txCacheCompression = ConfigGetParamBool(g_configVideoGliden64, "txCacheCompression");
 	config.textureFilter.txSaveCache = ConfigGetParamBool(g_configVideoGliden64, "txSaveCache");
+	config.textureFilter.txDump = ConfigGetParamBool(g_configVideoGliden64, "txDump");
 	config.textureFilter.txEnhancedTextureFileStorage = ConfigGetParamBool(g_configVideoGliden64, "txEnhancedTextureFileStorage");
 	config.textureFilter.txHiresTextureFileStorage = ConfigGetParamBool(g_configVideoGliden64, "txHiresTextureFileStorage");
 	config.textureFilter.txNoTextureFileStorage = ConfigGetParamBool(g_configVideoGliden64, "txNoTextureFileStorage");


### PR DESCRIPTION
As unlikely as it sounds, I have users wanting to dump textures in Android. This is currently not possible though with the hotkey requirement. This restores the tx dump option to allow it to be enabled through configuration, but only for mupen64plus API.