### PR TITLE
Bump minimum CMake version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 option(EGL "Set to ON if targeting an EGL device" ${EGL})
 option(PANDORA "Set to ON if targeting an OpenPandora" ${PANDORA})

--- a/src/GLideNHQ/CMakeLists.txt
+++ b/src/GLideNHQ/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 project( GLideNHQ )
 

--- a/src/osal/CMakeLists.txt
+++ b/src/osal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 project( osal )
 


### PR DESCRIPTION
Silences the deprecation warning.
See https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html.