### PR TITLE
Add missing chrono include to Log.cpp

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <fstream>
 #include <ctime>
+#include <chrono>
 
 #ifndef MUPENPLUSAPI // zilmar spec
 


### PR DESCRIPTION
This fixes the build failure on CI: https://github.com/gonetz/GLideN64/actions/runs/13611418874/job/38049082406

```
"D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.sln" (default target) (1) ->
       "D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj.metaproj" (default target) (2) ->
       "D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj" (default target) (6) ->
       (ClCompile target) -> 
         D:\a\GLideN64\GLideN64\src\Log.cpp(26,13): error C2653: 'system_clock': is not a class or namespace name [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]
         D:\a\GLideN64\GLideN64\src\Log.cpp(26,27): error C3536: 'now': cannot be used before it is initialized [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]
         D:\a\GLideN64\GLideN64\src\Log.cpp(26,27): error C2064: term does not evaluate to a function taking 0 arguments [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]
         D:\a\GLideN64\GLideN64\src\Log.cpp(30,12): error C2672: 'std::chrono::duration_cast': no matching overloaded function found [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]
         D:\a\GLideN64\GLideN64\src\Log.cpp(33,15): error C2653: 'system_clock': is not a class or namespace name [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]
         D:\a\GLideN64\GLideN64\src\Log.cpp(33,29): error C3861: 'to_time_t': identifier not found [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]
         D:\a\GLideN64\GLideN64\src\Log.cpp(41,55): error C3536: 'ms': cannot be used before it is initialized [D:\a\GLideN64\GLideN64\projects\msvc\GLideN64.vcxproj]

    19 Warning(s)
    7 Error(s)
```
