### PR TITLE
GLideN64.custom.ini small fixes

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -18,7 +18,7 @@ generalEmulation\enableLegacyBlending=0
 Good_Name=Bio F.R.E.A.K.S. (E)(U)
 frameBufferEmulation\copyToRDRAM=1
 
-[BioHazard%20II]
+[BIOHAZARD%20II]
 Good_Name=Biohazard 2 (J)
 frameBufferEmulation\copyFromRDRAM=1
 frameBufferEmulation\copyToRDRAM=0

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -340,6 +340,8 @@ void Config_LoadCustomConfig()
 		ROMname.replace(pos, 1, "%20");
 	for (size_t pos = ROMname.find('\''); pos != std::string::npos; pos = ROMname.find('\'', pos))
 		ROMname.replace(pos, 1, "%27");
+	for (size_t pos = ROMname.find('&'); pos != std::string::npos; pos = ROMname.find('&', pos))
+		ROMname.replace(pos, 1, "%26");
 	std::transform(ROMname.begin(), ROMname.end(), ROMname.begin(), ::toupper);
 	const char* sectionName = ROMname.c_str();
 	m64p_handle fileHandle;


### PR DESCRIPTION
Changed Biohazard 2 name to uppercase or else it's not picked up, example using RMG:
* With current lowercase name (settings not being applied):
  ![image](https://github.com/user-attachments/assets/242361f6-3af1-4b66-810b-0e4f0955d13a)
* With uppercase changes (custom settings properly applied:
  ![image](https://github.com/user-attachments/assets/0daeb15d-b36c-4133-be05-14ce72f2209a)

Second commit is to parse "&" ("%26" in the .ini) properly in Mupen64Plus (for Pokemon Stadium Kin Gin):
* Before:
  ![image](https://github.com/user-attachments/assets/41d985dc-f57c-493a-b07f-c9dcfe91a9b1)
* After:
  ![image](https://github.com/user-attachments/assets/6864d4b6-dc98-4797-9e63-d0f7d43a6cc5)

Idk if it requires additional changes for UI stuff, RMG at least seems to load that game custom settings just fine already.