### PR TITLE
Fix DEBUG_DUMP crash

### DIFF
--- a/src/DebugDump.cpp
+++ b/src/DebugDump.cpp
@@ -63,7 +63,7 @@ bool BufferedLog::needPrint(u32 _mode) const
 	return (m_mode&_mode) != 0;
 }
 
-std::unique_ptr<BufferedLog> g_log;
+static std::unique_ptr<BufferedLog> g_log;
 
 void DebugMsg(u32 _mode, const char * _format, ...)
 {


### PR DESCRIPTION
This patch fixes the following odd crash when compiling with `-DDEBUG_DUMP`:
```
Thread 30 "Thread::Emulati" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff6f7fe6c0 (LWP 44006)]
0x00007fffccd4e215 in BufferedLog::needPrint (this=0xd8ec8148fa1e0ff3, _mode=2) at /home/rosalie/dev/RMG/Build/Release/Source/3rdParty/mupen64plus-video-GLideN64/src/DebugDump.cpp:63
63              return (m_mode&_mode) != 0;
(gdb) bt full
#0  0x00007fffccd4e215 in BufferedLog::needPrint (this=0xd8ec8148fa1e0ff3, _mode=2)
    at /home/rosalie/dev/RMG/Build/Release/Source/3rdParty/mupen64plus-video-GLideN64/src/DebugDump.cpp:63
No locals.
#1  0x00007fffccd4e2c3 in DebugMsg (_mode=2, 
    _format=0x7fffccf96178 "gSPTexture:  tile: %d, mipmap_lvl: %d, on: %d, s_scale: %f, t_scale: %f\n")
    at /home/rosalie/dev/RMG/Build/Release/Source/3rdParty/mupen64plus-video-GLideN64/src/DebugDump.cpp:70
        buf = "\001\000\000\000\000\000\000\000\360K\326UUU\000\000\360K\326UUU\000\000\001\000\000\000\377\177\000\000\300\253\177o\377\177\000\000xO\326UUU", '\000' <repeats 18 times>, "\001\000\000\000\000\000\000\000\360K\326UUU\000\000\360K\326UUU\000\000\377\377\377\377\000\000\000\000(\212\243\314\377\177\000\000\360K\326UUU\000\000\000\000\000\000\000\000\000\000Շ\354\314\377\177\000\000\f\352N\315\377\177\000\000\250\005O\315\377\177\000\000\360K\326UUU\000\000\360K\326UUU\000\000\362\064\000\000\000\000\000\000\220\227\r\315\377\177\000\000T\323\346\002\000\000\000\000\000\000\300\000\000\000\000\000\000\315\v\274\377\177\000\000\002"...
        text = 0x0
        va = {{gp_offset = 0, fp_offset = 0, overflow_arg_area = 0x5, reg_save_area = 0x0}}
```

I'm not sure why the `static` fixes it but it does on linux (maybe compiler differences if this works on windows?).