### PR TITLE
GLideN64.custom.ini cleanups

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -15,6 +15,7 @@ Good_Name=Bio F.R.E.A.K.S. (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 
 [BioHazard%20II]
+Good_Name=Biohazard 2 (J)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
@@ -24,7 +25,7 @@ Good_Name=Densha de Go! 64 (J)
 generalEmulation\enableLegacyBlending=0
 
 [68D128AE]
-GoodName=Densha de Go! 64 (J) (Localization Patch v1.01)
+Good_Name=Densha de Go! 64 (J) (Localization Patch v1.01)
 generalEmulation\enableLegacyBlending=0
 
 [52150A67]
@@ -36,6 +37,7 @@ Good_Name=Eikou no Saint Andrews (J)
 frameBufferEmulation\forceDepthBufferClear=1
 
 [CAL%20SPEED]
+Good_Name=California Speed (U)
 frameBufferEmulation\bufferSwapMode=1
 
 [CASTLEVANIA2]
@@ -54,6 +56,7 @@ Good_Name=Mario Artist Talent Studio (J) (64DD)
 frameBufferEmulation\copyAuxToRDRAM=1
 
 [DINO%20PLANET]
+Good_Name=Dinosaur Planet (Dec 2000 Beta)
 frameBufferEmulation\copyToRDRAM=1
 frameBufferEmulation\copyAuxToRDRAM=1
 
@@ -119,6 +122,7 @@ Good_Name=Hexen (E)(F)(G)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 
 [HUMAN%20GRAND%20PRIX]
+Good_Name=Human Grand Prix - New Generation (J)
 frameBufferEmulation\copyToRDRAM=1
 
 [I%20S%20S%2064]
@@ -132,13 +136,13 @@ frameBufferEmulation\copyAuxToRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 
 [J%20F%20G%20DISPLAY]
-; See Jet Force Gemini for notes
 Good_Name=Jet Force Gemini Kiosk Demo (U)
 frameBufferEmulation\fbInfoDisabled=0
 frameBufferEmulation\copyAuxToRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 
 [J%20WORLD%20SOCCER3]
+Good_Name=Jikkyou World Soccer 3 (J)
 frameBufferEmulation\N64DepthCompare=1
 
 [301E07CC]
@@ -207,6 +211,7 @@ Good_Name=Ogre Battle 64 - Person of Lordly Caliber (U)
 graphics2D\enableTexCoordBounds=1
 
 [OLYMPIC%20HOCKEY]
+Good_Name=Olympic Hockey Nagano '98 (E)(J)(U)
 frameBufferEmulation\bufferSwapMode=1
 
 [PAPER%20MARIO]
@@ -252,6 +257,7 @@ Good_Name=Rat Attack
 frameBufferEmulation\fbInfoDisabled=0
 
 [RESIDENT%20EVIL%20II]
+Good_Name=Resident Evil 2 (E)(U)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
@@ -261,6 +267,7 @@ Good_Name=Rockman Dash - Hagane no Boukenshin (J)
 graphics2D\correctTexrectCoords=2
 
 [RUSH%202]
+Good_Name=Rush 2 - Extreme Racing USA (E)(U)
 frameBufferEmulation\bufferSwapMode=1
 graphics2D\correctTexrectCoords=2
 
@@ -288,7 +295,6 @@ Good_Name=Space Invaders (U)
 frameBufferEmulation\copyToRDRAM=0
 
 [STAR%20TWINS]
-; See Jet Force Gemini for notes
 Good_Name=Star Twins (J)
 frameBufferEmulation\fbInfoDisabled=0
 frameBufferEmulation\copyAuxToRDRAM=1
@@ -300,8 +306,8 @@ frameBufferEmulation\copyFromRDRAM=1
 generalEmulation\rdramImageDitheringMode=0
 
 [TETRISPHERE]
-Good_Name=Tetrisphere (U)
-generalEmulation\correctTexrectCoords=2
+Good_Name=Tetrisphere (E)(U)
+graphics2D\correctTexrectCoords=2
 
 [TIGGER%27S%20HONEY%20HUNT]
 Good_Name=Tiggers Honey Hunt (E)(U)
@@ -312,9 +318,11 @@ Good_Name=Tonic Trouble (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 
 [TG%20RALLY%202]
+Good_Name=TG Rally 2 (E)
 frameBufferEmulation\copyToRDRAM=1
 
 [TOP%20GEAR%20RALLY%202]
+Good_Name=Top Gear Rally 2 (E)(J)(U)
 frameBufferEmulation\copyToRDRAM=1
 
 [TUROK_DINOSAUR_HUNTE]
@@ -322,4 +330,9 @@ Good_Name=Turok - Dinosaur Hunter (E)(G)(U)(J)
 frameBufferEmulation\copyDepthToRDRAM=1
 
 [W.G.%203DHOCKEY]
+Good_Name=Wayne Gretzky's 3D Hockey (E)(U)
+frameBufferEmulation\bufferSwapMode=1
+
+[WGHOCKEY]
+Good_Name=Wayne Gretzky's 3D Hockey (J)
 frameBufferEmulation\bufferSwapMode=1


### PR DESCRIPTION
"correctTexrectCoords=2" wasn't working for Tetrisphere because it was in the wrong "category" ("generalEmulation" instead of "graphics2D").

Also some minor cleanups: renamed a "GoodName" to "Good_Name" for consistency and removed the "; See Jet Force Gemini for notes" comments since there are no more notes for it anymore (removed in 59c489036c78edc72ba7e08827f0de93302f55ae).

**edit:** + added missing Good names.

**one last edit:** + added the JPN version of "Wayne Gretzky's 3D Hockey", which as a different name than the EUR and USA versions ("WGHOCKEY" instead of "W.G. 3DHOCKEY").