### PR TITLE
Remove CoreVideo calls in resizeWindow

### DIFF
--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -175,10 +175,6 @@ bool DisplayWindowMupen64plus::_resizeWindow()
 {
 	_setAttributes();
 
-#ifndef M64P_GLIDENUI
-	m_bFullscreen = false;
-#endif // M64P_GLIDENUI
-
 #ifdef M64P_GLIDENUI
 	m64p_error returnValue;
 
@@ -206,21 +202,7 @@ bool DisplayWindowMupen64plus::_resizeWindow()
 
 	m_width = m_screenWidth = m_resizeWidth;
 	m_height = m_screenHeight = m_resizeHeight;
-	switch (CoreVideo_ResizeWindow(m_screenWidth, m_screenHeight)) {
-		case M64ERR_INVALID_STATE:
-			LOG(LOG_ERROR, "Error setting videomode %dx%d in fullscreen mode", m_screenWidth, m_screenHeight);
-			m_width = m_screenWidth = config.video.windowedWidth;
-			m_height = m_screenHeight = config.video.windowedHeight;
-			break;
-		case M64ERR_SUCCESS:
-			break;
-		default:
-			LOG(LOG_ERROR, "Error setting videomode %dx%d", m_screenWidth, m_screenHeight);
-			m_width = m_screenWidth = config.video.windowedWidth;
-			m_height = m_screenHeight = config.video.windowedHeight;
-			FunctionWrapper::CoreVideo_Quit();
-			return false;
-	}
+
 	_setBufferSize();
 	opengl::Utils::isGLError(); // reset GL error.
 	return true;


### PR DESCRIPTION
An attempt to fix #2736.
The changes don't show any ill effects on RMG or Logan's GUI (Dec 2018).
