### PR TITLE
Add parent argument to PluginConfig()

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -288,7 +288,7 @@ extern Config config;
 
 void Config_LoadConfig();
 #if defined(M64P_GLIDENUI) || !defined(MUPENPLUSAPI)
-void Config_DoConfig(/*HWND hParent*/);
+void Config_DoConfig(void* parent);
 #endif
 
 bool isHWLightingAllowed();

--- a/src/GLideNUI/Config_GLideNUI.cpp
+++ b/src/GLideNUI/Config_GLideNUI.cpp
@@ -8,7 +8,7 @@
 
 Config config;
 
-void Config_DoConfig(/*HWND hParent*/)
+void Config_DoConfig(void* parent)
 {
 	if (ConfigOpen)
 		return;
@@ -27,7 +27,7 @@ void Config_DoConfig(/*HWND hParent*/)
 	ConfigOpen = true;
 	const u32 maxMsaa = dwnd().maxMSAALevel();
 	const u32 maxAnisotropy = dwnd().maxAnisotropy();
-	const bool bRestart = RunConfig(strIniFolderPath, strSharedIniFolderPath, api().isRomOpen() ? RSP.romname : nullptr, maxMsaa, maxAnisotropy);
+	const bool bRestart = RunConfig(parent, strIniFolderPath, strSharedIniFolderPath, api().isRomOpen() ? RSP.romname : nullptr, maxMsaa, maxAnisotropy);
 	if (config.generalEmulation.enableCustomSettings != 0)
 		LoadCustomRomSettings(strIniFolderPath, strSharedIniFolderPath, RSP.romname);
 	config.validate();

--- a/src/GLideNUI/GLideNUI.h
+++ b/src/GLideNUI/GLideNUI.h
@@ -13,7 +13,7 @@ extern "C" {
 #define CALL
 #endif
 
-EXPORT bool CALL RunConfig(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
+EXPORT bool CALL RunConfig(void* parent, const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName, unsigned int _maxMSAALevel, unsigned int _maxAnisotropy);
 EXPORT int CALL RunAbout(const wchar_t * _strFileName);
 EXPORT void CALL LoadConfig(const wchar_t * _strFileName, const wchar_t * _strSharedFileName);
 EXPORT void CALL LoadCustomRomSettings(const wchar_t * _strFileName, const wchar_t * _strSharedFileName, const char * _romName);

--- a/src/MupenPlusPluginAPI.cpp
+++ b/src/MupenPlusPluginAPI.cpp
@@ -36,9 +36,9 @@ EXPORT m64p_error CALL PluginStartup(
 }
 
 #ifdef M64P_GLIDENUI
-EXPORT m64p_error CALL PluginConfig(void)
+EXPORT m64p_error CALL PluginConfig(void* parent)
 {
-	return api().PluginConfig();
+	return api().PluginConfig(parent);
 }
 #endif // M64P_GLIDENUI
 

--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -79,7 +79,7 @@ public:
 
 	m64p_error PluginStartup(m64p_dynlib_handle _CoreLibHandle, void * Context, void (*DebugCallback)(void *, int, const char *));
 #ifdef M64P_GLIDENUI
-	m64p_error PluginConfig();
+	m64p_error PluginConfig(void* parent);
 #endif // M64P_GLIDENUI
 	m64p_error PluginShutdown();
 	m64p_error PluginGetVersion(

--- a/src/mupenplus/MupenPlusAPIImpl.cpp
+++ b/src/mupenplus/MupenPlusAPIImpl.cpp
@@ -115,9 +115,9 @@ m64p_error PluginAPI::PluginStartup(m64p_dynlib_handle _CoreLibHandle, void* Con
 }
 
 #ifdef M64P_GLIDENUI
-m64p_error PluginAPI::PluginConfig()
+m64p_error PluginAPI::PluginConfig(void* parent)
 {
-	Config_DoConfig();
+	Config_DoConfig(parent);
 	return M64ERR_SUCCESS;
 }
 #endif // M64P_GLIDENUI

--- a/src/windows/ZilmarAPIImpl_windows.cpp
+++ b/src/windows/ZilmarAPIImpl_windows.cpp
@@ -21,7 +21,7 @@ void PluginAPI::CaptureScreen(char * _Directory)
 
 void PluginAPI::DllConfig(HWND _hParent)
 {
-	Config_DoConfig(/*_hParent*/);
+	Config_DoConfig(nullptr);
 }
 
 void PluginAPI::GetDllInfo(PLUGIN_INFO * PluginInfo)


### PR DESCRIPTION
This allows a Qt mupen64plus front-end like RMG to pass the main window as a parent to plugins, this patch adds support for using that argument which provides an overall more consistent user experience.

This also makes the `w.show()` code exclusive to non-Qt front-ends (like Project64), it's unneeded for RMG and causes an inconsistent dialog experience (i.e the window will be 'detached' from the main window when you call `.show()` instead of `.exec()` directly.