### PR TITLE
Fixed typo in resetting tri command ids

### DIFF
--- a/src/GBI.cpp
+++ b/src/GBI.cpp
@@ -204,7 +204,7 @@ void GBIInfo::_makeCurrent(MicrocodeInfo * _pCurrent)
 
 		RDP_Init();
 
-		G_TRI1 = G_TRI2 = G_TRIX = G_QUAD = G_TRISTRIP = G_TRIFAN -1; // For correct work of gSPFlushTriangles()
+		G_TRI1 = G_TRI2 = G_TRIX = G_QUAD = G_TRISTRIP = G_TRIFAN = -1; // For correct work of gSPFlushTriangles()
 		gSP.clipRatio = 1U;
 
 		switch (m_pCurrent->type) {


### PR DESCRIPTION
Fixes regression in OoT introduced in PR 2912 by accident.

![image](https://github.com/user-attachments/assets/f4148703-410b-4c47-9fe4-60dff78334a2)
