### PR TITLE
Fixed incorrect gSPMemset emulation

### DIFF
--- a/src/gDP.cpp
+++ b/src/gDP.cpp
@@ -831,6 +831,7 @@ void gDPMemset(u32 value, u32 addr, u32 length)
 		calculateParams(gDP.depthImageAddress, G_IM_SIZ_16b, imageWidth);
 
 		// HACK: this usually replaces gDPSetColorImage for zb so save zb
+		const auto backupCurr = frameBufferList().getCurrent();
 		frameBufferList().saveBuffer(gDP.depthImageAddress, (u16)G_IM_FMT_RGBA, (u16)G_IM_SIZ_16b, (u16)imageWidth, false);
 
 		if (config.generalEmulation.enableFragmentDepthWrite == 0)
@@ -847,6 +848,11 @@ void gDPMemset(u32 value, u32 addr, u32 length)
 			ValueKeeper<gDPInfo::OtherMode> backupOtherMode(gDP.otherMode, otherMode);
 			drawer.drawRect(0, uly, imageWidth, lry);
 			frameBufferList().setBufferChanged(f32(lry));
+		}
+
+		if (backupCurr != nullptr) {
+			frameBufferList().setCurrent(backupCurr);
+			frameBufferList().attachDepthBuffer();
 		}
 	}
 	else if (0 == config.frameBufferEmulation.enable) {

--- a/src/uCodes/F3DEX3.cpp
+++ b/src/uCodes/F3DEX3.cpp
@@ -361,7 +361,7 @@ static void F3DEX3_RelSegment(u32 w0, u32 w1)
 static void F3DEX3_Memset(u32 w0, u32 w1)
 {
 	u32 value = (u16)gDP.half_1;
-	u32 addr = w1;
+	u32 addr = w1 & 0x007fffff;
 	u32 length = w0 & 0x00FFFFFF;
 	gDPMemset(value, addr, length);
 }


### PR DESCRIPTION
Fixes boot for Zeldarune romhack that uses F3DEX3 and gSPMemset for ZBuffer.

1) Remove RDRAM address bits to satisfy physical address comparisons.
2) Restore attached fb + attach depth buffer.