### PR TITLE
Textures.cpp: only calculate strongcrc once

### DIFF
--- a/src/Textures.cpp
+++ b/src/Textures.cpp
@@ -1226,10 +1226,8 @@ bool TextureCache::_loadHiresTexture(u32 _tile, CachedTexture *_pTexture, u64 & 
 	GHQTexInfo ghqTexInfo;
 	// TODO: fix problem with zero texture dimensions on GLideNHQ side.
 	auto hirestexFound = txfilter_hirestex(_pTexture->crc, _ricecrc, palette, N64FormatSize(_pTexture->format, _pTexture->size), &ghqTexInfo);
-	if (!hirestexFound) {
+	if (!hirestexFound && _strongcrc != 0U) {
 		// Texture with RiceCRC was not found. Try alternative CRC.
-		if (_strongcrc == 0U)
-			_strongcrc = txfilter_checksum_strong(addr, width, height, _pTexture->size, bpl, paladdr);
 		hirestexFound = txfilter_hirestex(_pTexture->crc, _strongcrc, palette, N64FormatSize(_pTexture->format, _pTexture->size), &ghqTexInfo);
 	}
 	if (hirestexFound && ghqTexInfo.width != 0 && ghqTexInfo.height != 0) {


### PR DESCRIPTION
This makes sure that the strong crc is only calculated when the option has been enabled