### PR TITLE
GLideNUI: hide translations UI when no translations are found

### DIFF
--- a/src/GLideNUI/ConfigDialog.cpp
+++ b/src/GLideNUI/ConfigDialog.cpp
@@ -499,6 +499,15 @@ void ConfigDialog::setIniPath(const QString & _strIniPath, const QString & _strS
 	QStringList translationFiles;
 	_getTranslations(translationFiles);
 
+#ifdef M64P_GLIDENUI
+	if (translationFiles.empty())
+	{
+		ui->userInterfaceGroupBox->hide();
+		QSpacerItem* verticalSpacer = new QSpacerItem(20, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+		ui->verticalLayout_4->addItem(verticalSpacer);
+	}
+#endif
+
 	const QString currentTranslation = getTranslationFile();
 	int listIndex = 0;
 	QStringList translationLanguages("English");


### PR DESCRIPTION
This patch makes the translations UI hidden when no translations have been found, but keeps the same behavior for any build configuration that isn't `M64P_GLIDENUI`.

It achieves this behavior by adding a spacer, which is deleted when translations have been found or GLideNUI is built without `M64P_GLIDENUI`, else, when no translations have been found, it hides the translations groupbox instead.