### PR TITLE
GLideNUI: improve settings loading

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -127,9 +127,9 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 	m_blockReInit = true;
 
 	if (reInit && m_romName != nullptr && ui->customSettingsCheckBox->isChecked() && ui->settingsDestGameRadioButton->isChecked()) {
-		loadCustomRomSettings(m_strIniPath, m_romName);
+		loadCustomRomSettings(m_strIniPath, m_strSharedIniPath, m_romName);
 	} else if (reInit) {
-		loadSettings(m_strIniPath);
+		loadSettings(m_strIniPath, m_strSharedIniPath);
 	}
 
 	// Video settings
@@ -480,14 +480,15 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 
 void ConfigDialog::_getTranslations(QStringList & _translationFiles) const
 {
-	QDir pluginFolder(m_strIniPath);
+	QDir pluginFolder(m_strSharedIniPath);
 	QStringList nameFilters("gliden64_*.qm");
 	_translationFiles = pluginFolder.entryList(nameFilters, QDir::Files, QDir::Name);
 }
 
-void ConfigDialog::setIniPath(const QString & _strIniPath)
+void ConfigDialog::setIniPath(const QString & _strIniPath, const QString & _strSharedIniPath)
 {
 	m_strIniPath = _strIniPath;
+	m_strSharedIniPath = _strSharedIniPath;
 
 	QStringList translationFiles;
 	_getTranslations(translationFiles);
@@ -798,7 +799,7 @@ void ConfigDialog::accept(bool justSave) {
 		config.debug.dumpMode |= DEBUG_DETAIL;
 
 	if (config.generalEmulation.enableCustomSettings && ui->settingsDestGameRadioButton->isChecked() && m_romName != nullptr)
-		saveCustomRomSettings(m_strIniPath, m_romName);
+		saveCustomRomSettings(m_strIniPath, m_strSharedIniPath, m_romName);
 	else
 		writeSettings(m_strIniPath);
 
@@ -1111,7 +1112,7 @@ void ConfigDialog::on_profilesComboBox_currentTextChanged(const QString &profile
 		}
 		return;
 	}
-	changeProfile(m_strIniPath, profile);
+	changeProfile(m_strIniPath, m_strSharedIniPath, profile);
 	_init(true);
 }
 
@@ -1139,7 +1140,7 @@ void ConfigDialog::on_removeProfilePushButton_clicked()
 		removeProfile(m_strIniPath, profile);
 		ui->profilesComboBox->blockSignals(true);
 		ui->profilesComboBox->removeItem(ui->profilesComboBox->currentIndex());
-		changeProfile(m_strIniPath, ui->profilesComboBox->itemText(ui->profilesComboBox->currentIndex()));
+		changeProfile(m_strIniPath, m_strSharedIniPath, ui->profilesComboBox->itemText(ui->profilesComboBox->currentIndex()));
 		ui->profilesComboBox->blockSignals(false);
 		_init(true);
 		ui->removeProfilePushButton->setDisabled(ui->profilesComboBox->count() == 3);

--- a/src/GLideNUI/ConfigDialog.h
+++ b/src/GLideNUI/ConfigDialog.h
@@ -28,7 +28,7 @@ public:
 						unsigned int _maxAnisotropy = 16);
 	~ConfigDialog();
 
-	void setIniPath(const QString & _strIniPath);
+	void setIniPath(const QString & _strIniPath, const QString & _strSharedIniPath);
 	void setRomName(const char * _romName);
 	void setTitle();
 	bool isAccepted() const { return m_accepted; }
@@ -110,6 +110,7 @@ private:
 	bool m_fontsInited;
 	bool m_blockReInit;
 	QString m_strIniPath;
+	QString m_strSharedIniPath;
 	const char * m_romName;
 	unsigned int m_maxMSAA;
 	unsigned int m_maxAnisotropy;

--- a/src/GLideNUI/Config_GLideNUI.cpp
+++ b/src/GLideNUI/Config_GLideNUI.cpp
@@ -14,24 +14,22 @@ void Config_DoConfig(/*HWND hParent*/)
 		return;
 
 	wchar_t strIniFolderPath[PLUGIN_PATH_SIZE];
-	api().FindPluginPath(strIniFolderPath);
+	wchar_t strSharedIniFolderPath[PLUGIN_PATH_SIZE];
 
 #ifdef M64P_GLIDENUI
-	wchar_t strConfigFolderPath[PLUGIN_PATH_SIZE];
-	api().GetUserConfigPath(strConfigFolderPath);
-
-	if (!IsPathWriteable(strIniFolderPath)) {
-		CopyConfigFiles(strIniFolderPath, strConfigFolderPath);
-		api().GetUserConfigPath(strIniFolderPath);
-	}
+	api().FindPluginPath(strSharedIniFolderPath);
+	api().GetUserConfigPath(strIniFolderPath);
+#else
+	api().FindPluginPath(strSharedIniFolderPath);
+	api().FindPluginPath(strIniFolderPath);
 #endif // M64P_GLIDENUI
 
 	ConfigOpen = true;
 	const u32 maxMsaa = dwnd().maxMSAALevel();
 	const u32 maxAnisotropy = dwnd().maxAnisotropy();
-	const bool bRestart = RunConfig(strIniFolderPath, api().isRomOpen() ? RSP.romname : nullptr, maxMsaa, maxAnisotropy);
+	const bool bRestart = RunConfig(strIniFolderPath, strSharedIniFolderPath, api().isRomOpen() ? RSP.romname : nullptr, maxMsaa, maxAnisotropy);
 	if (config.generalEmulation.enableCustomSettings != 0)
-		LoadCustomRomSettings(strIniFolderPath, RSP.romname);
+		LoadCustomRomSettings(strIniFolderPath, strSharedIniFolderPath, RSP.romname);
 	config.validate();
 	if (bRestart)
 		dwnd().restart();
@@ -41,20 +39,18 @@ void Config_DoConfig(/*HWND hParent*/)
 void Config_LoadConfig()
 {
 	wchar_t strIniFolderPath[PLUGIN_PATH_SIZE];
-	api().FindPluginPath(strIniFolderPath);
+	wchar_t strSharedIniFolderPath[PLUGIN_PATH_SIZE];
 
 #ifdef M64P_GLIDENUI
-	wchar_t strConfigFolderPath[PLUGIN_PATH_SIZE];
-	api().GetUserConfigPath(strConfigFolderPath);
-
-	if (!IsPathWriteable(strIniFolderPath)) {
-		CopyConfigFiles(strIniFolderPath, strConfigFolderPath);
-		api().GetUserConfigPath(strIniFolderPath);
-	}
+	api().FindPluginPath(strSharedIniFolderPath);
+	api().GetUserConfigPath(strIniFolderPath);
+#else
+	api().FindPluginPath(strSharedIniFolderPath);
+	api().FindPluginPath(strIniFolderPath);
 #endif // M64P_GLIDENUI
 
-	LoadConfig(strIniFolderPath);
+	LoadConfig(strIniFolderPath, strSharedIniFolderPath);
 	if (config.generalEmulation.enableCustomSettings != 0)
-		LoadCustomRomSettings(strIniFolderPath, RSP.romname);
+		LoadCustomRomSettings(strIniFolderPath, strSharedIniFolderPath, RSP.romname);
 	config.validate();
 }

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -21,14 +21,15 @@ inline void initMyResource() { Q_INIT_RESOURCE(icon); }
 inline void cleanMyResource() { Q_CLEANUP_RESOURCE(icon); }
 
 static
-int openConfigDialog(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, float _maxAnisotropy, bool & _accepted)
+int openConfigDialog(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName, unsigned int _maxMSAALevel, float _maxAnisotropy, bool & _accepted)
 {
 	cleanMyResource();
 	initMyResource();
 	QString strIniFileName = QString::fromWCharArray(_strFileName);
-	loadSettings(strIniFileName);
+	QString strSharedIniFileName = QString::fromWCharArray(_strSharedFileName);
+	loadSettings(strIniFileName, strSharedIniFileName);
 	if (config.generalEmulation.enableCustomSettings != 0 && _romName != nullptr && strlen(_romName) != 0)
-		loadCustomRomSettings(strIniFileName, _romName);
+		loadCustomRomSettings(strIniFileName, strSharedIniFileName, _romName);
 
 	std::unique_ptr<QApplication> pQApp;
 	QCoreApplication* pApp = QCoreApplication::instance();
@@ -46,7 +47,7 @@ int openConfigDialog(const wchar_t * _strFileName, const char * _romName, unsign
 
 	ConfigDialog w(Q_NULLPTR, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint, _maxMSAALevel, _maxAnisotropy);
 
-	w.setIniPath(strIniFileName);
+	w.setIniPath(strIniFileName, strSharedIniFileName);
 	w.setRomName(_romName);
 	w.setTitle();
 	w.show();
@@ -75,13 +76,13 @@ int openAboutDialog(const wchar_t * _strFileName)
 	return a.exec();
 }
 
-bool runConfigThread(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy) {
+bool runConfigThread(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy) {
 	bool accepted = false;
 #ifdef RUN_DIALOG_IN_THREAD
-	std::thread configThread(openConfigDialog, _strFileName, _maxMSAALevel, std::ref(accepted));
+	std::thread configThread(openConfigDialog, _strFileName, _strSharedFileName, _maxMSAALevel, std::ref(accepted));
 	configThread.join();
 #else
-	openConfigDialog(_strFileName, _romName, _maxMSAALevel, _maxAnisotropy, accepted);
+	openConfigDialog(_strFileName, _strSharedFileName, _romName, _maxMSAALevel, _maxAnisotropy, accepted);
 #endif
 	return accepted;
 
@@ -97,21 +98,9 @@ int runAboutThread(const wchar_t * _strFileName) {
 	return 0;
 }
 
-#ifdef M64P_GLIDENUI
-EXPORT bool CALL IsPathWriteable(const wchar_t * dir)
+EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const wchar_t * _strUserFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy)
 {
-	return isPathWriteable(QString::fromWCharArray(dir));
-}
-
-EXPORT void CALL CopyConfigFiles(const wchar_t * _srcDir, const wchar_t * _targetDir)
-{
-	return copyConfigFiles(QString::fromWCharArray(_srcDir), QString::fromWCharArray(_targetDir));
-}
-#endif // M64P_GLIDENUI
-
-EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy)
-{
-	return runConfigThread(_strFileName, _romName, _maxMSAALevel, _maxAnisotropy);
+	return runConfigThread(_strFileName, _strUserFileName, _romName, _maxMSAALevel, _maxAnisotropy);
 }
 
 EXPORT int CALL RunAbout(const wchar_t * _strFileName)
@@ -119,12 +108,12 @@ EXPORT int CALL RunAbout(const wchar_t * _strFileName)
 	return runAboutThread(_strFileName);
 }
 
-EXPORT void CALL LoadConfig(const wchar_t * _strFileName)
+EXPORT void CALL LoadConfig(const wchar_t * _strFileName, const wchar_t * _strSharedFileName)
 {
-	loadSettings(QString::fromWCharArray(_strFileName));
+	loadSettings(QString::fromWCharArray(_strFileName), QString::fromWCharArray(_strSharedFileName));
 }
 
-EXPORT void CALL LoadCustomRomSettings(const wchar_t * _strFileName, const char * _romName)
+EXPORT void CALL LoadCustomRomSettings(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName)
 {
-	loadCustomRomSettings(QString::fromWCharArray(_strFileName), _romName);
+	loadCustomRomSettings(QString::fromWCharArray(_strFileName), QString::fromWCharArray(_strSharedFileName), _romName);
 }

--- a/src/GLideNUI/GLideNUI.h
+++ b/src/GLideNUI/GLideNUI.h
@@ -13,15 +13,10 @@ extern "C" {
 #define CALL
 #endif
 
-#ifdef M64P_GLIDENUI
-EXPORT bool CALL IsPathWriteable(const wchar_t * dir);
-EXPORT void CALL CopyConfigFiles(const wchar_t * _srcDir, const wchar_t * _targetDir);
-#endif // M64P_GLIDENUI
-
-EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
+EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
 EXPORT int CALL RunAbout(const wchar_t * _strFileName);
-EXPORT void CALL LoadConfig(const wchar_t * _strFileName);
-EXPORT void CALL LoadCustomRomSettings(const wchar_t * _strFileName, const char * _romName);
+EXPORT void CALL LoadConfig(const wchar_t * _strFileName, const wchar_t * _strSharedFileName);
+EXPORT void CALL LoadCustomRomSettings(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName);
 
 #if defined(__cplusplus)
 }

--- a/src/GLideNUI/Settings.h
+++ b/src/GLideNUI/Settings.h
@@ -1,21 +1,17 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-void loadSettings(const QString & _strIniFolder);
+void loadSettings(const QString & _strIniFolder, const QString & _strSharedIniFolder);
 void writeSettings(const QString & _strIniFolder);
 void resetSettings(const QString & _strIniFolder);
-void loadCustomRomSettings(const QString & _strIniFolder, const char * _strRomName);
-void saveCustomRomSettings(const QString & _strIniFolder, const char * _strRomName);
+void loadCustomRomSettings(const QString & _strIniFolder, const QString & _strSharedIniFolder, const char * _strRomName);
+void saveCustomRomSettings(const QString & _strIniFolder, const QString & _strSharedIniFolder, const char * _strRomName);
 QString getTranslationFile();
 QStringList getProfiles(const QString & _strIniFolder);
 QString getCurrentProfile(const QString & _strIniFolder);
-void changeProfile(const QString & _strIniFolder, const QString & _strProfile);
+void changeProfile(const QString & _strIniFolder, const QString & _strSharedIniFolder, const QString & _strProfile);
 void addProfile(const QString & _strIniFolder, const QString & _strProfile);
 void removeProfile(const QString & _strIniFolder, const QString & _strProfile);
-#ifdef M64P_GLIDENUI
-bool isPathWriteable(const QString dir);
-void copyConfigFiles(const QString _srcDir, const QString _targetDir);
-#endif // M64P_GLIDENUI
 
 #endif // SETTINGS_H
 


### PR DESCRIPTION
This patch improves the work I did in https://github.com/gonetz/GLideN64/pull/2643 and https://github.com/gonetz/GLideN64/pull/2654.

The problems before this patch are

1) my RMG updater (on windows) would always overwrite `GLideN64.custom.ini`, overwriting the user's per game settings.
2) `GLideN64.custom.ini` not being updated for linux system installations due to it copying `GLideN64.custom.ini` only once.

This patch solves it by reading the `GLideN64.custom.ini` from the user config directory first, if that doesn't exist or doesn't contain the specified ROM that's being loaded, then it'll fallback to the shared `GLideN64.custom.ini` file, and GLideNUI will save to the user's config directory for both the `GLideN64.ini` and `GLideN64.custom.ini` files, solving both problems and improving upon the previous solution I had.
