### PR TITLE
Reset lookat structure to default before display list execution.

### DIFF
--- a/src/RSP.cpp
+++ b/src/RSP.cpp
@@ -139,6 +139,8 @@ void RSP_ProcessDList()
 		gSP.matrix.modelViewi = 0;
 		gSP.status[0] = gSP.status[1] = gSP.status[2] = gSP.status[3] = 0;
 		gSP.geometryMode = 0U;
+		memset(&gSP.lookat, 0, sizeof(gSPInfo::lookat));
+		gSP.lookat.xyz[0][Y] = gSP.lookat.xyz[1][X] = 1.0f;
 		gSP.changed |= CHANGED_MATRIX | CHANGED_LIGHT | CHANGED_LOOKAT | CHANGED_GEOMETRYMODE;
 		gSP.tri_num = 0;
 		gSP.cbfd.advancedLighting = false;

--- a/src/gSP.h
+++ b/src/gSP.h
@@ -77,11 +77,8 @@ struct gSPInfo
 
 	struct
 	{
-		f32 rgb[2][3];
 		f32 xyz[2][3];
 		f32 i_xyz[2][3];
-		f32 pos_xyzw[2][4];
-		f32 ca[2], la[2], qa[2];
 	} lookat;
 
 	u32 numLights;


### PR DESCRIPTION
Fixes Super Mario 64 water bomb texture has wrong oriantation with HLE #2899