### PR TITLE
Fix Banjo-Kazooie puzzle transitions

### DIFF
--- a/ini/GLideN64.custom.ini
+++ b/ini/GLideN64.custom.ini
@@ -14,6 +14,10 @@ graphics2D\enableNativeResTexrects=1
 Good_Name=Baku Bomberman (J) [!]
 generalEmulation\enableLegacyBlending=0
 
+[BANJO-KAZOOIE]
+Good_Name=Banjo-Kazooie (U) [!]
+frameBufferEmulation\copyToRDRAM=1
+
 [BIOFREAKS]
 Good_Name=Bio F.R.E.A.K.S. (E)(U)
 frameBufferEmulation\copyToRDRAM=1


### PR DESCRIPTION
For the puzzle transitions to work correctly, `frameBufferEmulation\copyToRDRAM=1` is required.

See: https://github.com/Rosalie241/RMG/issues/431