### PR TITLE
Add qt5 dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get -y upgrade
-          sudo apt-get -y install build-essential libgl1-mesa-dev qt5-default
+          sudo apt-get -y install build-essential libgl1-mesa-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
       - name: Prepare Environment
         run: |
           echo "GIT_REVISION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV


### PR DESCRIPTION
It seems qt5-default is obsolete for some time now: https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg5902890.html

Replacing it with the qt5 dependencies seems to work which gives us time to see if we can use a newer version. I got a succesful build:
https://github.com/bladeoner/GLideN64/actions/runs/3507337878