### PR TITLE
Add bounds check to gSPCullVertices()

### DIFF
--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -1568,7 +1568,7 @@ bool gSPCullVertices( u32 v0, u32 vn )
 	}
 	u32 clip = 0;
 	GraphicsDrawer & drawer = dwnd().getDrawer();
-	for (u32 i = v0; i <= vn; ++i) {
+	for (u32 i = v0; i <= std::min(vn, (VERTBUFF_SIZE - 1)); ++i) {
 		clip |= (~drawer.getVertex(i).clip) & CLIP_ALL;
 		if (clip == CLIP_ALL)
 			return false;


### PR DESCRIPTION
This fixes a crash that only happens with a decompressed OOT ROM when trying to open the pause menu.

The issue is that for some reason `vn` is way higher than the amount of `triangles.vertices`, `vn` is in some cases `2204` or even higher.

Obviously this is a game bug, but I do think a crash from GLideN64's side should be fixed, I'm not entirely sure if a `std::min()` is preferred or an early return, but I'd rather stay on the safe side because I'm not sure how other games behave.

I added some debug logging which you can see:
```
vn is too high = 2204
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0E"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0A"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x2D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x27"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x17"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x12"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xC1"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x50"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x24"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x18"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x37"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x36"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x25"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xBA"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xAA"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x37"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x09"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xAB"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x7D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0D"
vn is too high = 2204
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0E"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0A"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x2D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x27"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x17"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x12"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xC1"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x50"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x24"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x18"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x37"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x36"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x25"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xBA"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xAA"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x37"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x09"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0xAB"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x7D"
[GFX]   GBI.cpp:159, "UNKNOWN GBI COMMAND 0x0D"
vn is too high = 2204
```