### PR TITLE
Fix Display Bug in Settings UI

### DIFF
--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -1445,9 +1445,6 @@
             <string>2D elements</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_48">
-            <property name="spacing">
-             <number>18</number>
-            </property>
             <item>
              <layout class="QVBoxLayout" name="verticalLayout_31">
               <property name="spacing">
@@ -1577,27 +1574,31 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QRadioButton" name="fixTexrectForceRadioButton">
-                   <property name="text">
-                    <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Always</string>
-                   </property>
-                   <attribute name="buttonGroup">
-                    <string notr="true">fixTexrectCoordsButtonGroup</string>
-                   </attribute>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QRadioButton" name="fixTexrectDisableRadioButton">
-                   <property name="text">
-                    <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Never</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                   <attribute name="buttonGroup">
-                    <string notr="true">fixTexrectCoordsButtonGroup</string>
-                   </attribute>
-                  </widget>
+                  <layout class="QHBoxLayout" name="horizontalLayout_39">
+                   <item>
+                    <widget class="QRadioButton" name="fixTexrectForceRadioButton">
+                     <property name="text">
+                      <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Always</string>
+                     </property>
+                     <attribute name="buttonGroup">
+                      <string notr="true">fixTexrectCoordsButtonGroup</string>
+                     </attribute>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="fixTexrectDisableRadioButton">
+                     <property name="text">
+                      <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Never</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                     <attribute name="buttonGroup">
+                      <string notr="true">fixTexrectCoordsButtonGroup</string>
+                     </attribute>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                 </layout>
                </widget>
@@ -1656,22 +1657,6 @@
                     <string>Stripped</string>
                    </property>
                   </widget>
-                 </item>
-                 <item>
-                  <spacer name="verticalSpacer_13">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Preferred</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>0</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
                  </item>
                 </layout>
                </widget>

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -29,12 +29,6 @@
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -1027,12 +1021,6 @@
       </layout>
      </widget>
      <widget class="QWidget" name="emulationTab">
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>380</height>
-       </size>
-      </property>
       <attribute name="title">
        <string>Emulation</string>
       </attribute>

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -1031,10 +1031,29 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_30">
          <item>
+          <widget class="QCheckBox" name="customSettingsCheckBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, all non-default values of settings are stored individually for each game.&lt;/p&gt;&lt;p&gt;When a game is running, settings are displayed and saved for the currently running game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; GLideN64 already contains settings for the optimal performance of most games. Be careful when altering options on 'Emulation' and 'Frame buffer' tab.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Use per-game settings</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QFrame" name="emulationOptionsFrame">
            <layout class="QVBoxLayout" name="verticalLayout_47">
             <property name="spacing">
-             <number>4</number>
+             <number>3</number>
             </property>
             <property name="leftMargin">
              <number>0</number>
@@ -1048,32 +1067,6 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item>
-             <widget class="QCheckBox" name="customSettingsCheckBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, all non-default values of settings are stored individually for each game.&lt;/p&gt;&lt;p&gt;When a game is running, settings are displayed and saved for the currently running game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; GLideN64 already contains settings for the optimal performance of most games. Be careful when altering options on 'Emulation' and 'Frame buffer' tab.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Use per-game settings</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="line_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
             <item>
              <widget class="QCheckBox" name="emulateLodCheckBox">
               <property name="sizePolicy">
@@ -1236,7 +1229,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_15">
               <property name="spacing">
-               <number>4</number>
+               <number>3</number>
               </property>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_12">
@@ -1369,6 +1362,9 @@
             <string>Dithering</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_6">
+            <property name="verticalSpacing">
+             <number>3</number>
+            </property>
             <item row="0" column="1">
              <widget class="QCheckBox" name="ditheringQuantizationCheckBox">
               <property name="toolTip">
@@ -1455,7 +1451,7 @@
             <item>
              <layout class="QVBoxLayout" name="verticalLayout_31">
               <property name="spacing">
-               <number>4</number>
+               <number>3</number>
               </property>
               <property name="leftMargin">
                <number>0</number>

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -29,6 +29,12 @@
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -1030,28 +1030,6 @@
        </property>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_30">
-         <property name="spacing">
-          <number>18</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="customSettingsCheckBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, all non-default values of settings are stored individually for each game.&lt;/p&gt;&lt;p&gt;When a game is running, settings are displayed and saved for the currently running game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; GLideN64 already contains settings for the optimal performance of most games. Be careful when altering options on 'Emulation' and 'Frame buffer' tab.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Use per-game settings</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
          <item>
           <widget class="QFrame" name="emulationOptionsFrame">
            <layout class="QVBoxLayout" name="verticalLayout_47">
@@ -1070,6 +1048,32 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
+            <item>
+             <widget class="QCheckBox" name="customSettingsCheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled, all non-default values of settings are stored individually for each game.&lt;/p&gt;&lt;p&gt;When a game is running, settings are displayed and saved for the currently running game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; GLideN64 already contains settings for the optimal performance of most games. Be careful when altering options on 'Emulation' and 'Frame buffer' tab.&lt;/p&gt;&lt;p&gt;[Recommended: &lt;span style=&quot; font-style:italic;&quot;&gt;Checked&lt;/span&gt;]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Use per-game settings</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QCheckBox" name="emulateLodCheckBox">
               <property name="sizePolicy">

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -1030,6 +1030,9 @@
        </property>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_30">
+         <property name="spacing">
+          <number>9</number>
+         </property>
          <item>
           <widget class="QCheckBox" name="customSettingsCheckBox">
            <property name="sizePolicy">
@@ -1053,7 +1056,7 @@
           <widget class="QFrame" name="emulationOptionsFrame">
            <layout class="QVBoxLayout" name="verticalLayout_47">
             <property name="spacing">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="leftMargin">
              <number>0</number>
@@ -1147,7 +1150,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_56">
               <property name="spacing">
-               <number>3</number>
+               <number>4</number>
               </property>
               <item>
                <widget class="QRadioButton" name="factor0xRadioButton">
@@ -1229,7 +1232,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_15">
               <property name="spacing">
-               <number>3</number>
+               <number>4</number>
               </property>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_12">
@@ -1363,7 +1366,7 @@
            </property>
            <layout class="QGridLayout" name="gridLayout_6">
             <property name="verticalSpacing">
-             <number>3</number>
+             <number>4</number>
             </property>
             <item row="0" column="1">
              <widget class="QCheckBox" name="ditheringQuantizationCheckBox">
@@ -1445,10 +1448,13 @@
             <string>2D elements</string>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_48">
+            <property name="spacing">
+             <number>9</number>
+            </property>
             <item>
              <layout class="QVBoxLayout" name="verticalLayout_31">
               <property name="spacing">
-               <number>3</number>
+               <number>4</number>
               </property>
               <property name="leftMargin">
                <number>0</number>
@@ -1533,7 +1539,7 @@
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_5">
                  <property name="spacing">
-                  <number>3</number>
+                  <number>4</number>
                  </property>
                  <property name="leftMargin">
                   <number>0</number>
@@ -1574,31 +1580,27 @@
                   </widget>
                  </item>
                  <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_39">
-                   <item>
-                    <widget class="QRadioButton" name="fixTexrectForceRadioButton">
-                     <property name="text">
-                      <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Always</string>
-                     </property>
-                     <attribute name="buttonGroup">
-                      <string notr="true">fixTexrectCoordsButtonGroup</string>
-                     </attribute>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QRadioButton" name="fixTexrectDisableRadioButton">
-                     <property name="text">
-                      <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Never</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                     <attribute name="buttonGroup">
-                      <string notr="true">fixTexrectCoordsButtonGroup</string>
-                     </attribute>
-                    </widget>
-                   </item>
-                  </layout>
+                  <widget class="QRadioButton" name="fixTexrectForceRadioButton">
+                   <property name="text">
+                    <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Always</string>
+                   </property>
+                   <attribute name="buttonGroup">
+                    <string notr="true">fixTexrectCoordsButtonGroup</string>
+                   </attribute>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="fixTexrectDisableRadioButton">
+                   <property name="text">
+                    <string extracomment="The label for this control is &quot;Fix black lines between 2D elements&quot;">Never</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                   <attribute name="buttonGroup">
+                    <string notr="true">fixTexrectCoordsButtonGroup</string>
+                   </attribute>
+                  </widget>
                  </item>
                 </layout>
                </widget>
@@ -1623,7 +1625,7 @@
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_35">
                  <property name="spacing">
-                  <number>3</number>
+                  <number>4</number>
                  </property>
                  <property name="leftMargin">
                   <number>0</number>
@@ -1657,6 +1659,22 @@
                     <string>Stripped</string>
                    </property>
                   </widget>
+                 </item>
+                 <item>
+                  <spacer name="verticalSpacer_13">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Preferred</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>0</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </widget>


### PR DESCRIPTION
The Settings UI has an issue where, when switching to the "Emulation" tab, the "Fix black lines between 2D elements" and "Background rendering mode (HLE only)" options appear squashed and garbled at the default window size. Attempting to resize the window temporarily fixes the issue by automatically expanding the window so that the options have enough space to display correctly, but switching to another tab allows the user to shrink the window back down again.

I assume that the expected behavior should be for the window's minimum height to be automatically set to the height of the largest tab, and for the window to disallow users from setting it smaller than that no matter what tab is open. This pull request implements this behavior by ~~changing the vertical Size Policy of tabWidget from "Expanding" (its default value) to "Minimum Expanding"~~ removing the erroneous minimum size property that was causing this issue.

An image showing the bug:
![GLideN64_bug](https://user-images.githubusercontent.com/70489593/219957954-4ffa3477-a030-4514-9357-452668d7b7bb.png)

An image showing the same screen after the fix is applied:
![GLideN64_fix](https://user-images.githubusercontent.com/70489593/219957959-addcea91-491b-4c6e-8d43-ee08fcb7fbb8.png)
