### PR TITLE
GLideNHQ: Fix Banjo-Kazooie 0x0 texture dumps

### DIFF
--- a/src/GLideNHQ/TxFilter.cpp
+++ b/src/GLideNHQ/TxFilter.cpp
@@ -623,7 +623,7 @@ TxFilter::dmptx(uint8 *src, int width, int height, int rowStridePixel,
 		if (!osal_path_existsW(tmpbuf.c_str()) && osal_mkdirp(tmpbuf.c_str()) != 0)
 			return 0;
 
-		if (n64FmtSz._format == 0x2) {
+		if ((n64FmtSz._format == 0x0 && n64FmtSz._size == 0x0) || n64FmtSz._format == 0x2) {
 			wchar_t wbuf[256];
 			tx_swprintf(wbuf, 256, wst("/%ls#%08X#%01X#%01X#%08X_ciByRGBA.png"), _ident.c_str(), r_crc64._texture, n64FmtSz._format, n64FmtSz._size, r_crc64._palette);
 			tmpbuf.append(wbuf);


### PR DESCRIPTION
Fixes the dumped texture names for `#0#0` textures. This seems to match Rice behaviour.

Banjo-Kazooie is to my knowledge the only game that benefits from this. Affected textures include (mostly Pause Screen):

- Eggs
- Gold Feathers
- **Jinjos (changing color by using different palettes!)**
- Joker (Grunty's Furnace Fun)
- Mumbo Token
- Propeller (special timer in Rusty Bucket Bay)
- Red Feathers

Sidenote: GLideN64 can load either `#0#0#[...]_ciByRGBA` or `#0#0_all` as HD textures and this change solely affects the naming of such textures when dumped.

See: https://github.com/gonetz/GLideN64/issues/2798#issuecomment-1987193853