### PR TITLE
Testing a change to Qt 5 DPI handling (actions runner test)

### DIFF
--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -37,6 +37,11 @@ int openConfigDialog(void* parent, const wchar_t * _strFileName, const wchar_t *
 	std::unique_ptr<QApplication> pQApp;
 	QCoreApplication* pApp = QCoreApplication::instance();
 
+	#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+	#endif
+	
 	if (pApp == nullptr) {
 		pQApp.reset(new QApplication(argc, argv));
 		pApp = pQApp.get();
@@ -76,6 +81,11 @@ int openAboutDialog(const wchar_t * _strFileName)
 	char argv0[] = "GLideN64";
 	char * argv[] = { argv0 };
 	QApplication a(argc, argv);
+
+	#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+	#endif
 
 	QTranslator translator;
 	if (translator.load(getTranslationFile(), QString::fromWCharArray(_strFileName)))

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -1,3 +1,8 @@
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <shellscalingapi.h>
+#endif
+
 #include <thread>
 #include <QApplication>
 #include <QTranslator>
@@ -38,6 +43,7 @@ int openConfigDialog(void* parent, const wchar_t * _strFileName, const wchar_t *
 	QCoreApplication* pApp = QCoreApplication::instance();
 
 	#ifdef Q_OS_WIN
+	<windows.h>
 	    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 	#endif
 	

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -37,10 +37,8 @@ int openConfigDialog(void* parent, const wchar_t * _strFileName, const wchar_t *
 	std::unique_ptr<QApplication> pQApp;
 	QCoreApplication* pApp = QCoreApplication::instance();
 
-	#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-	#endif
+	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	
 	if (pApp == nullptr) {
 		pQApp.reset(new QApplication(argc, argv));
@@ -82,10 +80,8 @@ int openAboutDialog(const wchar_t * _strFileName)
 	char * argv[] = { argv0 };
 	QApplication a(argc, argv);
 
-	#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-	#endif
+	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
 	QTranslator translator;
 	if (translator.load(getTranslationFile(), QString::fromWCharArray(_strFileName)))

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -42,10 +42,9 @@ int openConfigDialog(void* parent, const wchar_t * _strFileName, const wchar_t *
 	std::unique_ptr<QApplication> pQApp;
 	QCoreApplication* pApp = QCoreApplication::instance();
 
-	#ifdef Q_OS_WIN
-	<windows.h>
-	    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-	#endif
+#ifdef Q_OS_WIN
+	HRESULT hr = SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+#endif
 	
 	if (pApp == nullptr) {
 		pQApp.reset(new QApplication(argc, argv));
@@ -87,9 +86,9 @@ int openAboutDialog(const wchar_t * _strFileName)
 	char * argv[] = { argv0 };
 	QApplication a(argc, argv);
 
-	#ifdef Q_OS_WIN
-	    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-	#endif
+#ifdef Q_OS_WIN
+	HRESULT hr = SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+#endif
 
 	QTranslator translator;
 	if (translator.load(getTranslationFile(), QString::fromWCharArray(_strFileName)))

--- a/src/GLideNUI/GLideNUI.cpp
+++ b/src/GLideNUI/GLideNUI.cpp
@@ -37,8 +37,9 @@ int openConfigDialog(void* parent, const wchar_t * _strFileName, const wchar_t *
 	std::unique_ptr<QApplication> pQApp;
 	QCoreApplication* pApp = QCoreApplication::instance();
 
-	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+	#ifdef Q_OS_WIN
+	    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+	#endif
 	
 	if (pApp == nullptr) {
 		pQApp.reset(new QApplication(argc, argv));
@@ -80,8 +81,9 @@ int openAboutDialog(const wchar_t * _strFileName)
 	char * argv[] = { argv0 };
 	QApplication a(argc, argv);
 
-	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+	#ifdef Q_OS_WIN
+	    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+	#endif
 
 	QTranslator translator;
 	if (translator.load(getTranslationFile(), QString::fromWCharArray(_strFileName)))


### PR DESCRIPTION
if successful, enables DPI Scaling for Qt5 (Qt6 defaults to it)