### PR TITLE
Add GLIDENUI_QT6 option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})
 option(ODROID "Set to ON if targeting an Odroid" ${ODROID})
 option(MUPENPLUSAPI "Set to ON for Mupen64Plus plugin" ${MUPENPLUSAPI})
 option(MUPENPLUSAPI_GLIDENUI "Set to ON for GLideNUI for Mupen64Plus" ${MUPENPLUSAPI_GLIDENUI})
+option(GLIDENUI_QT6 "Set to ON to use Qt6 for GLideNUI" ${GLIDENUI_QT6})
 option(MESA "Set to ON to disable Raspberry Pi autodetection" ${MESA})
 option(VERO4K "Set to ON if targeting a Vero4k" ${VERO4K})
 option(ANDROID "Set to ON if targeting an Android device" ${ANDROID})
@@ -162,10 +163,17 @@ if(MUPENPLUSAPI_GLIDENUI OR NOT MUPENPLUSAPI)
   set(CMAKE_AUTORCC ON)
   set(CMAKE_AUTOUIC ON)
 
-  find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
-  set(GLIDENUI_LIBRARIES
-      Qt5::Widgets Qt5::Core Qt5::Gui
-  )
+  if (GLIDENUI_QT6)
+    find_package(Qt6 COMPONENTS Core Widgets Gui REQUIRED)
+    set(GLIDENUI_LIBRARIES
+        Qt6::Widgets Qt6::Core Qt6::Gui
+    )
+  else(GLIDENUI_QT6)
+    find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
+    set(GLIDENUI_LIBRARIES
+        Qt5::Widgets Qt5::Core Qt5::Gui
+    )
+  endif(GLIDENUI_QT6)
   if (MUPENPLUSAPI)
     list(APPEND GLideNUI_SOURCES
       GLideNUI/fullscreenresolutions_mupen64plus.cpp

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -836,8 +836,8 @@ void ConfigDialog::on_buttonBox_clicked(QAbstractButton *button)
 			QMessageBox::RestoreDefaults | QMessageBox::Cancel, this
 			);
 		msgBox.setDefaultButton(QMessageBox::Cancel);
-		msgBox.setButtonText(QMessageBox::RestoreDefaults, tr("Restore Defaults"));
-		msgBox.setButtonText(QMessageBox::Cancel, tr("Cancel"));
+		msgBox.button(QMessageBox::RestoreDefaults)->setText(tr("Restore Defaults"));
+		msgBox.button(QMessageBox::Cancel)->setText(tr("Cancel"));
 		if (msgBox.exec() == QMessageBox::RestoreDefaults) {
 			const u32 enableCustomSettings = config.generalEmulation.enableCustomSettings;
 			resetSettings(m_strIniPath);
@@ -1125,8 +1125,8 @@ void ConfigDialog::on_removeProfilePushButton_clicked()
 	QMessageBox msgBox(QMessageBox::Warning, tr("Remove Profile"),
 		msg, QMessageBox::Yes | QMessageBox::Cancel, this);
 	msgBox.setDefaultButton(QMessageBox::Cancel);
-	msgBox.setButtonText(QMessageBox::Yes, tr("Remove"));
-	msgBox.setButtonText(QMessageBox::No, tr("Cancel"));
+	msgBox.button(QMessageBox::Yes)->setText(tr("Remove"));
+	msgBox.button(QMessageBox::Cancel)->setText(tr("Cancel"));
 	if (msgBox.exec() == QMessageBox::Yes) {
 		removeProfile(m_strIniPath, profile);
 		ui->profilesComboBox->blockSignals(true);


### PR DESCRIPTION
This patch adds an `GLIDENUI_QT6` option which allows front-ends (i.e RMG) to use GLideN64 with Qt6 instead of Qt5.

This also fixes some deprecation warnings from Qt6, mainly
```cpp
/home/runner/work/RMG/RMG/Build/Release/Source/3rdParty/mupen64plus-video-GLideN64/src/GLideNUI/ConfigDialog.cpp:1129:29: warning: ‘void QMessageBox::setButtonText(int, const QString&)’ is deprecated: Use addButton() instead. [-Wdeprecated-declarations]
 1129 |         msgBox.setButtonText(QMessageBox::No, tr("Cancel"));
      |         ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

You can see the documentation for the deprecation: https://doc.qt.io/qt-6/qmessagebox-obsolete.html#setButtonText
and this patch seems like the right solution.