### PR TITLE
FrameBuffer: Don't delete default framebuffer

### DIFF
--- a/src/FrameBuffer.cpp
+++ b/src/FrameBuffer.cpp
@@ -50,7 +50,8 @@ FrameBuffer::~FrameBuffer()
 	gfxContext.deleteFramebuffer(m_depthFBO);
 	gfxContext.deleteFramebuffer(m_resolveFBO);
 	gfxContext.deleteFramebuffer(m_SubFBO);
-	gfxContext.deleteFramebuffer(m_copyFBO);
+	if (m_copyFBO != ObjectHandle::defaultFramebuffer)
+		gfxContext.deleteFramebuffer(m_copyFBO);
 
 	textureCache().removeFrameBufferTexture(m_pTexture);
 	textureCache().removeFrameBufferTexture(m_pDepthTexture);


### PR DESCRIPTION
See https://github.com/gonetz/GLideN64/issues/2803#issuecomment-2343761945

I didn't get a reply there, maybe it fell through the cracks