### PR TITLE
Fix framebuffer binding being potentially invalid in ReadScreen2

### DIFF
--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -253,18 +253,20 @@ void DisplayWindowMupen64plus::_readScreen2(void * _dest, int * _width, int * _h
 		return;
 
 #if !defined(OS_ANDROID) && !defined(OS_IOS)
-	GLint oldFbo;
 	GLint oldMode;
-	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &oldFbo);
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(graphics::ObjectHandle::defaultFramebuffer));
 	glGetIntegerv(GL_READ_BUFFER, &oldMode);
+	gfxContext.bindFramebuffer(graphics::bufferTarget::READ_FRAMEBUFFER, graphics::ObjectHandle::defaultFramebuffer);
 	if (_front != 0)
 		glReadBuffer(GL_FRONT);
 	else
 		glReadBuffer(GL_BACK);
 	glReadPixels(0, m_heightOffset, m_screenWidth, m_screenHeight, GL_RGB, GL_UNSIGNED_BYTE, _dest);
+	if (graphics::BufferAttachmentParam(oldMode) == graphics::bufferAttachment::COLOR_ATTACHMENT0) {
+		FrameBuffer * pBuffer = frameBufferList().getCurrent();
+		if (pBuffer != nullptr)
+			gfxContext.bindFramebuffer(graphics::bufferTarget::READ_FRAMEBUFFER, pBuffer->m_FBO);
+	}
 	glReadBuffer(oldMode);
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, oldFbo);
 #else
 	u8 *pBufferData = (u8*)malloc((*_width)*(*_height) * 4);
 	if (pBufferData == nullptr)

--- a/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
+++ b/src/Graphics/OpenGLContext/mupen64plus/mupen64plus_DisplayWindow.cpp
@@ -253,7 +253,10 @@ void DisplayWindowMupen64plus::_readScreen2(void * _dest, int * _width, int * _h
 		return;
 
 #if !defined(OS_ANDROID) && !defined(OS_IOS)
+	GLint oldFbo;
 	GLint oldMode;
+	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &oldFbo);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(graphics::ObjectHandle::defaultFramebuffer));
 	glGetIntegerv(GL_READ_BUFFER, &oldMode);
 	if (_front != 0)
 		glReadBuffer(GL_FRONT);
@@ -261,6 +264,7 @@ void DisplayWindowMupen64plus::_readScreen2(void * _dest, int * _width, int * _h
 		glReadBuffer(GL_BACK);
 	glReadPixels(0, m_heightOffset, m_screenWidth, m_screenHeight, GL_RGB, GL_UNSIGNED_BYTE, _dest);
 	glReadBuffer(oldMode);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, oldFbo);
 #else
 	u8 *pBufferData = (u8*)malloc((*_width)*(*_height) * 4);
 	if (pBufferData == nullptr)


### PR DESCRIPTION
In my porting attempt of modern mupen64plus (and relevant plugins such as GLideN64) I'm relying heavily on the `ReadScreen2` function to get screen data. However for some games it returns garbage data at times. When enabling OpenGL debug functions, I got the following warning/error on the `glReadPixels` call inside of the function: `GL_INVALID_OPERATION error generated. The required buffer is missing.`.

An example of what the screen looks like in that case is here: https://github.com/TASEmulators/BizHawk/pull/4117#issuecomment-2705326068

Explicitly binding the default framebuffer before reading fixes this.

I don't know if this would affect android or ios too so I can't tell if putting the code inside the #ifdef is correct or not.