### PR TITLE
Add "Try to adjust 16:9 game to fit" option (ultrawidescreen hack)

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -99,8 +99,9 @@ struct Config
 		aStretch = 0,
 		a43 = 1,
 		a169 = 2,
-		aAdjust = 3,
-		aTotal = 4
+		aAdjust43 = 3,
+		aAdjust169 = 4,
+		aTotal = 5
 	};
 
 	enum CopyToRDRAM {

--- a/src/DisplayWindow.cpp
+++ b/src/DisplayWindow.cpp
@@ -174,11 +174,20 @@ void DisplayWindow::_setBufferSize()
 			m_height = m_screenHeight;
 		}
 		break;
-	case Config::aAdjust: // adjust
+	case Config::aAdjust43: // adjust
 		m_width = m_screenWidth;
 		m_height = m_screenHeight;
 		if (m_screenWidth * 3 / 4 > m_screenHeight) {
 			f32 width43 = m_screenHeight * 4.0f / 3.0f;
+			m_adjustScale = width43 / m_screenWidth;
+			m_bAdjustScreen = true;
+		}
+		break;
+	case Config::aAdjust169: // adjust
+		m_width = m_screenWidth;
+		m_height = m_screenHeight;
+		if (m_screenWidth * 9 / 16 > m_screenHeight) {
+			f32 width43 = m_screenHeight * 16.0f / 9.0f;
 			m_adjustScale = width43 / m_screenWidth;
 			m_bAdjustScreen = true;
 		}

--- a/src/GLideNUI-wtl/Language.cpp
+++ b/src/GLideNUI-wtl/Language.cpp
@@ -33,11 +33,12 @@ void LoadDefaultStrings(void)
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_WINDOWED_RESOLUTION, "Windowed resolution:"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_WINDOWED_RESOLUTION_TOOLTIP, "This option selects the resolution for windowed mode. You can also type in a custom window size.\n\n[Recommended: 640 x 480, 800 x 600, 1024 x 768, 1280 x 960]"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_RATIO, "Aspect ratio:"));
-	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_RATIO_TOOLTIP, "This setting adjusts the aspect ratio of the video output. All N64 games support 4:3. Some games support 16:9 within game settings. Use Stretch to fill the screen without pillar or letterboxing.\n\nTry to adjust game to fit tries to adjust the viewing space to fit without stretching. Many games work well adjusted, but some don't."));
+	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_RATIO_TOOLTIP, "This setting adjusts the aspect ratio of the video output. All N64 games support 4:3. Some games support 16:9 within game settings. Use Stretch to fill the screen without pillar or letterboxing.\n\nTry to adjust 4:3 game to fit (also known as \"widescreen hack\") tries to adjust the viewing space to fit a game designed for 4:3 without stretching. Many games work well adjusted, but some don't.\n\nTry to adjust 16:9 game to fit&lt;/span&gt; (also known as \"ultrawidescreen hack\") tries to adjust the viewing space to fit a game designed for 16:9 without stretching. Many games work well adjusted, but some don't. For games offering native 16:9 options, this is generally preferable for ultrawide aspect ratios as it'll lead to fewer rendering issues."));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_4_3, "4:3 (recommended)"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_16_19, "16:9"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_STRETCH, "Stretch"));
-	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_ADJUST, "Try to adjust game to fit"));
+	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_ADJUST, "Try to adjust 4:3 game to fit"));
+	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_ASPECT_ADJUST, "Try to adjust 16:9 game to fit"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_VSYNC, "Enable VSync"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_VSYNC_TOOLTIP, "Vertical sync, or VSync, can improve the image by syncing the game's frame rate to your monitor's refresh rate. This prevents image tearing, but may cause performance problems.\n\n[Recommended: Usually off, on if you have image tearing problems]"));
 	g_defaultStrings.insert(LANG_STRINGS::value_type(VIDEO_THREADED_VIDEO, "Enable threaded video"));

--- a/src/GLideNUI-wtl/config-video.cpp
+++ b/src/GLideNUI-wtl/config-video.cpp
@@ -477,7 +477,8 @@ void CVideoTab::LoadSettings(bool /*blockCustomSettings*/) {
 	case Config::aStretch: aspectComboBox.SetCurSel(2); break;
 	case Config::a43: aspectComboBox.SetCurSel(0); break;
 	case Config::a169: aspectComboBox.SetCurSel(1); break;
-	case Config::aAdjust: aspectComboBox.SetCurSel(3); break;
+	case Config::aAdjust43: aspectComboBox.SetCurSel(3); break;
+	case Config::aAdjust169: aspectComboBox.SetCurSel(4); break;
 	}
 
 	CComboBox(GetDlgItem(IDC_CMB_PATTERN)).SetCurSel(config.generalEmulation.rdramImageDitheringMode);
@@ -522,7 +523,8 @@ void CVideoTab::SaveSettings()
 	if (AspectIndx == 2) { config.frameBufferEmulation.aspect = Config::aStretch; }
 	else if (AspectIndx == 0) { config.frameBufferEmulation.aspect = Config::a43; }
 	else if (AspectIndx == 1) { config.frameBufferEmulation.aspect = Config::a169; }
-	else if (AspectIndx == 3) { config.frameBufferEmulation.aspect = Config::aAdjust; }
+	else if (AspectIndx == 3) { config.frameBufferEmulation.aspect = Config::aAdjust43; }
+	else if (AspectIndx == 4) { config.frameBufferEmulation.aspect = Config::aAdjust169; }
 
 	config.video.verticalSync = CButton(GetDlgItem(IDC_CHK_VERTICAL_SYNC)).GetCheck() == BST_CHECKED;
 	config.video.threadedVideo = CButton(GetDlgItem(IDC_CHK_THREADED_VIDEO)).GetCheck() == BST_CHECKED;

--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -330,8 +330,11 @@ void ConfigDialog::_init(bool reInit, bool blockCustomSettings)
 	case Config::a169:
 		ui->aspectComboBox->setCurrentIndex(1);
 		break;
-	case Config::aAdjust:
+	case Config::aAdjust43:
 		ui->aspectComboBox->setCurrentIndex(3);
+		break;
+	case Config::aAdjust169:
+		ui->aspectComboBox->setCurrentIndex(4);
 		break;
 	}
 
@@ -649,7 +652,9 @@ void ConfigDialog::accept(bool justSave) {
 	else if (ui->aspectComboBox->currentIndex() == 1)
 		config.frameBufferEmulation.aspect = Config::a169;
 	else if (ui->aspectComboBox->currentIndex() == 3)
-		config.frameBufferEmulation.aspect = Config::aAdjust;
+		config.frameBufferEmulation.aspect = Config::aAdjust43;
+	else if (ui->aspectComboBox->currentIndex() == 4)
+		config.frameBufferEmulation.aspect = Config::aAdjust169;
 
 	if (ui->factor0xRadioButton->isChecked())
 		config.frameBufferEmulation.nativeResFactor = 0;

--- a/src/GLideNUI/configDialog.ui
+++ b/src/GLideNUI/configDialog.ui
@@ -168,7 +168,7 @@
             <item>
              <widget class="QFrame" name="aspectFrame">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting adjusts the aspect ratio of the video output. All N64 games support &lt;span style=&quot; font-weight:600;&quot;&gt;4:3&lt;/span&gt;. Some games support &lt;span style=&quot; font-weight:600;&quot;&gt;16:9&lt;/span&gt; within game settings. Use &lt;span style=&quot; font-weight:600;&quot;&gt;Stretch&lt;/span&gt; to fill the screen without pillar or letterboxing.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Try to adjust game to fit&lt;/span&gt; tries to adjust the viewing space to fit without stretching. Many games work well adjusted, but some don't.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This setting adjusts the aspect ratio of the video output. All N64 games support &lt;span style=&quot; font-weight:600;&quot;&gt;4:3&lt;/span&gt;. Some games support &lt;span style=&quot; font-weight:600;&quot;&gt;16:9&lt;/span&gt; within game settings. Use &lt;span style=&quot; font-weight:600;&quot;&gt;Stretch&lt;/span&gt; to fill the screen without pillar or letterboxing.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Try to adjust 4:3 game to fit&lt;/span&gt; (also known as &quot;widescreen hack&quot;) tries to adjust the viewing space to fit a game designed for 4:3 without stretching. Many games work well adjusted, but some don't.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Try to adjust 16:9 game to fit&lt;/span&gt; (also known as &quot;ultrawidescreen hack&quot;) tries to adjust the viewing space to fit a game designed for 16:9 without stretching. Many games work well adjusted, but some don't. For games offering native 16:9 options, this is generally preferable for ultrawide aspect ratios as it'll lead to fewer rendering issues.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
                <property name="spacing">
@@ -212,7 +212,12 @@
                  </item>
                  <item>
                   <property name="text">
-                   <string extracomment="This option activates a widescreen hack. The language &quot;Try to&quot; implies it may it may not work and the language &quot;adjust game&quot; implies the emulation will be inaccurate.">Try to adjust game to fit</string>
+                   <string extracomment="This option activates a widescreen hack. The language &quot;Try to&quot; implies it may it may not work and the language &quot;adjust 4:3 game&quot; implies the emulation will be inaccurate.">Try to adjust 4:3 game to fit</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string extracomment="This option activates a widescreen hack. The language &quot;Try to&quot; implies it may it may not work and the language &quot;adjust 16:9 game&quot; implies the emulation will be inaccurate.">Try to adjust 16:9 game to fit</string>
                   </property>
                  </item>
                 </widget>


### PR DESCRIPTION
This is the 16:9 counterpart of the existing widescreen hack, which is designed for 4:3-native games. This one is designed for games that natively support 16:9 and are configured to run this way, or games that have 16:9 widescreen cheats available.

When targeting ultrawide aspect ratios like 21:9, adjusting from 16:9 results in fewer culling issues compared to adjusting from 4:3. The downside is that in some games, HUD elements will be stretched up to 16:9 (this depends on the game's widescreen implementation).

You can usually get good results with aspect ratios up to 21:9, although wider aspect ratios will start exhibiting more and more culling issues inherent to each game.

The current setting is preserved in existing configurations; "Try to adjust game to fit" was renamed to "Try to adjust 4:3 game to fit" for clarity.

![Screenshot_20240121_203132](https://github.com/gonetz/GLideN64/assets/180032/695e5b36-b436-4128-a429-9f3c05ba496b)

## Preview

*21:9 aspect ratio:*

[ultrawide10.webm](https://github.com/gonetz/GLideN64/assets/180032/84746794-309c-44ad-ac5c-256386206878)

*Very wide aspect ratios like 48:9 aren't viable for gameplay due to frequent culling errors, but sometimes, stars will align and there won't be any culling issues in a specific spot* :slightly_smiling_face:

![Screenshot_20240121_202222 webp](https://github.com/gonetz/GLideN64/assets/180032/8786c85e-ef93-49ca-9740-d3e80fd05918)
![Screenshot_20240121_203440 webp](https://github.com/gonetz/GLideN64/assets/180032/9754ab28-3e22-4969-ac0a-ff628bd6e599)

