### PR TITLE
Add missing `#include <dlfcn.h>` (required by dlsym)

### DIFF
--- a/src/Graphics/OpenGLContext/GLFunctions.cpp
+++ b/src/Graphics/OpenGLContext/GLFunctions.cpp
@@ -8,6 +8,7 @@
 #define GL_GET_PROC_ADR(proc_type, proc_name) ptr##proc_name = (proc_type) glGetProcAddress("gl"#proc_name)
 
 #elif defined(VERO4K) || defined(ODROID) || defined(VC)
+#include <dlfcn.h>
 
 #define GL_GET_PROC_ADR(proc_type, proc_name) ptr##proc_name = (proc_type) dlsym(gles2so, "gl"#proc_name);
 


### PR DESCRIPTION
Add missing `#include <dlfcn.h>` (required by a use of `dlsym()`), for VERO4K, Odroid and VC (VideoCore, usually Raspberry Pi).  Without this patch, the compiler obviously complains that `dlsym()` is not declared.