### PR TITLE
Add DllCrtFree implementation

### DIFF
--- a/src/ZilmarGFX_1_3.h
+++ b/src/ZilmarGFX_1_3.h
@@ -277,6 +277,14 @@ EXPORT void CALL ViWidthChanged (void);
  ******************************************************************/
 EXPORT void CALL ReadScreen (void **dest, long *width, long *height);
 
+/******************************************************************
+  Function: DllCrtFree
+  Purpose:  Frees the memory at the specified address with the dll's standard library
+  Input:    none
+  Output:   none
+ ******************************************************************/
+EXPORT void CALL DllCrtFree(void* addr);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/ZilmarPluginAPI.cpp
+++ b/src/ZilmarPluginAPI.cpp
@@ -55,4 +55,9 @@ EXPORT void CALL ReadScreen (void **dest, long *width, long *height)
 	api().ReadScreen(dest, width, height);
 }
 
+EXPORT void CALL DllCrtFree(void* addr)
+{
+	free(addr);
+}
+
 }


### PR DESCRIPTION
Mupen64-rr-lua is crashing when freeing the image buffer acquired from `ReadScreen`.

GLideN64 doesn't provide a free override (DllCrtFree), so mupen falls back to the standard library one, assuming the plugin is using it as well

Adding a DllCrtFree implementation to GLideN64 makes sure the buffer allocated by the plugin is freed by the same CRT version, avoiding this error.