### PR TITLE
CI: Retain UEFI signature upgrades more directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Packages
         run: |
           # fix for "error processing package grub-efi-amd64-signed"
-          sudo apt-mark hold grub-common
+          sudo apt-mark hold grub-common grub-efi-amd64-bin shim-signed
           sudo apt-get -qq update
           sudo apt-get -y upgrade
           sudo apt-get -y install build-essential libfreetype6-dev libgl1-mesa-dev libpng-dev qt5-qmake qtbase5-dev qtbase5-dev-tools qtchooser zlib1g-dev


### PR DESCRIPTION
Sorry, holding `grub-common` in #2897 failed to preserve `grub-efi-amd64-signed`... I'm re-adding `shim-signed` back for good. Just in case.

`sudo apt-mark hold grub-common`
```
grub-common set on hold.
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  grub-common grub-pc grub-pc-bin grub2-common
The following packages will be upgraded:
  bsdextrautils bsdutils eject fdisk firefox grub-efi-amd64-bin
  grub-efi-amd64-signed libblkid1 libfdisk1 libmount1 libopenjp2-7
  libpolkit-agent-1-0 libpolkit-gobject-1-0 libsmartcols1 libuuid1 mount
  polkitd powershell util-linux uuid-runtime vim vim-common vim-runtime
  vim-tiny xfsprogs xxd
26 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
```

`sudo apt-mark hold grub-common grub-efi-amd64-bin shim-signed`
```
grub-common set on hold.
grub-efi-amd64-bin set on hold.
shim-signed set on hold.
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  grub-common grub-efi-amd64-bin grub-efi-amd64-signed grub-pc grub-pc-bin
  grub2-common
The following packages will be upgraded:
  bsdextrautils bsdutils eject fdisk firefox libblkid1 libfdisk1 libmount1
  libopenjp2-7 libpolkit-agent-1-0 libpolkit-gobject-1-0 libsmartcols1
  libuuid1 mount polkitd powershell util-linux uuid-runtime vim vim-common
  vim-runtime vim-tiny xfsprogs xxd
24 upgraded, 0 newly installed, 0 to remove and 6 not upgraded.
```