### PR TITLE
F3DEX3: support gSPMemset for graphics buffers

### DIFF
--- a/src/gDP.h
+++ b/src/gDP.h
@@ -313,6 +313,7 @@ void gDPLoadTile( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt );
 void gDPLoadBlock( u32 tile, u32 uls, u32 ult, u32 lrs, u32 dxt );
 void gDPLoadTLUT( u32 tile, u32 uls, u32 ult, u32 lrs, u32 lrt );
 void gDPSetScissor( u32 mode, s16 xh, s16 yh, s16 xl, s16 yl);
+void gDPMemset(u32 value, u32 addr, u32 length);
 void gDPFillRectangle( s32 ulx, s32 uly, s32 lrx, s32 lry );
 void gDPSetConvert( s32 k0, s32 k1, s32 k2, s32 k3, s32 k4, s32 k5 );
 void gDPSetKeyR( u32 cR, u32 sR, u32 wR );

--- a/src/uCodes/F3DEX3.cpp
+++ b/src/uCodes/F3DEX3.cpp
@@ -8,6 +8,8 @@
 
 #define	F3DEX3_BRANCH_WZ	0x04
 
+#define F3DEX3_MEMSET            0xD5
+
 #define F3DEX3_TRISTRIP          0x08
 #define F3DEX3_TRIFAN            0x09
 #define F3DEX3_LIGHTTORDP        0x0A
@@ -234,6 +236,14 @@ static void F3DEX3_RelSegment(u32 w0, u32 w1)
 	gSPRelSegment(_SHIFTR(w0, 2, 4), w1 & 0x00FFFFFF);
 }
 
+static void F3DEX3_Memset(u32 w0, u32 w1)
+{
+	u32 value = (u16) gDP.half_1;
+	u32 addr = w1;
+	u32 length = w0 & 0x00FFFFFF;
+	gDPMemset(value, addr, length);
+}
+
 void F3DEX3_Init()
 {
 	gSPSetupFunctions();
@@ -258,7 +268,6 @@ void F3DEX3_Init()
 	GBI_SetGBI(G_POPMTX, F3DEX2_POPMTX, F3DEX2_PopMtx);
 	GBI_SetGBI(G_TEXTURE, F3DEX2_TEXTURE, F3DEX2_Texture);
 	GBI_SetGBI(G_DMA_IO, F3DEX2_DMA_IO, F3DEX2_DMAIO);
-	GBI_SetGBI(G_SPECIAL_1, F3DEX2_SPECIAL_1, F3DEX2_Special_1);
 	GBI_SetGBI(G_SPECIAL_2, F3DEX2_SPECIAL_2, F3DEX2_Special_2);
 	GBI_SetGBI(G_SPECIAL_3, F3DEX2_SPECIAL_3, F3DEX2_Special_3);
 
@@ -273,4 +282,5 @@ void F3DEX3_Init()
 	GBI_SetGBI(G_TRIFAN, F3DEX3_TRIFAN, F3DEX3_TriFan);
 	GBI_SetGBI(G_LIGHTTORDP, F3DEX3_LIGHTTORDP, F3DEX3_LightToRDP);
 	GBI_SetGBI(G_RELSEGMENT, F3DEX3_RELSEGMENT, F3DEX3_RelSegment);
+	GBI_SetGBI(G_SPECIAL_1, F3DEX3_MEMSET, F3DEX3_Memset);
 }


### PR DESCRIPTION
This PR implements gSPMemset to handle graphics buffers. It is heavily HLE implementation that can be further improved but at least it fixes basically ZB issues.