### PR TITLE
Update node.js version 12 to version 16 in CI/CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   Linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Packages
         run: |
           sudo apt-get -qq update
@@ -35,14 +35,14 @@ jobs:
           cp ini/GLideN64.custom.ini build/linux-mupen64plus-qt/
           cp translations/release/*.qm build/linux-mupen64plus-qt/
       - name: Upload GLideN64 (x64 Mupen64Plus-CLI)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Linux-Mupen64Plus-CLI-x64
           path: |
             build/linux-mupen64plus-cli/*.so
             build/linux-mupen64plus-cli/GLideN64.custom.ini
       - name: Upload GLideN64 (x64 Mupen64Plus-Qt)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Linux-Mupen64Plus-Qt-x64
           path: |
@@ -58,7 +58,7 @@ jobs:
       QT_BUILD_x86: qt-5_15-x86-msvc2017-static
       QT_BUILD_x64: qt-5_15-x64-msvc2017-static
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1.0.3
       - uses: msys2/setup-msys2@v2
         with:
@@ -142,7 +142,7 @@ jobs:
           cp translations/release/*.qm build/windows-mupen64plus-qt/
         shell: msys2 {0}
       - name: Upload GLideN64 (x64 Project64-Qt)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-Qt-x64
           path: |
@@ -150,7 +150,7 @@ jobs:
             build\windows-project64-qt-x64\GLideN64.custom.ini
             build\windows-project64-qt-x64\*.qm
       - name: Upload GLideN64 (x86 Project64-Qt)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-Qt-x86
           path: |
@@ -158,7 +158,7 @@ jobs:
             build\windows-project64-qt\GLideN64.custom.ini
             build\windows-project64-qt\*.qm
       - name: Upload GLideN64 (x64 Project64-WTL)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-WTL-x64
           path: |
@@ -166,7 +166,7 @@ jobs:
             build\windows-project64-wtl-x64\GLideN64.custom.ini
             build\windows-project64-wtl-x64\translations\*.Lang
       - name: Upload GLideN64 (x86 Project64-WTL)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-WTL-x86
           path: |
@@ -174,21 +174,21 @@ jobs:
             build\windows-project64-wtl\GLideN64.custom.ini
             build\windows-project64-wtl\translations\*.Lang
       - name: Upload GLideN64 (x64 Mupen64Plus-CLI)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Mupen64Plus-CLI-x64
           path: |
             build\windows-mupen64plus-cli-x64\*.dll
             build\windows-mupen64plus-cli-x64\GLideN64.custom.ini
       - name: Upload GLideN64 (x86 Mupen64Plus-CLI)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Mupen64Plus-CLI-x86
           path: |
             build\windows-mupen64plus-cli\*.dll
             build\windows-mupen64plus-cli\GLideN64.custom.ini
       - name: Upload GLideN64 (x64 Mupen64Plus-Qt)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Mupen64Plus-Qt-x64
           path: |
@@ -200,9 +200,9 @@ jobs:
     needs: [Windows, Linux]
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
       # sadly we can't download the artifacts without extracting it


### PR DESCRIPTION
Under the CI/CD runs you see that node.js version 12 is deprecated, this commit uses version 16 instead.

Example of the deprecation warning: https://github.com/gonetz/GLideN64/actions/runs/3354777758