### PR TITLE
GLideNUI: fix creation of profiles

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -1056,7 +1056,7 @@ void ConfigDialog::setTitle()
 	setWindowTitle(tr("GLideN64 Settings"));
 }
 
-void ConfigDialog::on_profilesComboBox_currentIndexChanged(const QString &profile)
+void ConfigDialog::on_profilesComboBox_currentTextChanged(const QString &profile)
 {
 	ui->settingsDestProfileRadioButton->setChecked(true);
 	if (profile == tr("New...")) {

--- a/src/GLideNUI/ConfigDialog.h
+++ b/src/GLideNUI/ConfigDialog.h
@@ -83,7 +83,7 @@ private slots:
 
 	void on_noTexFileStorageCheckBox_toggled(bool checked);
 
-	void on_profilesComboBox_currentIndexChanged(const QString &arg1);
+	void on_profilesComboBox_currentTextChanged(const QString &arg1);
 
 	void on_settingsDestProfileRadioButton_toggled(bool checked);
 


### PR DESCRIPTION
Creating a profile in GLideNUI didn't work because `currentIndexChanged` is the wrong event signal/slot, it should be `currentTextChanged`, which fixes the issue and allows people to create profiles again.

See the documentation: https://doc.qt.io/qt-6/qcombobox.html#currentIndexChanged and https://doc.qt.io/qt-6/qcombobox.html#currentTextChanged