### PR TITLE
Update node.js version 16 to version 20 in CI/CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         image: ["GLideN64 (x64 Mupen64Plus-CLI)", "GLideN64 (x64 Mupen64Plus-Qt)"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Packages
         run: |
           # fix for "error processing package grub-efi-amd64-signed"
@@ -43,7 +43,7 @@ jobs:
           cp translations/release/*.qm build/linux-mupen64plus-qt/
       - name: Upload GLideN64 (x64 Mupen64Plus-CLI)
         if: ${{ matrix.image == 'GLideN64 (x64 Mupen64Plus-CLI)' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Linux-Mupen64Plus-CLI-x64
           path: |
@@ -51,7 +51,7 @@ jobs:
             build/linux-mupen64plus-cli/GLideN64.custom.ini
       - name: Upload GLideN64 (x64 Mupen64Plus-Qt)
         if: ${{ matrix.image == 'GLideN64 (x64 Mupen64Plus-Qt)' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Linux-Mupen64Plus-Qt-x64
           path: |
@@ -70,8 +70,8 @@ jobs:
       QT_BUILD_x86: qt-5_15-x86-msvc2017-static
       QT_BUILD_x64: qt-5_15-x64-msvc2017-static
     steps:
-      - uses: actions/checkout@v3
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
       - uses: msys2/setup-msys2@v2
         with:
           update: true
@@ -162,7 +162,7 @@ jobs:
           cp translations/release/*.qm build/windows-mupen64plus-qt/
         shell: msys2 {0}
       - name: Upload GLideN64 (x64 Project64-Qt)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x64 Project64-Qt)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-Qt-x64
@@ -171,7 +171,7 @@ jobs:
             build\windows-project64-qt-x64\GLideN64.custom.ini
             build\windows-project64-qt-x64\*.qm
       - name: Upload GLideN64 (x86 Project64-Qt)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x86 Project64-Qt)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-Qt-x86
@@ -180,7 +180,7 @@ jobs:
             build\windows-project64-qt\GLideN64.custom.ini
             build\windows-project64-qt\*.qm
       - name: Upload GLideN64 (x64 Project64-WTL)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x64 Project64-WTL)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-WTL-x64
@@ -189,7 +189,7 @@ jobs:
             build\windows-project64-wtl-x64\GLideN64.custom.ini
             build\windows-project64-wtl-x64\translations\*.Lang
       - name: Upload GLideN64 (x86 Project64-WTL)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x86 Project64-WTL)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Project64-WTL-x86
@@ -198,7 +198,7 @@ jobs:
             build\windows-project64-wtl\GLideN64.custom.ini
             build\windows-project64-wtl\translations\*.Lang
       - name: Upload GLideN64 (x64 Mupen64Plus-CLI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x64 Mupen64Plus-CLI)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Mupen64Plus-CLI-x64
@@ -206,7 +206,7 @@ jobs:
             build\windows-mupen64plus-cli-x64\*.dll
             build\windows-mupen64plus-cli-x64\GLideN64.custom.ini
       - name: Upload GLideN64 (x86 Mupen64Plus-CLI)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x86 Mupen64Plus-CLI)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Mupen64Plus-CLI-x86
@@ -214,7 +214,7 @@ jobs:
             build\windows-mupen64plus-cli\*.dll
             build\windows-mupen64plus-cli\GLideN64.custom.ini
       - name: Upload GLideN64 (x64 Mupen64Plus-Qt)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.image == 'GLideN64 (x64 Mupen64Plus-Qt)' }}
         with:
           name: GLideN64-${{ env.GIT_REVISION }}-Windows-Mupen64Plus-Qt-x64
@@ -227,9 +227,9 @@ jobs:
     needs: [Windows, Linux]
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       # sadly we can't download the artifacts without extracting it
@@ -238,7 +238,7 @@ jobs:
         run: |
           cd artifacts
           for artifact in *
-          do 
+          do
             echo "-> Creating ${artifact}.zip"
             pushd "$artifact"
             zip -r "../${artifact}.zip" *


### PR DESCRIPTION
Hi @gonetz, I hope you are doing well.

I have updated the CI actions to update node.js from version 16 to version 20, this fixes the warning in the CI runs:
https://github.com/gonetz/GLideN64/actions/runs/7947586317