### PR TITLE
Use mupen64plus API for logging

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -13,6 +13,8 @@
 #include <fstream>
 #include <ctime>
 
+#ifndef MUPENPLUSAPI // zilmar spec
+
 std::mutex g_logMutex;
 std::wofstream fileOutput;
 
@@ -112,6 +114,54 @@ void LogDebug(const char* _fileName, int _line, u16 _type, const char* _format, 
 	fileOutput << lcFormatString.str();
 	fileOutput.flush();
 }
+
+#else // mupen64plus
+#include "mupenplus/GLideN64_mupenplus.h"
+
+void LogDebug(const char* _fileName, int _line, u16 _type, const char* _format, ...)
+{
+	static const int logLevel[] = {
+		M64MSG_INFO,
+		M64MSG_ERROR,
+		M64MSG_INFO,
+		M64MSG_WARNING,
+		M64MSG_VERBOSE,
+		M64MSG_VERBOSE
+	};
+
+	if (CoreDebugCallback == nullptr ||
+		_type > LOG_LEVEL)
+	{
+		return;
+	}
+
+	// initialize use of the variable argument array
+	va_list vaArgs;
+	va_start(vaArgs, _format);
+
+	// reliably acquire the size from a copy of
+	// the variable argument array
+	// and a functionally reliable call
+	// to mock the formatting
+	va_list vaCopy;
+	va_copy(vaCopy, vaArgs);
+	const int iLen = std::vsnprintf(NULL, 0, _format, vaCopy);
+	va_end(vaCopy);
+
+	// return a formatted string without
+	// risking memory mismanagement
+	// and without assuming any compiler
+	// or platform specific behavior
+	std::vector<char> zc(iLen + 1);
+	std::vsnprintf(zc.data(), zc.size(), _format, vaArgs);
+	va_end(vaArgs);
+
+	std::stringstream formatString;
+	formatString << _fileName << ":" << _line << ", \"" << zc.data() << "\"";
+
+	CoreDebugCallback(CoreDebugCallbackContext, logLevel[_type], formatString.str().c_str());
+}
+#endif
 
 #if defined(OS_WINDOWS) && !defined(MINGW)
 #include "windows/GLideN64_windows.h"

--- a/src/MupenPlusPluginAPI.cpp
+++ b/src/MupenPlusPluginAPI.cpp
@@ -32,7 +32,7 @@ EXPORT m64p_error CALL PluginStartup(
 	void (*DebugCallback)(void *, int, const char *)
 )
 {
-	return api().PluginStartup(CoreLibHandle);
+	return api().PluginStartup(CoreLibHandle, Context, DebugCallback);
 }
 
 #ifdef M64P_GLIDENUI

--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -76,7 +76,7 @@ public:
 	void ResizeVideoOutput(int _Width, int _Height);
 	void ReadScreen2(void * _dest, int * _width, int * _height, int _front);
 
-	m64p_error PluginStartup(m64p_dynlib_handle _CoreLibHandle);
+	m64p_error PluginStartup(m64p_dynlib_handle _CoreLibHandle, void * Context, void (*DebugCallback)(void *, int, const char *));
 #ifdef M64P_GLIDENUI
 	m64p_error PluginConfig();
 #endif // M64P_GLIDENUI

--- a/src/mupenplus/GLideN64_mupenplus.h
+++ b/src/mupenplus/GLideN64_mupenplus.h
@@ -4,6 +4,7 @@
 #include "m64p_common.h"
 #include "m64p_config.h"
 #include "m64p_vidext.h"
+#include "m64p_frontend.h"
 
 #define PLUGIN_VERSION              0x020000
 #define VIDEO_PLUGIN_API_VERSION	0x020200
@@ -52,6 +53,9 @@ extern ptr_VidExt_GL_SwapBuffers        CoreVideo_GL_SwapBuffers;
 extern ptr_VidExt_GL_GetDefaultFramebuffer CoreVideo_GL_GetDefaultFramebuffer;
 
 extern ptr_PluginGetVersion             CoreGetVersion;
+
+extern void*                            CoreDebugCallbackContext;
+extern ptr_DebugCallback                CoreDebugCallback;
 
 extern const unsigned int* rdram_size;
 

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -49,12 +49,18 @@ ptr_VidExt_GL_GetDefaultFramebuffer CoreVideo_GL_GetDefaultFramebuffer = nullptr
 
 ptr_PluginGetVersion             CoreGetVersion = nullptr;
 
+void*                            CoreDebugCallbackContext = nullptr;
+ptr_DebugCallback                CoreDebugCallback        = nullptr;
+
 const unsigned int* rdram_size = nullptr;
 
-void(*renderCallback)(int) = nullptr;
+void (*renderCallback)(int) = nullptr;
 
-m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle)
+m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle, void* Context, void (*DebugCallback)(void *, int, const char *))
 {
+	CoreDebugCallbackContext = Context;
+	CoreDebugCallback = DebugCallback;
+
 	ConfigGetSharedDataFilepath = (ptr_ConfigGetSharedDataFilepath)	DLSYM(_CoreLibHandle, "ConfigGetSharedDataFilepath");
 	ConfigGetUserConfigPath = (ptr_ConfigGetUserConfigPath)	DLSYM(_CoreLibHandle, "ConfigGetUserConfigPath");
 	ConfigGetUserCachePath = (ptr_ConfigGetUserCachePath)DLSYM(_CoreLibHandle, "ConfigGetUserCachePath");


### PR DESCRIPTION
This patch makes GLideN64 use the debug callback for logging when built for mupen64plus instead of logging into a file.

An RMG user reported a very large GLideN64 log (47 GB) which isn't ideal, so this makes GLideN64 use the proper API to add logging for mupen64plus front-ends, so front-ends can handle the saving themselves if they want to.