### PR TITLE
Update GLideN64.custom.ini

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -337,3 +337,15 @@ frameBufferEmulation\bufferSwapMode=1
 [WGHOCKEY]
 Good_Name=Wayne Gretzky's 3D Hockey (J)
 frameBufferEmulation\bufferSwapMode=1
+
+[BOMBERMAN64E]
+Good_Name=Bomberman 64 (E) [!]
+generalEmulation\enableLegacyBlending=0
+
+[BOMBERMAN64U]
+Good_Name=Bomberman 64 (U) [!]
+generalEmulation\enableLegacyBlending=0
+
+[BAKU-BOMBERMAN]
+Good_Name=Baku Bomberman (J) [!]
+generalEmulation\enableLegacyBlending=0

--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -10,6 +10,10 @@ frameBufferEmulation\N64DepthCompare=1
 Good_Name=40 Winks (E) (M3) (Prototype)
 graphics2D\enableNativeResTexrects=1
 
+[BAKU-BOMBERMAN]
+Good_Name=Baku Bomberman (J) [!]
+generalEmulation\enableLegacyBlending=0
+
 [BIOFREAKS]
 Good_Name=Bio F.R.E.A.K.S. (E)(U)
 frameBufferEmulation\copyToRDRAM=1
@@ -19,6 +23,14 @@ Good_Name=Biohazard 2 (J)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0
 frameBufferEmulation\copyDepthToRDRAM=0
+
+[BOMBERMAN64E]
+Good_Name=Bomberman 64 (E) [!]
+generalEmulation\enableLegacyBlending=0
+
+[BOMBERMAN64U]
+Good_Name=Bomberman 64 (U) [!]
+generalEmulation\enableLegacyBlending=0
 
 [362D06B6]
 Good_Name=Densha de Go! 64 (J)
@@ -337,15 +349,3 @@ frameBufferEmulation\bufferSwapMode=1
 [WGHOCKEY]
 Good_Name=Wayne Gretzky's 3D Hockey (J)
 frameBufferEmulation\bufferSwapMode=1
-
-[BOMBERMAN64E]
-Good_Name=Bomberman 64 (E) [!]
-generalEmulation\enableLegacyBlending=0
-
-[BOMBERMAN64U]
-Good_Name=Bomberman 64 (U) [!]
-generalEmulation\enableLegacyBlending=0
-
-[BAKU-BOMBERMAN]
-Good_Name=Baku Bomberman (J) [!]
-generalEmulation\enableLegacyBlending=0


### PR DESCRIPTION
Disabling of Legacy Blending is required for Bomberman 64 / Baku Bomberman to avoid the menu black screen