### PR TITLE
Add PluginAPI::GetSharedDataPath()

### DIFF
--- a/src/GLideNUI/Config_GLideNUI.cpp
+++ b/src/GLideNUI/Config_GLideNUI.cpp
@@ -17,7 +17,7 @@ void Config_DoConfig(void* parent)
 	wchar_t strSharedIniFolderPath[PLUGIN_PATH_SIZE];
 
 #ifdef M64P_GLIDENUI
-	api().FindPluginPath(strSharedIniFolderPath);
+	api().GetSharedDataPath(strSharedIniFolderPath);
 	api().GetUserConfigPath(strIniFolderPath);
 #else
 	api().FindPluginPath(strSharedIniFolderPath);
@@ -42,7 +42,7 @@ void Config_LoadConfig()
 	wchar_t strSharedIniFolderPath[PLUGIN_PATH_SIZE];
 
 #ifdef M64P_GLIDENUI
-	api().FindPluginPath(strSharedIniFolderPath);
+	api().GetSharedDataPath(strSharedIniFolderPath);
 	api().GetUserConfigPath(strIniFolderPath);
 #else
 	api().FindPluginPath(strSharedIniFolderPath);

--- a/src/PluginAPI.h
+++ b/src/PluginAPI.h
@@ -54,6 +54,7 @@ public:
 	void GetUserCachePath(wchar_t * _strPath);
 #ifdef M64P_GLIDENUI
 	void GetUserConfigPath(wchar_t * _strPath);
+	void GetSharedDataPath(wchar_t * _strPath);
 #endif // M64P_GLIDENUI
 	bool isRomOpen() const { return m_bRomOpen; }
 

--- a/src/mupenplus/CommonAPIImpl_mupenplus.cpp
+++ b/src/mupenplus/CommonAPIImpl_mupenplus.cpp
@@ -73,6 +73,16 @@ void PluginAPI::GetUserConfigPath(wchar_t * _strPath)
 {
 	_getWSPath(ConfigGetUserConfigPath(), _strPath);
 }
+
+void PluginAPI::GetSharedDataPath(wchar_t * _strPath)
+{
+	/* this is kind of a hack, we know mupen64plus.ini is always present
+	 * on valid installations, so we use that to retrieve the shared
+	 * data path, we'll get the full path to the filename but
+	 * we strip it to the final seperator to strip out the filename
+	 */
+	_getWSPath(ConfigGetSharedDataFilepath("mupen64plus.ini"), _strPath, true);
+}
 #endif // M64P_GLIDENUI
 
 void PluginAPI::FindPluginPath(wchar_t * _strPath)


### PR DESCRIPTION
This patch adds the `PluginAPI::GetSharedDataPath()`, allowing RMG to properly install the `GLideN64.custom.ini` to `/usr/share/RMG` instead of the plugin directory.