### PR TITLE
GLideNHQ: fix build with gcc 15

### DIFF
--- a/src/GLideNHQ/TxHiResLoader.h
+++ b/src/GLideNHQ/TxHiResLoader.h
@@ -13,6 +13,8 @@
 #define CORRECTFILENAME(str)
 #endif /* OS_WINDOWS */
 
+#include <cstdint>
+
 #include "TxCache.h"
 #include "TxQuantize.h"
 #include "TxImage.h"


### PR DESCRIPTION
Adds a missing include to fix a build failure with gcc 15 as reported for the Gentoo issue tracker.

Gentoo Issue: https://bugs.gentoo.org/949732