### PR TITLE
Fix shader noise generation on GLES

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilderCommon.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilderCommon.cpp
@@ -1004,11 +1004,11 @@ public:
 	ShaderNoise(const opengl::GLInfo & _glinfo)
 	{
 		m_part =
-			"uniform float uNoiseSeed;								\n"
+			"uniform mediump float uNoiseSeed;						\n"
 			"lowp float snoise()									\n"
 			"{														\n"
-			"  mediump vec2 coord = floor(gl_FragCoord.xy/uScreenScale);	\n"
-			"  mediump vec3 p3 = vec3(uNoiseSeed, coord);			\n"
+			"  highp vec2 coord = floor(gl_FragCoord.xy/uScreenScale);\n"
+			"  highp vec3 p3 = vec3(uNoiseSeed, coord);				\n"
 			// hash13 from https://www.shadertoy.com/view/4djSRW
 			"  p3 = fract(p3 * .1031);								\n"
 			"  p3 += dot(p3, p3.zyx + 31.32);						\n"
@@ -1068,8 +1068,8 @@ public:
 			m_part +=
 			"  lowp float mult = 1.0;								\n";
 		m_part +=
-			"  mediump vec2 coord = floor(mult * (gl_FragCoord.xy/uScreenScale));	\n"
-			"  mediump vec3 p3 = vec3(uNoiseSeed, coord);				\n"
+			"  highp vec2 coord = floor(mult * (gl_FragCoord.xy/uScreenScale));\n"
+			"  highp vec3 p3 = vec3(uNoiseSeed, coord);					\n"
 			// hash33 from https://www.shadertoy.com/view/4djSRW
 			"  p3 = fract(p3 * vec3(.1031, .1030, .0973));				\n"
 			"  p3 += dot(p3, p3.yxz+33.33);								\n"
@@ -1087,8 +1087,8 @@ public:
 			"  lowp float mult = 1.0;								\n";
 		m_part +=
 			"														\n"
-			"  mediump vec2 coord = floor(mult * (gl_FragCoord.xy/uScreenScale));	\n"
-			"  mediump vec3 p3 = vec3(uNoiseSeed, coord);			\n"
+			"  highp vec2 coord = floor(mult * (gl_FragCoord.xy/uScreenScale));\n"
+			"  highp vec3 p3 = vec3(uNoiseSeed, coord);				\n"
 			// hash13 from https://www.shadertoy.com/view/4djSRW
 			"  p3 = fract(p3 * .1031);								\n"
 			"  p3 += dot(p3, p3.zyx + 31.32);						\n"


### PR DESCRIPTION
Fixes noise generation shaders added in #2833 in OpenGL ES by adding missing precision qualifiers. 

Closes #2837, which was caused by the missing qualifier on the uniform making shader compilation fail.