### PR TITLE
Fix possible data races between the main and GL threads

### DIFF
--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.cpp
@@ -11,8 +11,8 @@
 
 namespace glsl {
 
-u32 CombinerProgramBuilder::s_cycleType = G_CYC_1CYCLE;
-TextureConvert CombinerProgramBuilder::s_textureConvert;
+thread_local u32 CombinerProgramBuilder::s_cycleType = G_CYC_1CYCLE;
+thread_local TextureConvert CombinerProgramBuilder::s_textureConvert;
 
 /*---------------_compileCombiner-------------*/
 

--- a/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.h
+++ b/src/Graphics/OpenGLContext/GLSL/glsl_CombinerProgramBuilder.h
@@ -64,8 +64,8 @@ public:
 
 	virtual bool isObsolete() const = 0;
 
-	static u32 s_cycleType;
-	static TextureConvert s_textureConvert;
+	static thread_local u32 s_cycleType;
+	static thread_local TextureConvert s_textureConvert;
 
 protected:
 	virtual const ShaderPart * getVertexShaderTexturedRect() const = 0;

--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.cpp
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.cpp
@@ -8,7 +8,7 @@ namespace opengl {
 
 	bool FunctionWrapper::m_threaded_wrapper = false;
 	bool FunctionWrapper::m_shutdown = false;
-	int FunctionWrapper::m_swapBuffersQueued = 0;
+	std::atomic<int> FunctionWrapper::m_swapBuffersQueued{0};
 	bool FunctionWrapper::m_fastVertexAttributes = false;
 	std::thread FunctionWrapper::m_commandExecutionThread;
 	std::mutex FunctionWrapper::m_condvarMutex;

--- a/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.h
+++ b/src/Graphics/OpenGLContext/ThreadedOpenGl/opengl_Wrapper.h
@@ -4,6 +4,7 @@
 #include "readerwriterqueue.h"
 #include "opengl_WrappedFunctions.h"
 #include "opengl_Command.h"
+#include <atomic>
 #include <thread>
 #include <map>
 
@@ -29,7 +30,7 @@ namespace opengl {
 
 		static bool m_threaded_wrapper;
 		static bool m_shutdown;
-		static int m_swapBuffersQueued;
+		static std::atomic<int> m_swapBuffersQueued;
 		static bool m_fastVertexAttributes;
 		static std::thread m_commandExecutionThread;
 		static std::mutex m_condvarMutex;


### PR DESCRIPTION
opengl_Wrapper.h / .cpp — m_swapBuffersQueued → std::atomic<int>

The counter was incremented from the main thread (SwapBuffers) and decremented from the GL command thread (ReduceSwapBuffersQueued), with no synchronization between the two writes. That's a data race — undefined behavior in C++. std::atomic<int> makes every read/write an atomic operation; the existing ++, --, and comparison operators all work unchanged. 

glsl_CombinerProgramBuilder.h / .cpp — s_cycleType and s_textureConvert → thread_local

These were plain static class members set at the top of buildCombinerProgram and then read throughout all the _write* sub-functions. If two threads ever call buildCombinerProgram concurrently, one would stomp the other's values mid-build, corrupting shader generation. Changing them to thread_local gives each thread its own copy, so concurrent builds are isolated. No call-site changes needed — all the existing CombinerProgramBuilder::s_cycleType reads throughout the Accurate and Fast builder files automatically pick up the correct per-thread value.
