### PR TITLE
GLideNUI: remove fullscreen UI elements as needed

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -197,6 +197,11 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 	QStringList fullscreenModesList, fullscreenRatesList;
 	int fullscreenMode, fullscreenRate;
 	fillFullscreenResolutionsList(fullscreenModesList, fullscreenMode, fullscreenRatesList, fullscreenRate);
+#ifdef M64P_GLIDENUI
+	if (fullscreenModesList.isEmpty() && fullscreenRatesList.isEmpty()) {
+		ui->fullScreenResolutionFrame->setVisible(false);
+	}
+#endif
 	ui->fullScreenResolutionComboBox->clear();
 	ui->fullScreenResolutionComboBox->insertItems(0, fullscreenModesList);
 	ui->fullScreenResolutionComboBox->setCurrentIndex(fullscreenMode);


### PR DESCRIPTION
This is handy for front-ends which i.e don't support the vidext functions to retrieve the resolutions/refresh rates and disables the fullscreen frame as needed.