### PR TITLE
Change copyToRDRAM default when building with M64P_GLIDENUI

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -73,7 +73,11 @@ void Config::resetToDefaults()
 	frameBufferEmulation.copyDepthToRDRAM = cdSoftwareRender;
 	frameBufferEmulation.copyFromRDRAM = 0;
 	frameBufferEmulation.copyAuxToRDRAM = 0;
+#ifdef M64P_GLIDENUI
+	frameBufferEmulation.copyToRDRAM = ctSync;
+#else
 	frameBufferEmulation.copyToRDRAM = ctDoubleBuffer;
+#endif
 	frameBufferEmulation.N64DepthCompare = dcDisable;
 	frameBufferEmulation.forceDepthBufferClear = 0;
 	frameBufferEmulation.aspect = a43;


### PR DESCRIPTION
Should fix all corruption when resizing the window for all games, because some users were still experiencing this issue