### PR TITLE
GLideNUI: fix OSD tab crash

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -1022,8 +1022,11 @@ void ConfigDialog::on_tabWidget_currentChanged(int tab)
 		while (fontIt.hasNext()) {
 			QString font = fontIt.next();
 			int id = QFontDatabase::addApplicationFont(font);
-			QString fontListFamily = QFontDatabase::applicationFontFamilies(id).at(0);
-			internalFontList[fontListFamily].append(font);
+			QStringList fontListFamilies = QFontDatabase::applicationFontFamilies(id);
+			if (!fontListFamilies.isEmpty()) {
+				QString fontListFamily = fontListFamilies.at(0);
+				internalFontList[fontListFamily].append(font);
+			}
 		}
 
 		QMap<QString, QStringList>::const_iterator i;


### PR DESCRIPTION
A RMG user reported a GLideN64 crash when going to the OSD tab in GLideNUI, after some investigation & debugging, this fixes it.