### PR TITLE
Implement mge_get_video_size

### DIFF
--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -63,6 +63,7 @@ public:
 	void DllConfig(HWND _hParent);
 	void GetDllInfo (PLUGIN_INFO * PluginInfo);
 	void ReadScreen(void **_dest, long *_width, long *_height);
+	void GetVideoSize(int32_t* width, int32_t* height);
 
 	void DllAbout(/*HWND _hParent*/);
 

--- a/src/ZilmarGFX_1_3.h
+++ b/src/ZilmarGFX_1_3.h
@@ -20,6 +20,7 @@ the plugin
 #define _GFX_H_INCLUDED__
 
 #if defined(__cplusplus)
+#include <cstdint>
 extern "C" {
 #endif
 
@@ -284,6 +285,15 @@ EXPORT void CALL ReadScreen (void **dest, long *width, long *height);
   Output:   none
  ******************************************************************/
 EXPORT void CALL DllCrtFree(void* addr);
+
+/******************************************************************
+  Function: mge_get_video_size
+  Purpose:  Gets the current video size.
+  Input:    width - Pointer receiving the video width. Can be null.
+		    height - Pointer receiving the video height. Can be null.
+  Output:   none
+ ******************************************************************/
+EXPORT void CALL mge_get_video_size(int32_t* width, int32_t* height);
 
 #if defined(__cplusplus)
 }

--- a/src/ZilmarPluginAPI.cpp
+++ b/src/ZilmarPluginAPI.cpp
@@ -60,4 +60,9 @@ EXPORT void CALL DllCrtFree(void* addr)
 	free(addr);
 }
 
+void CALL mge_get_video_size(int32_t* width, int32_t* height)
+{
+	api().GetVideoSize(width, height);
+}
+
 }

--- a/src/common/CommonAPIImpl_common.cpp
+++ b/src/common/CommonAPIImpl_common.cpp
@@ -312,4 +312,17 @@ void PluginAPI::ReadScreen(void **_dest, long *_width, long *_height)
 	dwnd().readScreen(_dest, _width, _height);
 #endif
 }
+
+void PluginAPI::GetVideoSize(int32_t* width, int32_t* height)
+{
+	if (width)
+	{
+		*width = dwnd().getWidth();
+	}
+	if (height)
+	{
+		*height = dwnd().getHeight();
+	}
+}
+
 #endif


### PR DESCRIPTION
Required for capture on legacy Mupen64, as it needs a way to request the video size in a thread and wgl context-agnostic way.

